### PR TITLE
feat: add frontend-swing unit tests for API client

### DIFF
--- a/frontend-swing/src/test/java/com/licensis/notaire/api/client/ApiConfigTest.java
+++ b/frontend-swing/src/test/java/com/licensis/notaire/api/client/ApiConfigTest.java
@@ -1,0 +1,95 @@
+package com.licensis.notaire.api.client;
+
+import com.licensis.notaire.dto.DtoUsuario;
+import com.licensis.notaire.dto.GenericDto;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class ApiConfigTest {
+
+    @Test
+    public void testDefaultConfiguration() {
+        assertEquals("http://localhost:8080/api/v1", ApiConfig.getApiBaseUrl());
+        assertEquals(10000, ApiConfig.getConnectionTimeout());
+        assertEquals(10000, ApiConfig.getReadTimeout());
+    }
+
+    @Test
+    public void testSetApiBaseUrl() {
+        String originalUrl = ApiConfig.getApiBaseUrl();
+        try {
+            ApiConfig.setApiBaseUrl("http://test.server:9090/api/v1");
+            assertEquals("http://test.server:9090/api/v1", ApiConfig.getApiBaseUrl());
+        } finally {
+            ApiConfig.setApiBaseUrl(originalUrl);
+        }
+    }
+
+    @Test
+    public void testSetConnectionTimeout() {
+        int originalTimeout = ApiConfig.getConnectionTimeout();
+        try {
+            ApiConfig.setConnectionTimeout(5000);
+            assertEquals(5000, ApiConfig.getConnectionTimeout());
+        } finally {
+            ApiConfig.setConnectionTimeout(originalTimeout);
+        }
+    }
+
+    @Test
+    public void testSetReadTimeout() {
+        int originalTimeout = ApiConfig.getReadTimeout();
+        try {
+            ApiConfig.setReadTimeout(30000);
+            assertEquals(30000, ApiConfig.getReadTimeout());
+        } finally {
+            ApiConfig.setReadTimeout(originalTimeout);
+        }
+    }
+
+    @Test
+    public void testLoadFromPropertiesWithDefaults() {
+        String originalUrl = ApiConfig.getApiBaseUrl();
+        int originalConnectTimeout = ApiConfig.getConnectionTimeout();
+        int originalReadTimeout = ApiConfig.getReadTimeout();
+        
+        try {
+            ApiConfig.loadFromProperties();
+            
+            assertEquals("http://localhost:8080/api/v1", ApiConfig.getApiBaseUrl());
+            assertEquals(10000, ApiConfig.getConnectionTimeout());
+            assertEquals(10000, ApiConfig.getReadTimeout());
+        } finally {
+            ApiConfig.setApiBaseUrl(originalUrl);
+            ApiConfig.setConnectionTimeout(originalConnectTimeout);
+            ApiConfig.setReadTimeout(originalReadTimeout);
+        }
+    }
+
+    @Test
+    public void testLoadFromPropertiesWithSystemProperties() {
+        String originalUrl = ApiConfig.getApiBaseUrl();
+        int originalConnectTimeout = ApiConfig.getConnectionTimeout();
+        int originalReadTimeout = ApiConfig.getReadTimeout();
+        
+        try {
+            System.setProperty("api.base.url", "http://custom:7777/api/v1");
+            System.setProperty("api.timeout", "5000");
+            
+            ApiConfig.loadFromProperties();
+            
+            assertEquals("http://custom:7777/api/v1", ApiConfig.getApiBaseUrl());
+            assertEquals(5000, ApiConfig.getConnectionTimeout());
+            assertEquals(5000, ApiConfig.getReadTimeout());
+        } finally {
+            System.clearProperty("api.base.url");
+            System.clearProperty("api.timeout");
+            ApiConfig.setApiBaseUrl(originalUrl);
+            ApiConfig.setConnectionTimeout(originalConnectTimeout);
+            ApiConfig.setReadTimeout(originalReadTimeout);
+        }
+    }
+}

--- a/frontend-swing/src/test/java/com/licensis/notaire/api/client/RestClientTest.java
+++ b/frontend-swing/src/test/java/com/licensis/notaire/api/client/RestClientTest.java
@@ -1,0 +1,116 @@
+package com.licensis.notaire.api.client;
+
+import com.licensis.notaire.dto.DtoUsuario;
+import com.licensis.notaire.dto.GenericDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class RestClientTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testDtoUsuarioSerialization() throws Exception {
+        DtoUsuario usuario = new DtoUsuario();
+        usuario.setIdUsuario(1);
+        usuario.setNombre("admin");
+        usuario.setContrasenia("admin123");
+        usuario.setEstado(true);
+        usuario.setTipo("ADMINISTRADOR");
+        usuario.setValido(true);
+
+        String json = objectMapper.writeValueAsString(usuario);
+        assertNotNull(json);
+        assertTrue(json.contains("\"nombre\":\"admin\""));
+        assertTrue(json.contains("\"valido\":true"));
+    }
+
+    @Test
+    public void testDtoUsuarioDeserialization() throws Exception {
+        String json = "{\"idUsuario\":1,\"nombre\":\"testuser\",\"contrasenia\":\"pass\",\"estado\":true,\"tipo\":\"USUARIO\",\"valido\":true}";
+
+        DtoUsuario usuario = objectMapper.readValue(json, DtoUsuario.class);
+        
+        assertEquals(Integer.valueOf(1), usuario.getIdUsuario());
+        assertEquals("testuser", usuario.getNombre());
+        assertEquals("pass", usuario.getContrasenia());
+        assertTrue(usuario.isEstado());
+        assertEquals("USUARIO", usuario.getTipo());
+        assertTrue(usuario.isValido());
+    }
+
+    @Test
+    public void testDtoUsuarioWithNullValues() throws Exception {
+        String json = "{\"idUsuario\":null,\"nombre\":null,\"contrasenia\":null,\"estado\":false,\"tipo\":null,\"valido\":false}";
+
+        DtoUsuario usuario = objectMapper.readValue(json, DtoUsuario.class);
+        
+        assertNull(usuario.getIdUsuario());
+        assertNull(usuario.getNombre());
+        assertFalse(usuario.isValido());
+    }
+
+    @Test
+    public void testGenericDtoSerialization() throws Exception {
+        GenericDto genericDto = new GenericDto();
+        java.util.HashMap<String, Object> data = new java.util.HashMap<>();
+        data.put("id", 1);
+        data.put("name", "Test");
+        data.put("active", true);
+        genericDto.setData(data);
+
+        String json = objectMapper.writeValueAsString(genericDto);
+        assertNotNull(json);
+        assertTrue(json.contains("\"id\":1"));
+        assertTrue(json.contains("\"name\":\"Test\""));
+    }
+
+    @Test
+    public void testGenericDtoDeserialization() throws Exception {
+        String json = "{\"data\":{\"id\":42,\"description\":\"Sample\",\"count\":100}}";
+
+        GenericDto genericDto = objectMapper.readValue(json, GenericDto.class);
+        
+        assertNotNull(genericDto.getData());
+        assertEquals(42, genericDto.getData().get("id"));
+        assertEquals("Sample", genericDto.getData().get("description"));
+        assertEquals(100, genericDto.getData().get("count"));
+    }
+
+    @Test
+    public void testLoginRequestDto() throws Exception {
+        DtoUsuario loginRequest = new DtoUsuario();
+        loginRequest.setNombre("admin");
+        loginRequest.setContrasenia("admin");
+
+        String json = objectMapper.writeValueAsString(loginRequest);
+        
+        assertTrue(json.contains("\"nombre\":\"admin\""));
+        assertTrue(json.contains("\"contrasenia\":\"admin\""));
+    }
+
+    @Test
+    public void testApiEndpointConstruction() {
+        String baseUrl = ApiConfig.getApiBaseUrl();
+        
+        assertEquals("http://localhost:8080/api/v1/usuarios", baseUrl + "/usuarios");
+        assertEquals("http://localhost:8080/api/v1/personas", baseUrl + "/personas");
+        assertEquals("http://localhost:8080/api/v1/conceptos", baseUrl + "/conceptos");
+        assertEquals("http://localhost:8080/api/v1/presupuestos", baseUrl + "/presupuestos");
+    }
+
+    @Test
+    public void testApiEndpointWithQueryParameters() {
+        String baseUrl = ApiConfig.getApiBaseUrl();
+        
+        String searchEndpoint = baseUrl + "/personas/buscar?nombre=John";
+        assertEquals("http://localhost:8080/api/v1/personas/buscar?nombre=John", searchEndpoint);
+        
+        String filterEndpoint = baseUrl + "/presupuestos?estado=pendiente";
+        assertEquals("http://localhost:8080/api/v1/presupuestos?estado=pendiente", filterEndpoint);
+    }
+}


### PR DESCRIPTION
## Summary
Add initial unit tests for frontend-swing module:
- **ApiConfigTest**: 6 tests for API configuration
  - Default configuration values
  - Setter methods
  - Properties loading with defaults
  - System properties override
- **RestClientTest**: 8 tests for DTO handling
  - DtoUsuario serialization/deserialization
  - GenericDto serialization/deserialization
  - Login request DTO
  - API endpoint construction

## Test Results
- **14 tests run**
- **0 failures**
- **0 errors**
- **BUILD SUCCESS**

## New Files
- `frontend-swing/src/test/java/com/licensis/notaire/api/client/ApiConfigTest.java`
- `frontend-swing/src/test/java/com/licensis/notaire/api/client/RestClientTest.java`

## Note
This is the first test infrastructure added to the frontend-swing module. The module previously had no unit tests despite having JUnit declared in pom.xml.