### PR TITLE
feat: migrate CI/CD reports from GitHub Pages to Wiki

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -220,38 +220,33 @@ EOFMARKDOWN
           retention-days: 30
 
   # ==========================================
-  # Publish to GitHub Pages
+  # Publish to GitHub Wiki
   # ==========================================
   publish-report:
-    name: Publish Report
+    name: Publish to Wiki
     runs-on: ubuntu-latest
     needs: [generate-report]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
+    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: 'gh-pages'
-          fetch-depth: 0
 
       - name: Download Report
         uses: actions/download-artifact@v4
         with:
           name: cd-report
-          path: .
+          path: ./reports
 
-      - name: Prepare reports
+      - name: Publish to Wiki
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          mkdir -p _posts/cicd
-          # Copy report with date-based name
-          cp cd-report.md ./_posts/cicd/$(date +%Y-%m-%d)-cd-report.md
-
-      - name: Commit and Push
-        run: |
-          git config --local user.email "ci@notaire.com"
-          git config --local user.name "CI Bot"
-          git add -A
-          git commit -m "Update CD report - $(date +%Y-%m-%d)" || echo "No changes to commit"
-          git push origin gh-pages || git push origin gh-pages --force
+          python3 .github/scripts/publish_wiki_reports.py \
+            --token "$GH_TOKEN" \
+            --repo "$REPO" \
+            --report-dir ./reports \
+            --workflow cd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,10 +451,10 @@ EOF
           retention-days: 30
 
   # ==========================================
-  # JOB 9: Publish to GitHub Pages (No External Wiki)
+  # JOB 9: Publish to GitHub Wiki
   # ==========================================
   publish-reports:
-    name: Publish Reports
+    name: Publish to Wiki
     runs-on: ubuntu-latest
     needs: [generate-reports]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
@@ -464,9 +464,6 @@ EOF
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: 'gh-pages'
-          fetch-depth: 0
 
       - name: Download Markdown Reports
         uses: actions/download-artifact@v4
@@ -474,39 +471,29 @@ EOF
           name: markdown-reports
           path: ./reports
 
-      - name: Prepare reports
+      - name: Prepare reports directory
         run: |
-          mkdir -p _posts/cicd
-          # Copy reports with date-based names
-          cp ./reports/ci-report.md ./_posts/cicd/$(date +%Y-%m-%d)-ci-report.md
-          # Create/update index
-          cat > index.md << 'EOF'
----
-title: CI/CD Reports
-layout: default
-nav_order: 1
----
+          mkdir -p ./wiki-reports
+          # Copy and rename files for the Python script
+          # Unit tests - find the first XML file
+          find reports -name "TEST-*.xml" -path "*/backend-api/*" -exec cp {} ./wiki-reports/unit-tests.xml \; 2>/dev/null || true
+          find reports -name "TEST-*.xml" -path "*/integration*" -exec cp {} ./wiki-reports/integration-tests.xml \; 2>/dev/null || true
+          cp reports/jacoco-report/jacoco.xml ./wiki-reports/ 2>/dev/null || true
+          cp reports/trivy-results/trivy-results.json ./wiki-reports/ 2>/dev/null || true
+          cp reports/spotbugs-report/spotbugsXml.xml ./wiki-reports/spotbugs.xml 2>/dev/null || true
+          # Also copy the generated markdown report
+          cp reports/markdown-reports/ci-report.md ./wiki-reports/ 2>/dev/null || true
+          # List available files for debugging
+          echo "=== Available report files ==="
+          ls -la ./wiki-reports/ 2>/dev/null || echo "No files found"
 
-# 📊 CI/CD Reports
-
-Latest CI/CD pipeline reports.
-
-## 📋 Available Reports
-
-EOF
-          ls -1 _posts/cicd/*.md 2>/dev/null | while read f; do
-            fname=$(basename "$f")
-            date=$(echo "$fname" | cut -d'-' -f1,2,3)
-            echo "- [$(date)](cicd/$fname) - CI Pipeline Report" >> index.md
-          done
-          echo "" >> index.md
-          echo "---" >> index.md
-          echo "*Automatically generated*" >> index.md
-
-      - name: Commit and Push
+      - name: Publish to Wiki
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          git config --local user.email "ci@notaire.com"
-          git config --local user.name "CI Bot"
-          git add -A
-          git commit -m "Update CI/CD reports - $(date +%Y-%m-%d)" || echo "No changes to commit"
-          git push origin gh-pages || git push origin gh-pages --force
+          python3 .github/scripts/publish_wiki_reports.py \
+            --token "$GH_TOKEN" \
+            --repo "$REPO" \
+            --report-dir ./wiki-reports \
+            --workflow ci

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -287,3 +287,35 @@ EOFMARKDOWN
               issue_number: prNumber,
               body: comment
             })
+
+  # ==========================================
+  # JOB 8: Publish to GitHub Wiki
+  # ==========================================
+  publish-report:
+    name: Publish to Wiki
+    runs-on: ubuntu-latest
+    needs: [generate-report]
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: write
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download Report
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-validation-report
+          path: ./reports
+
+      - name: Publish to Wiki
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          python3 .github/scripts/publish_wiki_reports.py \
+            --token "$GH_TOKEN" \
+            --repo "$REPO" \
+            --report-dir ./reports \
+            --workflow pr


### PR DESCRIPTION
## Summary

- Migrate CI/CD reports from GitHub Pages to GitHub Wiki
- Update CI workflow to publish decorated markdown reports to Wiki
- Update CD workflow to publish deployment reports to Wiki
- Add PR Validation workflow with Wiki publishing
- Use publish_wiki_reports.py script for generating formatted reports

## Changes

- `.github/workflows/ci.yml`: Changed publish-reports job to use Wiki instead of Pages
- `.github/workflows/cd.yml`: Changed publish-report job to use Wiki instead of Pages
- `.github/workflows/pr-validation.yml`: Added new job to publish PR validation reports to Wiki

## Testing

- Workflows updated with continue-on-error to prevent failures
- Reports will be available at: https://github.com/matiaspakua/notaire/wiki

Fixes #223