### PR TITLE
docs(arch): add ADR-005 modern frontend and ADR-006 testing strategy

### DIFF
--- a/docs/02-architecture/01-adr/ADR-005-modern-frontend-migration.md
+++ b/docs/02-architecture/01-adr/ADR-005-modern-frontend-migration.md
@@ -1,0 +1,166 @@
+# ADR-005: Migración de Frontend Java Swing a Next.js
+
+**Status:** Accepted
+**Date:** 2026-04-13
+**Deciders:** Matías Miguez
+**Supersedes:** N/A
+**Related:** ADR-001 (Microservices Architecture), ADR-003 (REST API Versioning)
+
+## Context
+
+El módulo `frontend-swing` fue creado como paso intermedio en la migración del monolito:
+fue refactorizado para usar el backend REST en lugar de acceso directo a la base de datos,
+pero sigue siendo una aplicación Java Swing de escritorio.
+
+### Problemas actuales con Java Swing
+
+- **Tecnología deprecated:** Java Swing no recibe mejoras activas desde Java 8. Oracle no lo desarrolla activamente para uso moderno.
+- **Sin soporte web/móvil:** Aplicación de escritorio solamente, sin acceso desde navegador.
+- **UX desactualizada:** Look and feel limitado, sin componentes modernos (tablas reactivas, gráficas, dashboards).
+- **Testing difícil:** Swing requiere herramientas especializadas (AssertJ-Swing, UISpec4J) que son complejas y frágiles.
+- **Distribución compleja:** Requiere JRE instalado en cada cliente, updates manuales.
+- **Integración con herramientas modernas:** No se integra fácilmente con DevTools, CI/CD de frontend, ni ecosistema npm.
+
+### Opciones Evaluadas
+
+| Opción | Pros | Contras |
+|--------|------|---------|
+| Mantener Swing | Sin migración | Todos los problemas arriba |
+| JavaFX | Mismo ecosistema Java | Igualmente deprecated, poca adopción |
+| Electron | Familiar para Java devs | Bundle muy pesado, no web-native |
+| Angular | Robusto, tipado | Más verboso, curva de aprendizaje |
+| **Next.js (React)** | Ecosystem enorme, SSR, TypeScript, testing moderno | Requiere aprender JS/TS |
+| Vue.js / Nuxt | Simple, progresivo | Menor ecosystem que React |
+
+### Criterios de Decisión
+
+1. Soporte TypeScript nativo (type safety comparable a Java)
+2. Testing moderno (unit + E2E automatizado)
+3. Rendimiento y SEO (server-side rendering)
+4. Ecosistema de componentes UI maduros
+5. Facilidad de integración con REST API
+6. Deployable como contenedor
+
+## Decision
+
+**Migrar el frontend a Next.js 15 con TypeScript** como tecnología base, complementado por:
+
+- **Tailwind CSS** para estilos utilitarios
+- **shadcn/ui** para componentes accesibles y customizables
+- **React Query (TanStack Query)** para manejo de estado servidor y cache de API
+- **Zustand** para estado cliente (auth, UI state)
+- **Vitest + Testing Library** para tests unitarios de componentes
+- **Playwright** para tests E2E automatizados
+
+### Arquitectura del Nuevo Frontend
+
+```
+frontend-nextjs/
+├── app/                    # Next.js App Router
+│   ├── (auth)/             # Páginas públicas (login)
+│   ├── (dashboard)/        # Páginas protegidas
+│   │   ├── gestiones/      # CU01-CU16 (core workflow)
+│   │   ├── clientes/       # CU17-CU19, CU41, CU46
+│   │   ├── escrituras/     # CU52, CU62
+│   │   ├── presupuestos/   # CU01, CU39, CU45, CU49, CU55, CU60
+│   │   ├── protocolos/     # CU28, CU33, CU36, CU40, CU63, CU68
+│   │   ├── administracion/ # CU20-CU23, CU26-CU32, CU34-CU38
+│   │   └── reportes/       # CU24, CU25, CU50
+│   └── api/                # Route handlers (BFF pattern)
+├── components/
+│   ├── ui/                 # shadcn/ui components
+│   ├── forms/              # Form components por dominio
+│   ├── tables/             # Data tables con paginación
+│   └── layout/             # Navigation, sidebar, header
+├── lib/
+│   ├── api-client.ts       # HTTP client (tipo-safe, basado en fetch)
+│   ├── auth.ts             # JWT management
+│   └── utils.ts            # Helpers
+├── hooks/                  # Custom React hooks
+├── stores/                 # Zustand stores
+├── types/                  # TypeScript types (mirrors DTOs del backend)
+├── tests/
+│   ├── unit/               # Vitest tests
+│   └── e2e/                # Playwright tests
+└── public/                 # Static assets
+```
+
+### Estrategia de Migración (Backend For Frontend)
+
+El backend REST existente (`/api/v1`) se expone directamente al nuevo frontend.
+Para casos donde se necesite composición de múltiples APIs o transformaciones específicas,
+se usarán Next.js Route Handlers como BFF (Backend For Frontend) liviano.
+
+```
+Browser → Next.js (SSR/CSR) → Spring Boot REST API → PostgreSQL
+                    ↓
+             Route Handlers (BFF)
+             - Session management
+             - Token refresh
+             - Response aggregation
+```
+
+## Consequences
+
+### Positivo
+
+- **Testing completo:** Vitest (unit) + Playwright (E2E) cubren todos los 68 CUs
+- **UX moderna:** Componentes accesibles, responsive, dark mode
+- **Type safety:** TypeScript en frontend + Java en backend = sistema end-to-end tipado
+- **Deploy:** Docker container deployable en Kubernetes igual que el backend
+- **Developer experience:** Hot reload, DevTools, ecosistema npm
+- **CI/CD:** Integración nativa con GitHub Actions para lint, tests, build
+
+### Negativo
+
+- **Curva de aprendizaje:** Equipo Java necesita aprender React/TypeScript
+- **Dos stacks:** Java (backend) + TypeScript (frontend) en el mismo repo
+- **Migración costosa:** Los 68 CUs necesitan reimplementarse
+- **Duplicación de tipos:** DTOs en Java y types en TypeScript (mitigado con OpenAPI codegen)
+
+### Mitigaciones
+
+- Usar `openapi-typescript` para generar types automáticamente desde la spec de Swagger
+- Migración incremental: un módulo de CUs por sprint
+- El módulo `frontend-swing` se mantiene durante la transición hasta que cada CU sea validado
+
+## Implementation Plan
+
+### Sprint 1: Setup Base
+- [ ] Crear módulo `frontend-nextjs` en el mono-repo Maven
+- [ ] Setup Next.js 15 + TypeScript + Tailwind + shadcn/ui
+- [ ] Implementar autenticación JWT con Spring Security
+- [ ] Crear layout base: sidebar con todos los módulos
+
+### Sprint 2-3: Core Workflow
+- [ ] Migrar CU01-CU16: Gestiones (workflow principal del negocio)
+- [ ] Tests Playwright para el flujo completo gestión → escritura → pago
+
+### Sprint 4-5: Clientes & Personas
+- [ ] Migrar CU17-CU19, CU41, CU46, CU54, CU61
+
+### Sprint 6-7: Administración
+- [ ] Migrar CU20-CU23, CU26-CU38, CU48, CU51
+
+### Sprint 8: Presupuestos & Escrituras
+- [ ] Migrar CU39, CU45, CU49, CU52, CU55, CU60, CU62
+
+### Sprint 9: Reportes & Protocolos
+- [ ] Migrar CU24, CU25, CU50 (PDF via JasperReports API)
+- [ ] Migrar CU28, CU33, CU36, CU40, CU63-CU68
+
+### Sprint 10: E2E & Deprecation
+- [ ] Playwright E2E para todos los flujos
+- [ ] Deprecar y eliminar `frontend-swing`
+
+## References
+
+- [Next.js 15 Documentation](https://nextjs.org/docs)
+- [shadcn/ui Components](https://ui.shadcn.com/)
+- [TanStack Query](https://tanstack.com/query/latest)
+- [Playwright Testing](https://playwright.dev/)
+- [openapi-typescript](https://openapi-ts.dev/)
+- ADR-001: Microservices Architecture
+- ADR-003: REST API Versioning
+- Issue #240: Complete remaining form migration
+- Milestone: Phase 3 - Modern Frontend

--- a/docs/02-architecture/01-adr/ADR-006-testing-strategy.md
+++ b/docs/02-architecture/01-adr/ADR-006-testing-strategy.md
@@ -1,0 +1,103 @@
+# ADR-006: Testing Strategy
+
+**Status:** Accepted
+**Date:** 2026-04-13
+**Deciders:** Matías Miguez
+**Related:** ADR-001, ADR-005
+
+## Context
+
+El proyecto necesita una estrategia de testing clara que cubra todos los componentes
+del sistema: backend (Spring Boot), frontend (Next.js), y el stack completo desplegado
+en Kubernetes.
+
+## Decision
+
+Adoptamos la **Testing Trophy** adaptada al stack actual:
+
+```
+        ┌──────────────────────────────┐
+        │   E2E Tests (Playwright)     │  ← Flujos completos de negocio
+        │   ~10-20 tests críticos      │
+        └──────────────────────────────┘
+      ┌────────────────────────────────────┐
+      │   Integration Tests                │  ← API tests, DB tests
+      │   (Spring Boot Test + H2/PG)       │
+      │   ~50-100 tests                    │
+      └────────────────────────────────────┘
+    ┌────────────────────────────────────────────┐
+    │   Unit Tests (JUnit 5 + Vitest)            │  ← Lógica de negocio
+    │   Backend: servicios, validators           │
+    │   Frontend: componentes, hooks, utils      │
+    │   ~200+ tests                              │
+    └────────────────────────────────────────────┘
+```
+
+### Backend Testing (Java)
+
+| Tipo | Herramientas | Scope | Requisito |
+|------|-------------|-------|-----------|
+| Unit | JUnit 5 + Mockito + AssertJ | Services, validators | 80% coverage |
+| Integration | @SpringBootTest + Testcontainers | Controllers, repositories | Todos los endpoints |
+| API Contract | MockMvc + Spring Security Test | Auth, roles, status codes | Happy + sad paths |
+| Performance | Gatling / k6 | API bajo carga | Baseline documented |
+| Security | OWASP ZAP | Todos los endpoints | 0 CRITICAL/HIGH |
+
+**Convenciones backend:**
+- Métodos: `shouldXxxWhenYyy()` con `@DisplayName`
+- Patrón: Arrange / Act / Assert
+- Un assert por test cuando sea posible
+- Tests en `src/test/java/.../unit/` e `integration/`
+- Tagging con `@Tag("unit")` y `@Tag("integration")`
+
+### Frontend Testing (TypeScript)
+
+| Tipo | Herramientas | Scope |
+|------|-------------|-------|
+| Unit | Vitest + Testing Library | Components, hooks, utils |
+| Visual | Storybook (opcional) | Component states |
+| E2E | Playwright | User journeys completos |
+| Accessibility | axe-core + Playwright | WCAG 2.1 compliance |
+
+**Convenciones frontend:**
+- Archivos de test: `*.test.ts` junto al código
+- E2E en `tests/e2e/*.spec.ts`
+- Page Object Model para E2E
+
+### E2E Tests - Flujos Prioritarios
+
+| Flujo | CUs | Prioridad |
+|-------|-----|-----------|
+| Login → Gestión completa → Pago | CU01, CU02, CU15, CU16 | Critical |
+| Alta cliente → Búsqueda | CU17, CU18, CU19, CU61 | High |
+| Presupuesto → Escritura → Testimonio | CU01, CU05, CU07 | High |
+| Admin: alta usuario + suplencia | CU20, CU22 | Medium |
+| Generar reporte mensual | CU24, CU25 | Medium |
+
+### CI Pipeline
+
+```yaml
+# Por cada PR:
+1. Backend: mvn test (unit + integration)
+2. Backend: JaCoCo coverage report (80% gate)
+3. Backend: Checkstyle + SpotBugs
+4. Backend: Trivy vulnerability scan
+5. Frontend: vitest run
+6. Frontend: playwright test (headless)
+7. Build: Docker images
+8. Security: OWASP ZAP (weekly en main)
+```
+
+## Consequences
+
+- Tests etiquetados permiten ejecutar solo unit tests en feedback rápido
+- Testcontainers elimina diferencias entre H2 y PostgreSQL en integration tests
+- Playwright E2E en CI garantiza que los 68 CUs funcionan end-to-end
+- Coverage gate del 80% mantiene calidad del backend
+
+## References
+
+- [Testing Trophy (Kent C. Dodds)](https://kentcdodds.com/blog/the-testing-trophy-and-testing-classifications)
+- [Spring Boot Testing Guide](https://docs.spring.io/spring-boot/docs/current/reference/html/test-auto-configuration.html)
+- [Testcontainers for Java](https://java.testcontainers.org/)
+- [Playwright Documentation](https://playwright.dev/docs/intro)


### PR DESCRIPTION
## Summary

- **ADR-005**: Decisión formal de migrar de Java Swing a Next.js 15 + TypeScript
- **ADR-006**: Estrategia de testing completa (Testing Trophy) para backend y frontend

## ADR-005: Modern Frontend Migration

**Decision:** Reemplazar Java Swing con Next.js 15 + TypeScript

Stack elegido:
- **Next.js 15** (App Router) — SSR, routing, BFF pattern
- **TypeScript** — type safety comparable a Java
- **shadcn/ui + Tailwind** — componentes accesibles y modernos
- **React Query** — server state + API cache
- **Vitest** — unit tests de componentes
- **Playwright** — E2E automatizado para los 68 casos de uso

Plan: 10 sprints, migrando CUs por grupo temático.

## ADR-006: Testing Strategy

**Decision:** Testing Trophy adaptado al stack

| Capa | Backend | Frontend |
|------|---------|----------|
| Unit | JUnit 5 + Mockito | Vitest + Testing Library |
| Integration | SpringBootTest + Testcontainers | - |
| E2E | - | Playwright |
| Security | OWASP ZAP | axe-core |

CI gates: 80% coverage backend, 0 CRITICAL security findings.

## Test plan

- [ ] Verificar que los ADRs se renderizan correctamente en GitHub
- [ ] Verificar links a issues y milestones en los documentos

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)