### PR TITLE
test(e2e): batch 1 - login, navigation, and enhanced automation library

### DIFF
--- a/integration-test/e2e-swing/libs/SwingAutomation.py
+++ b/integration-test/e2e-swing/libs/SwingAutomation.py
@@ -1,12 +1,15 @@
 """
 SwingAutomation - Robot Framework library for Java Swing GUI automation.
-Uses PyAutoGUI for cross-platform desktop interaction on macOS.
+Uses PyAutoGUI for desktop interaction and AppleScript (macOS) for
+accessibility-based element finding by name.
 Designed to be lightweight and agent-friendly.
 """
 
 import pyautogui
 import time
 import os
+import subprocess
+import re
 from robot.api import logger
 from robot.api.deco import keyword
 
@@ -17,12 +20,16 @@ pyautogui.PAUSE = 0.1
 
 
 class SwingAutomation:
-    """Robot Framework library wrapping PyAutoGUI for Swing desktop automation."""
+    """Robot Framework library wrapping PyAutoGUI + AppleScript for Swing desktop automation."""
 
     ROBOT_LIBRARY_SCOPE = "GLOBAL"
 
     def __init__(self):
-        logger.info("SwingAutomation library initialized (PyAutoGUI backend)")
+        logger.info("SwingAutomation library initialized (PyAutoGUI + AppleScript backend)")
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Screenshot
+    # ─────────────────────────────────────────────────────────────────────────
 
     @keyword("Capture Desktop Screenshot")
     def capture_desktop_screenshot(self, filepath):
@@ -36,6 +43,10 @@ class SwingAutomation:
             logger.warn(f"Failed to capture screenshot (permissions issue?): {e}")
         return filepath
 
+    # ─────────────────────────────────────────────────────────────────────────
+    # Typing & keyboard
+    # ─────────────────────────────────────────────────────────────────────────
+
     @keyword("Type Text Slowly")
     def type_text_slowly(self, text, interval=0.05):
         """Type text character by character with a small interval."""
@@ -44,8 +55,10 @@ class SwingAutomation:
 
     @keyword("Clear Text Field")
     def clear_text_field(self):
-        """Press Backspace multiple times to clear the field."""
-        pyautogui.press("backspace", presses=50, interval=0.01)
+        """Select all text and delete it."""
+        pyautogui.hotkey("command", "a")
+        time.sleep(0.1)
+        pyautogui.press("backspace")
         time.sleep(0.2)
 
     @keyword("Press Tab Key")
@@ -58,6 +71,18 @@ class SwingAutomation:
     def press_enter_key(self):
         """Press Enter key."""
         pyautogui.press("enter")
+        time.sleep(0.3)
+
+    @keyword("Press Escape Key")
+    def press_escape_key(self):
+        """Press Escape key to dismiss dialogs."""
+        pyautogui.press("escape")
+        time.sleep(0.3)
+
+    @keyword("Press Space Key")
+    def press_space_key(self):
+        """Press Space key (activates focused button)."""
+        pyautogui.press("space")
         time.sleep(0.3)
 
     @keyword("Click At Coordinates")
@@ -81,3 +106,184 @@ class SwingAutomation:
     def wait_seconds(self, seconds):
         """Wait for specified seconds."""
         time.sleep(float(seconds))
+
+    @keyword("Select All Text")
+    def select_all_text(self):
+        """Press Cmd+A to select all text."""
+        pyautogui.hotkey("command", "a")
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # AppleScript-based accessibility (macOS Swing automation)
+    # ─────────────────────────────────────────────────────────────────────────
+
+    def _run_applescript(self, script):
+        """Run an AppleScript and return stdout."""
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True, text=True, timeout=10
+        )
+        if result.returncode != 0:
+            logger.warn(f"AppleScript error: {result.stderr.strip()}")
+        return result.stdout.strip(), result.returncode
+
+    @keyword("Click Button By Name")
+    def click_button_by_name(self, button_name, window_title="Notaire"):
+        """Click a button by its accessibility label (text) using AppleScript.
+
+        Works for Swing buttons when macOS Accessibility is enabled.
+        Raises RuntimeError if the button is not found.
+        """
+        script = f'''
+tell application "System Events"
+    tell process "java"
+        set frontmost to true
+        delay 0.3
+        try
+            click button "{button_name}" of window 1
+            return "clicked"
+        on error errMsg
+            try
+                -- Try searching in all UI elements recursively
+                set allButtons to every button of window 1
+                repeat with btn in allButtons
+                    if description of btn is "{button_name}" then
+                        click btn
+                        return "clicked by description"
+                    end if
+                end repeat
+            end try
+            error errMsg
+        end try
+    end tell
+end tell
+'''
+        out, rc = self._run_applescript(script)
+        if rc != 0 or "clicked" not in out:
+            logger.warn(f"AppleScript click failed for '{button_name}', trying image/coordinate fallback")
+            raise RuntimeError(f"Button '{button_name}' not found via AppleScript.")
+        logger.info(f"Clicked button: '{button_name}' via AppleScript")
+        time.sleep(0.5)
+
+    @keyword("Click Menu Item")
+    def click_menu_item(self, menu_name, item_name=None):
+        """Click a menu bar item, optionally selecting a sub-item."""
+        if item_name:
+            script = f'''
+tell application "System Events"
+    tell process "java"
+        set frontmost to true
+        delay 0.2
+        click menu item "{item_name}" of menu "{menu_name}" of menu bar 1
+    end tell
+end tell
+'''
+        else:
+            script = f'''
+tell application "System Events"
+    tell process "java"
+        set frontmost to true
+        delay 0.2
+        click menu "{menu_name}" of menu bar 1
+    end tell
+end tell
+'''
+        out, rc = self._run_applescript(script)
+        if rc != 0:
+            logger.warn(f"Menu click failed: {menu_name} > {item_name}")
+        time.sleep(0.5)
+
+    @keyword("Get Screen Size")
+    def get_screen_size(self):
+        """Return screen width and height as a tuple."""
+        size = pyautogui.size()
+        logger.info(f"Screen size: {size.width}x{size.height}")
+        return size.width, size.height
+
+    @keyword("Bring Java App To Front")
+    def bring_java_app_to_front(self):
+        """Activate the Java process (Swing app) window."""
+        script = '''
+tell application "System Events"
+    tell process "java"
+        set frontmost to true
+    end tell
+end tell
+'''
+        self._run_applescript(script)
+        time.sleep(0.5)
+
+    @keyword("Get Swing Window Title")
+    def get_swing_window_title(self):
+        """Return the title of the current Swing window."""
+        script = '''
+tell application "System Events"
+    tell process "java"
+        return name of window 1
+    end tell
+end tell
+'''
+        out, rc = self._run_applescript(script)
+        logger.info(f"Window title: {out}")
+        return out
+
+    @keyword("Click Left Panel Button")
+    def click_left_panel_button(self, button_text):
+        """Click one of the main navigation buttons in the left sidebar.
+
+        This uses a Tab-navigation approach to find buttons in the left panel.
+        Buttons order (top to bottom): Clientes, Presupuestos, Gestiones,
+        Protocolo, Pagos, Administración, Salir.
+        """
+        button_order = {
+            "Clientes": 1,
+            "Presupuestos": 2,
+            "Gestiones": 3,
+            "Protocolo": 4,
+            "Pagos": 5,
+            "Administración": 6,
+            "Administracion": 6,
+        }
+        # First try AppleScript
+        try:
+            self.click_button_by_name(button_text)
+            return
+        except Exception:
+            pass
+
+        # Fallback: Tab navigation from window focus
+        logger.warn(f"AppleScript click failed for '{button_text}', using Tab navigation")
+        self.bring_java_app_to_front()
+        time.sleep(0.3)
+        tabs = button_order.get(button_text, 1)
+        for _ in range(tabs):
+            pyautogui.press("tab")
+            time.sleep(0.15)
+        pyautogui.press("space")
+        time.sleep(0.5)
+
+    @keyword("Dismiss Dialog If Present")
+    def dismiss_dialog_if_present(self):
+        """Press Enter to dismiss any open dialog box."""
+        pyautogui.press("enter")
+        time.sleep(0.5)
+
+    @keyword("Read Log File")
+    def read_log_file(self, log_path):
+        """Read and return the content of a log file."""
+        try:
+            with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+                return f.read()
+        except Exception as e:
+            logger.warn(f"Could not read log file {log_path}: {e}")
+            return ""
+
+    @keyword("Log Contains Message")
+    def log_contains_message(self, log_path, message):
+        """Check if a log file contains a specific message. Returns True/False."""
+        content = self.read_log_file(log_path)
+        found = message in content
+        if found:
+            logger.info(f"Found in log: '{message}'")
+        else:
+            logger.warn(f"NOT found in log: '{message}'")
+        return found

--- a/integration-test/e2e-swing/resources/common.resource
+++ b/integration-test/e2e-swing/resources/common.resource
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation    Reusable keywords for Notaire Swing E2E tests.
-...              Uses PyAutoGUI for macOS GUI automation with Robot Framework.
+...              Uses PyAutoGUI + AppleScript for macOS Swing GUI automation.
 Library          Process
 Library          OperatingSystem
 Library          String
@@ -13,10 +13,17 @@ ${FRONTEND_JAR}          ${REPO_DIR}${/}frontend-swing${/}target${/}frontend-swi
 ${SCREENSHOT_DIR}        ${CURDIR}${/}..${/}screenshots
 ${STARTUP_WAIT}          8s
 ${ACTION_DELAY}          1s
+${NAV_DELAY}             2s
+${LOGIN_USER}            admin
+${LOGIN_PASSWORD}        admin
 
 *** Keywords ***
+# ─────────────────────────────────────────────────────────────────────────────
+# Infrastructure
+# ─────────────────────────────────────────────────────────────────────────────
+
 Ensure Backend Is Running
-    [Documentation]    Verify backend API is reachable.
+    [Documentation]    Verify backend API is reachable at localhost:8080.
     ${result}=    Run Process    curl    -sf    http://localhost:8080/swagger-ui.html
     ...    shell=False    timeout=10s
     IF    ${result.rc} != 0
@@ -47,6 +54,10 @@ Close Swing Application
         Log    Swing application terminated.
     END
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Screenshots
+# ─────────────────────────────────────────────────────────────────────────────
+
 Take Named Screenshot
     [Documentation]    Take a screenshot with a descriptive name and timestamp, organized by module.
     [Arguments]    ${module}    ${name}
@@ -57,6 +68,10 @@ Take Named Screenshot
     Capture Desktop Screenshot    ${filename}
     Log    Screenshot saved: ${filename}
     RETURN    ${filename}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Field interaction
+# ─────────────────────────────────────────────────────────────────────────────
 
 Type In Current Field
     [Documentation]    Clear the field, then type text in the currently focused field.
@@ -76,11 +91,99 @@ Submit Form
     Press Enter Key
     Sleep    ${ACTION_DELAY}
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Login
+# ─────────────────────────────────────────────────────────────────────────────
+
+Perform Login
+    [Documentation]    Full login flow: type user, tab to password, tab to button, enter.
+    [Arguments]    ${user}=${LOGIN_USER}    ${password}=${LOGIN_PASSWORD}
+    Type In Current Field    ${user}
+    Navigate To Next Field
+    Type In Current Field    ${password}
+    Navigate To Next Field
+    Submit Form
+    Wait For Principal Window
+
 Wait For Principal Window
-    [Documentation]    Polls the java output log for the 'Ventana Principal abierta' message indicating successful login and main GUI load.
+    [Documentation]    Polls the swing log for "Ventana Principal abierta" indicating successful login.
     Wait Until Keyword Succeeds    30s    2s    Check Principal Window Log
 
 Check Principal Window Log
-    [Documentation]    Helper to grep the swing output log for the success message.
+    [Documentation]    Helper to grep the swing log for the success message.
     ${log_content}=    Get File    ${SWING_LOG}
     Should Contain    ${log_content}    Ventana Principal abierta satisfactoriamente
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Module navigation (left sidebar)
+# ─────────────────────────────────────────────────────────────────────────────
+
+Navigate To Module
+    [Documentation]    Click a left-sidebar module button and wait for the log confirmation.
+    [Arguments]    ${module_name}    ${log_message}
+    Bring Java App To Front
+    Sleep    0.3s
+    Click Left Panel Button    ${module_name}
+    Sleep    ${NAV_DELAY}
+    ${log_content}=    Get File    ${SWING_LOG}
+    Should Contain    ${log_content}    ${log_message}
+    Log    Navigated to module: ${module_name}
+
+Navigate To Clientes
+    [Documentation]    Open the Clientes module.
+    Navigate To Module    Clientes    Usuario navego al modulo: Clientes
+
+Navigate To Presupuestos
+    [Documentation]    Open the Presupuestos module.
+    Navigate To Module    Presupuestos    Usuario navego al modulo: Presupuestos
+
+Navigate To Gestiones
+    [Documentation]    Open the Gestiones module.
+    Navigate To Module    Gestiones    Usuario navego al modulo: Gestiones
+
+Navigate To Protocolo
+    [Documentation]    Open the Protocolo module.
+    Navigate To Module    Protocolo    Usuario navego al modulo: Protocolo
+
+Navigate To Administracion
+    [Documentation]    Open the Administración module.
+    Navigate To Module    Administración    Usuario navego al modulo: Administracion
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sub-form navigation (click a button inside a module panel)
+# ─────────────────────────────────────────────────────────────────────────────
+
+Open Sub Form
+    [Documentation]    Click a button inside a module panel (e.g., "Dar Alta Persona").
+    [Arguments]    ${button_name}
+    Bring Java App To Front
+    Sleep    0.3s
+    Click Button By Name    ${button_name}
+    Sleep    ${NAV_DELAY}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Log verification
+# ─────────────────────────────────────────────────────────────────────────────
+
+Verify Log Contains
+    [Documentation]    Assert that the swing log contains an expected message.
+    [Arguments]    ${expected_message}
+    ${log_content}=    Get File    ${SWING_LOG}
+    Should Contain    ${log_content}    ${expected_message}
+    Log    Verified log: "${expected_message}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Suite helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+Full Suite Setup
+    [Documentation]    Standard setup: verify backend, launch app, login.
+    Ensure Backend Is Running
+    Launch Swing Application
+    Take Named Screenshot    setup    01_app_started
+    Perform Login
+    Take Named Screenshot    setup    02_logged_in
+
+Full Suite Teardown
+    [Documentation]    Standard teardown: close the Swing app.
+    Close Swing Application

--- a/integration-test/e2e-swing/tests/principal_navigation_e2e.robot
+++ b/integration-test/e2e-swing/tests/principal_navigation_e2e.robot
@@ -1,0 +1,128 @@
+*** Settings ***
+Documentation    E2E navigation tests for the Principal (main) window of Notaire Swing.
+...
+...              Validates:
+...              - CU: Login flow (admin/admin)
+...              - Principal window loads with all module buttons
+...              - Each module button navigates to the correct sub-module
+...              - Menu bar items are accessible
+...
+...              Requires: backend running (scripts/start.sh), frontend JAR built.
+Resource         ../resources/common.resource
+Suite Setup      Suite Initialization
+Suite Teardown   Close Swing Application
+Test Teardown    Run Keyword If Test Failed    Take Named Screenshot    navigation    FAIL_${TEST_NAME}
+
+*** Variables ***
+${MODULE}    navigation
+
+*** Keywords ***
+Suite Initialization
+    [Documentation]    Start backend check, launch app, login once.
+    Ensure Backend Is Running
+    Launch Swing Application
+    Take Named Screenshot    ${MODULE}    01_app_launched
+
+*** Test Cases ***
+# ─────────────────────────────────────────────────────────────────────────────
+# Login smoke tests (CU: Login)
+# ─────────────────────────────────────────────────────────────────────────────
+
+Login Window Should Appear On Startup
+    [Documentation]    Verify the Login window is displayed after app launch.
+    [Tags]    smoke    login    navigation    agent-callable
+    Take Named Screenshot    ${MODULE}    02_login_window
+
+Login With Invalid Credentials Should Fail Gracefully
+    [Documentation]    Enter wrong credentials - system should not crash (may show error dialog).
+    [Tags]    login    negative    agent-callable
+    Type In Current Field    wronguser
+    Navigate To Next Field
+    Type In Current Field    wrongpass
+    Navigate To Next Field
+    Submit Form
+    Sleep    2s
+    Take Named Screenshot    ${MODULE}    03_invalid_login_attempt
+    # Dismiss any error dialog that may have appeared
+    Dismiss Dialog If Present
+    Sleep    1s
+    # App should still be running (not crashed)
+    ${running}=    Is Process Running    swing_app
+    Should Be True    ${running}    msg=App crashed after invalid login
+
+Login With Valid Credentials Should Open Principal Window
+    [Documentation]    Enter admin/admin and verify main window loads successfully.
+    [Tags]    login    smoke    e2e    agent-callable
+    # Clear any leftover text from previous test
+    Clear Text Field
+    Navigate To Next Field
+    Clear Text Field
+    # Tab back to username
+    Press Key Combination    shift    tab
+    # Enter valid credentials
+    Type In Current Field    ${LOGIN_USER}
+    Navigate To Next Field
+    Type In Current Field    ${LOGIN_PASSWORD}
+    Navigate To Next Field
+    Submit Form
+    Wait For Principal Window
+    Take Named Screenshot    ${MODULE}    04_principal_window_loaded
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Module navigation tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+Clicking Clientes Button Should Open Clientes Module
+    [Documentation]    Verify the Clientes sidebar button navigates to the Clientes module.
+    [Tags]    navigation    clientes    smoke    agent-callable
+    Navigate To Clientes
+    Take Named Screenshot    ${MODULE}    05_clientes_module
+
+Clicking Presupuestos Button Should Open Presupuestos Module
+    [Documentation]    Verify the Presupuestos sidebar button opens Presupuestos.
+    [Tags]    navigation    presupuestos    smoke    agent-callable
+    Navigate To Presupuestos
+    Take Named Screenshot    ${MODULE}    06_presupuestos_module
+
+Clicking Gestiones Button Should Open Gestiones Module
+    [Documentation]    Verify the Gestiones sidebar button opens Gestiones.
+    [Tags]    navigation    gestiones    smoke    agent-callable
+    Navigate To Gestiones
+    Take Named Screenshot    ${MODULE}    07_gestiones_module
+
+Clicking Protocolo Button Should Open Protocolo Module
+    [Documentation]    Verify the Protocolo sidebar button opens Protocolo.
+    [Tags]    navigation    protocolo    smoke    agent-callable
+    Navigate To Protocolo
+    Take Named Screenshot    ${MODULE}    08_protocolo_module
+
+Clicking Administracion Button Should Open Administracion Module
+    [Documentation]    Verify the Administración sidebar button opens Administración.
+    [Tags]    navigation    administracion    smoke    agent-callable
+    Navigate To Administracion
+    Take Named Screenshot    ${MODULE}    09_administracion_module
+
+Clicking Pagos Button Should Show Under Construction Screen
+    [Documentation]    Pagos module shows "En construcción" screen (not yet implemented).
+    [Tags]    navigation    pagos    agent-callable
+    Bring Java App To Front
+    Sleep    0.3s
+    Click Left Panel Button    Pagos
+    Sleep    2s
+    Take Named Screenshot    ${MODULE}    10_pagos_under_construction
+    # Note: Pagos module shows CartelConstruccion - this is expected behavior
+    Log    Pagos module is under construction - expected behavior documented
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Log verification for all navigation
+# ─────────────────────────────────────────────────────────────────────────────
+
+Log Should Record All Module Navigations
+    [Documentation]    Verify the log recorded all module navigation events.
+    [Tags]    navigation    log    agent-callable
+    Verify Log Contains    Usuario navego al modulo: Clientes
+    Verify Log Contains    Usuario navego al modulo: Presupuestos
+    Verify Log Contains    Usuario navego al modulo: Gestiones
+    Verify Log Contains    Usuario navego al modulo: Protocolo
+    Verify Log Contains    Usuario navego al modulo: Administracion
+    Log    All module navigation events verified in log


### PR DESCRIPTION
## Summary

Batch 1 del suite completo de E2E tests para el frontend Swing de Notaire.

## Changes

### `SwingAutomation.py` — nueva funcionalidad
- `Click Button By Name`: usa AppleScript para encontrar botones por nombre de accesibilidad
- `Click Left Panel Button`: AppleScript + fallback Tab para el panel lateral
- `Bring Java App To Front`, `Dismiss Dialog If Present`
- `Read Log File`, `Log Contains Message`

### `common.resource` — keywords reutilizables
- `Navigate To Module` con verificación por log
- `Navigate To Clientes/Presupuestos/Gestiones/Protocolo/Administracion`
- `Perform Login`, `Full Suite Setup/Teardown`
- `Verify Log Contains`

### `principal_navigation_e2e.robot` — 10 tests
| Test | CU | Tags |
|------|----|------|
| Login window appears | Login | smoke |
| Invalid credentials handled | Login | negative |
| Valid login opens principal | Login | smoke, e2e |
| Clientes button navigation | - | navigation, smoke |
| Presupuestos button navigation | - | navigation, smoke |
| Gestiones button navigation | - | navigation, smoke |
| Protocolo button navigation | - | navigation, smoke |
| Administración button navigation | - | navigation, smoke |
| Pagos shows under construction | - | navigation |
| Log records all navigations | - | log |

## Test plan

- [ ] `bash run_tests.sh --dryrun` passes (10/10 ✅)
- [ ] Verify with real app: `bash run_tests.sh --suite principal_navigation_e2e`
- [ ] Check screenshots in `integration-test/e2e-swing/screenshots/navigation/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)