### PR TITLE
fix(auth): corregir login de usuario admin en Notaire

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
@@ -11,7 +11,9 @@ import org.springframework.web.bind.annotation.*;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,7 +112,7 @@ public class UsuarioController {
 
     @PostMapping("/login")
     @Operation(summary = "Autenticar usuario")
-    public ResponseEntity<DtoUsuario> login(@RequestBody DtoUsuario loginRequest) {
+    public ResponseEntity<?> login(@RequestBody DtoUsuario loginRequest) {
         try {
             List<Usuario> usuarios = getJpaController().buscarUsuarios();
 
@@ -145,7 +147,24 @@ public class UsuarioController {
                                 dtoUsuario.setPersonas(dtoPersona);
                             }
                             dtoUsuario.setValido(true);
-                            return ResponseEntity.ok(dtoUsuario);
+                            log.debug("DTO Usuario creado - valido: {}, estado: {}", dtoUsuario.isValido(), dtoUsuario.isEstado());
+                            
+                            // Create a map response to ensure 'valido' field is included
+                            Map<String, Object> response = new HashMap<>();
+                            response.put("valido", true);
+                            response.put("idUsuario", dtoUsuario.getIdUsuario());
+                            response.put("nombre", dtoUsuario.getNombre());
+                            response.put("estado", dtoUsuario.isEstado());
+                            response.put("tipo", dtoUsuario.getTipo());
+                            response.put("version", dtoUsuario.getVersion());
+                            if (dtoUsuario.getPersonas() != null) {
+                                Map<String, Object> personaMap = new HashMap<>();
+                                personaMap.put("idPersona", dtoUsuario.getPersonas().getIdPersona());
+                                personaMap.put("nombre", dtoUsuario.getPersonas().getNombre());
+                                personaMap.put("apellido", dtoUsuario.getPersonas().getApellido());
+                                response.put("personas", personaMap);
+                            }
+                            return ResponseEntity.ok(response);
                         } else {
                             log.warn("Login fallido para '{}': usuario inactivo", usuario.getNombre());
                         }
@@ -157,13 +176,13 @@ public class UsuarioController {
 
             log.warn("Login fallido: usuario '{}' no encontrado en {} usuarios cargados.", loginRequest.getNombre(),
                     usuarios.size());
-            DtoUsuario errorResponse = new DtoUsuario();
-            errorResponse.setValido(false);
+            Map<String, Object> errorResponse = new HashMap<>();
+            errorResponse.put("valido", false);
             return ResponseEntity.ok(errorResponse);
 
         } catch (Exception e) {
-            DtoUsuario errorResponse = new DtoUsuario();
-            errorResponse.setValido(false);
+            Map<String, Object> errorResponse = new HashMap<>();
+            errorResponse.put("valido", false);
             return ResponseEntity.ok(errorResponse);
         }
     }

--- a/backend-api/src/main/resources/application.properties
+++ b/backend-api/src/main/resources/application.properties
@@ -6,8 +6,10 @@ spring.jmx.enabled=false
 
 # Jackson Configuration for JPA lazy loading
 spring.jackson.serialization.fail-on-empty-beans=false
-spring.jackson.default-property-inclusion=non_null
-spring.jackson.serialization-inclusion=non_null
+spring.jackson.default-property-inclusion=always
+spring.jackson.serialization-inclusion=always
+# Include all properties for DtoUsuario (valido field)
+spring.jackson.mapper.default-view-inclusion=true
 
 # Disable open-in-view to avoid lazy loading issues
 spring.jpa.open-in-view=false

--- a/init-db/02-data.sql
+++ b/init-db/02-data.sql
@@ -85,8 +85,10 @@ INSERT INTO personas (
 SELECT setval('personas_id_persona_seq', (SELECT MAX(id_persona) FROM personas));
 
 -- Sample usuario (nombre/contrasenia for login; tipo: Escribano/Empleado; estado: habilitado)
+-- Password: admin (almacenado como hash MD5)
+-- MD5("admin") = 21232f297a57a5a743894a0e4a801fc3
 INSERT INTO usuarios (version, id_usuario, nombre, contrasenia, tipo, estado, fk_id_persona) VALUES
-(0, 1, 'admin', 'admin', 'Escribano', true, 1);
+(0, 1, 'admin', '21232f297a57a5a743894a0e4a801fc3', 'Escribano', true, 1);
 
 -- Reset sequence  
 SELECT setval('usuarios_id_usuario_seq', (SELECT MAX(id_usuario) FROM usuarios));

--- a/notaire-shared/src/main/java/com/licensis/notaire/dto/DtoUsuario.java
+++ b/notaire-shared/src/main/java/com/licensis/notaire/dto/DtoUsuario.java
@@ -16,7 +16,7 @@ public class DtoUsuario
     private String tipo;
     private String registroAuditoria;
     private Integer version;
-    private boolean valido;
+    private boolean valido = false;
 
     public boolean isValido()
     {


### PR DESCRIPTION
## Summary

Corrige el problema de autenticación que impedía el login con el usuario `admin`/`admin`.

## Root Cause

1. **Contraseña en texto plano vs MD5**: La contraseña en la base de datos estaba almacenada como texto plano `'admin'`, pero el código del controller encriptaba la contraseña ingresada a MD5 antes de comparar, causando que nunca coincidan.

2. **Campo 'valido' no serializado**: El campo `valido` no se incluía en la respuesta JSON debido a configuración de Jackson.

## Changes

- `init-db/02-data.sql`: Cambiar contraseña a hash MD5 (`21232f297a57a5a743894a0e4a801fc3`)
- `backend-api/.../UsuarioController.java`: Modificar respuesta para incluir campo `valido`
- `backend-api/.../application.properties`: Actualizar configuración Jackson
- `notaire-shared/.../DtoUsuario.java`: Simplificar manejo del campo `valido`

## Testing

```bash
curl -X POST http://localhost:8080/api/v1/usuarios/login \
  -H "Content-Type: application/json" \
  -d '{"nombre":"admin","contrasenia":"admin"}'
# Respuesta exitosa con {"estado":true,"tipo":"Escribano","valido":true,...}
```

## Labels

- `bug` - Corrección de bug
- `auth` - Cambios relacionados con autenticación
- `backend` - Cambios en backend

Fixes #226