### PR TITLE
[#336, #337, #338] fix: resolve 500 errors in 6 API controllers

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/EscrituraController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/EscrituraController.java
@@ -1,5 +1,6 @@
 package com.licensis.notaire.api;
 
+import com.licensis.notaire.dto.DtoPersona;
 import com.licensis.notaire.negocio.Escritura;
 import com.licensis.notaire.negocio.Persona;
 import com.licensis.notaire.service.EscrituraService;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -71,8 +73,13 @@ public class EscrituraController {
     @GetMapping("/escribanos-disponibles")
     @Operation(summary = "Obtener lista de escribanos disponibles (con registro)")
     @Transactional(readOnly = true)
-    public ResponseEntity<List<Persona>> getEscribanosDisponibles() {
-        return ResponseEntity.ok(escrituraService.findEscribanosDisponibles());
+    public ResponseEntity<List<DtoPersona>> getEscribanosDisponibles() {
+        List<Persona> escribanos = escrituraService.findEscribanosDisponibles();
+        List<DtoPersona> result = new ArrayList<>();
+        for (Persona p : escribanos) {
+            result.add(p.getDto());
+        }
+        return ResponseEntity.ok(result);
     }
 
     @GetMapping("/buscar")

--- a/backend-api/src/main/java/com/licensis/notaire/api/EstadoDeGestionController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/EstadoDeGestionController.java
@@ -1,13 +1,16 @@
 package com.licensis.notaire.api;
 
 import com.licensis.notaire.config.JpaControllerProvider;
+import com.licensis.notaire.dto.DtoEstadoDeGestion;
 import com.licensis.notaire.jpa.EstadoDeGestionJpaController;
 import com.licensis.notaire.negocio.EstadoDeGestion;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -21,57 +24,54 @@ public class EstadoDeGestionController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los estados de gestion")
-    public ResponseEntity<List<EstadoDeGestion>> getAll() {
-        try {
-            List<EstadoDeGestion> list = getJpaController().findEstadoDeGestionEntities();
-            return ResponseEntity.ok(list);
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+    public ResponseEntity<List<DtoEstadoDeGestion>> getAll() {
+        List<EstadoDeGestion> list = getJpaController().findEstadoDeGestionEntities();
+        List<DtoEstadoDeGestion> result = new ArrayList<>();
+        for (EstadoDeGestion e : list) {
+            result.add(e.getDto());
         }
+        return ResponseEntity.ok(result);
     }
 
     @GetMapping("/{id}")
     @Operation(summary = "Obtener estado de gestion por ID")
-    public ResponseEntity<EstadoDeGestion> getById(@PathVariable Integer id) {
-        try {
-            EstadoDeGestion e = getJpaController().findEstadoDeGestion(id);
-            return e != null ? ResponseEntity.ok(e) : ResponseEntity.notFound().build();
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
-        }
+    public ResponseEntity<DtoEstadoDeGestion> getById(@PathVariable Integer id) {
+        EstadoDeGestion e = getJpaController().findEstadoDeGestion(id);
+        return e != null ? ResponseEntity.ok(e.getDto()) : ResponseEntity.notFound().build();
     }
 
     @PostMapping
     @Operation(summary = "Crear estado de gestion")
-    public ResponseEntity<Void> create(@RequestBody EstadoDeGestion estadoDeGestion) {
+    public ResponseEntity<Object> create(@RequestBody EstadoDeGestion estadoDeGestion) {
         try {
             getJpaController().create(estadoDeGestion);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
         }
     }
 
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar estado de gestion")
-    public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody EstadoDeGestion estadoDeGestion) {
+    public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody EstadoDeGestion estadoDeGestion) {
         try {
             estadoDeGestion.setIdEstadoGestion(id);
             getJpaController().edit(estadoDeGestion);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.internalServerError().body(e.getMessage());
         }
     }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar estado de gestion")
-    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+    public ResponseEntity<Object> delete(@PathVariable Integer id) {
         try {
             getJpaController().destroy(id);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body("No se puede eliminar: el estado de gestión está referenciado por otros registros.");
         }
     }
 }

--- a/backend-api/src/main/java/com/licensis/notaire/api/MovimientoTestimonioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/MovimientoTestimonioController.java
@@ -2,11 +2,15 @@ package com.licensis.notaire.api;
 
 import com.licensis.notaire.jpa.MovimientoTestimonioJpaController;
 import com.licensis.notaire.config.JpaControllerProvider;
+import com.licensis.notaire.dto.DtoMovimientoTestimonio;
 import com.licensis.notaire.negocio.MovimientoTestimonio;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -17,59 +21,57 @@ public class MovimientoTestimonioController {
     private MovimientoTestimonioJpaController getJpaController() {
         return new MovimientoTestimonioJpaController(null, JpaControllerProvider.getEntityManagerFactory());
     }
-    // JpaController instantiated dynamically
 
     @GetMapping
     @Operation(summary = "Obtener todos los movimiento-testimonio")
-    public ResponseEntity<List<MovimientoTestimonio>> getAll() {
-        try {
-            return ResponseEntity.ok(getJpaController().findMovimientoTestimonioEntities());
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+    public ResponseEntity<List<DtoMovimientoTestimonio>> getAll() {
+        List<MovimientoTestimonio> list = getJpaController().findMovimientoTestimonioEntities();
+        List<DtoMovimientoTestimonio> result = new ArrayList<>();
+        for (MovimientoTestimonio e : list) {
+            result.add(e.getDto());
         }
+        return ResponseEntity.ok(result);
     }
 
     @GetMapping("/{id}")
     @Operation(summary = "Obtener movimiento-testimonio por ID")
-    public ResponseEntity<MovimientoTestimonio> getById(@PathVariable Integer id) {
-        try {
-            return ResponseEntity.ok(getJpaController().findMovimientoTestimonio(id));
-        } catch (Exception e) {
-            return ResponseEntity.notFound().build();
-        }
+    public ResponseEntity<DtoMovimientoTestimonio> getById(@PathVariable Integer id) {
+        MovimientoTestimonio e = getJpaController().findMovimientoTestimonio(id);
+        return e != null ? ResponseEntity.ok(e.getDto()) : ResponseEntity.notFound().build();
     }
 
     @PostMapping
     @Operation(summary = "Crear nuevo movimiento-testimonio")
-    public ResponseEntity<Void> create(@RequestBody MovimientoTestimonio entity) {
+    public ResponseEntity<Object> create(@RequestBody MovimientoTestimonio entity) {
         try {
             getJpaController().create(entity);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
         }
     }
 
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar movimiento-testimonio")
-    public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody MovimientoTestimonio entity) {
+    public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody MovimientoTestimonio entity) {
         try {
             entity.setIdMovimientoTestimonio(id);
             getJpaController().edit(entity);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.internalServerError().body(e.getMessage());
         }
     }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar movimiento-testimonio")
-    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+    public ResponseEntity<Object> delete(@PathVariable Integer id) {
         try {
             getJpaController().destroy(id);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body("No se puede eliminar: el movimiento de testimonio está referenciado por otros registros.");
         }
     }
 }

--- a/backend-api/src/main/java/com/licensis/notaire/api/TestimonioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TestimonioController.java
@@ -2,11 +2,15 @@ package com.licensis.notaire.api;
 
 import com.licensis.notaire.jpa.TestimonioJpaController;
 import com.licensis.notaire.config.JpaControllerProvider;
+import com.licensis.notaire.dto.DtoTestimonio;
 import com.licensis.notaire.negocio.Testimonio;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -17,59 +21,57 @@ public class TestimonioController {
     private TestimonioJpaController getJpaController() {
         return new TestimonioJpaController(null, JpaControllerProvider.getEntityManagerFactory());
     }
-    // JpaController instantiated dynamically
 
     @GetMapping
     @Operation(summary = "Obtener todos los testimonio")
-    public ResponseEntity<List<Testimonio>> getAll() {
-        try {
-            return ResponseEntity.ok(getJpaController().findTestimonioEntities());
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+    public ResponseEntity<List<DtoTestimonio>> getAll() {
+        List<Testimonio> list = getJpaController().findTestimonioEntities();
+        List<DtoTestimonio> result = new ArrayList<>();
+        for (Testimonio e : list) {
+            result.add(e.getDto());
         }
+        return ResponseEntity.ok(result);
     }
 
     @GetMapping("/{id}")
     @Operation(summary = "Obtener testimonio por ID")
-    public ResponseEntity<Testimonio> getById(@PathVariable Integer id) {
-        try {
-            return ResponseEntity.ok(getJpaController().findTestimonio(id));
-        } catch (Exception e) {
-            return ResponseEntity.notFound().build();
-        }
+    public ResponseEntity<DtoTestimonio> getById(@PathVariable Integer id) {
+        Testimonio e = getJpaController().findTestimonio(id);
+        return e != null ? ResponseEntity.ok(e.getDto()) : ResponseEntity.notFound().build();
     }
 
     @PostMapping
     @Operation(summary = "Crear nuevo testimonio")
-    public ResponseEntity<Void> create(@RequestBody Testimonio entity) {
+    public ResponseEntity<Object> create(@RequestBody Testimonio entity) {
         try {
             getJpaController().create(entity);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
         }
     }
 
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar testimonio")
-    public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody Testimonio entity) {
+    public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody Testimonio entity) {
         try {
             entity.setIdTestimonio(id);
             getJpaController().edit(entity);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.internalServerError().body(e.getMessage());
         }
     }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar testimonio")
-    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+    public ResponseEntity<Object> delete(@PathVariable Integer id) {
         try {
             getJpaController().destroy(id);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body("No se puede eliminar: el testimonio está referenciado por otros registros.");
         }
     }
 }

--- a/backend-api/src/main/java/com/licensis/notaire/api/TipoDeDocumentoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TipoDeDocumentoController.java
@@ -2,11 +2,15 @@ package com.licensis.notaire.api;
 
 import com.licensis.notaire.jpa.TipoDeDocumentoJpaController;
 import com.licensis.notaire.config.JpaControllerProvider;
+import com.licensis.notaire.dto.DtoTipoDeDocumento;
 import com.licensis.notaire.negocio.TipoDeDocumento;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -17,59 +21,57 @@ public class TipoDeDocumentoController {
     private TipoDeDocumentoJpaController getJpaController() {
         return new TipoDeDocumentoJpaController(null, JpaControllerProvider.getEntityManagerFactory());
     }
-    // JpaController instantiated dynamically
 
     @GetMapping
     @Operation(summary = "Obtener todos los tipo-de-documento")
-    public ResponseEntity<List<TipoDeDocumento>> getAll() {
-        try {
-            return ResponseEntity.ok(getJpaController().findTipoDeDocumentoEntities());
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+    public ResponseEntity<List<DtoTipoDeDocumento>> getAll() {
+        List<TipoDeDocumento> list = getJpaController().findTipoDeDocumentoEntities();
+        List<DtoTipoDeDocumento> result = new ArrayList<>();
+        for (TipoDeDocumento e : list) {
+            result.add(e.getDto());
         }
+        return ResponseEntity.ok(result);
     }
 
     @GetMapping("/{id}")
     @Operation(summary = "Obtener tipo-de-documento por ID")
-    public ResponseEntity<TipoDeDocumento> getById(@PathVariable Integer id) {
-        try {
-            return ResponseEntity.ok(getJpaController().findTipoDeDocumento(id));
-        } catch (Exception e) {
-            return ResponseEntity.notFound().build();
-        }
+    public ResponseEntity<DtoTipoDeDocumento> getById(@PathVariable Integer id) {
+        TipoDeDocumento e = getJpaController().findTipoDeDocumento(id);
+        return e != null ? ResponseEntity.ok(e.getDto()) : ResponseEntity.notFound().build();
     }
 
     @PostMapping
     @Operation(summary = "Crear nuevo tipo-de-documento")
-    public ResponseEntity<Void> create(@RequestBody TipoDeDocumento entity) {
+    public ResponseEntity<Object> create(@RequestBody TipoDeDocumento entity) {
         try {
             getJpaController().create(entity);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
         }
     }
 
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar tipo-de-documento")
-    public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody TipoDeDocumento entity) {
+    public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody TipoDeDocumento entity) {
         try {
             entity.setIdTipoDocumento(id);
             getJpaController().edit(entity);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.internalServerError().body(e.getMessage());
         }
     }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar tipo-de-documento")
-    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+    public ResponseEntity<Object> delete(@PathVariable Integer id) {
         try {
             getJpaController().destroy(id);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body("No se puede eliminar: el tipo de documento está referenciado por otros registros.");
         }
     }
 }

--- a/backend-api/src/main/java/com/licensis/notaire/api/TipoDeFolioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TipoDeFolioController.java
@@ -1,13 +1,16 @@
 package com.licensis.notaire.api;
 
 import com.licensis.notaire.config.JpaControllerProvider;
+import com.licensis.notaire.dto.DtoTipoDeFolio;
 import com.licensis.notaire.jpa.TipoDeFolioJpaController;
 import com.licensis.notaire.negocio.TipoDeFolio;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -21,57 +24,54 @@ public class TipoDeFolioController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los tipos de folio")
-    public ResponseEntity<List<TipoDeFolio>> getAll() {
-        try {
-            List<TipoDeFolio> list = getJpaController().findTipoDeFolioEntities();
-            return ResponseEntity.ok(list);
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+    public ResponseEntity<List<DtoTipoDeFolio>> getAll() {
+        List<TipoDeFolio> list = getJpaController().findTipoDeFolioEntities();
+        List<DtoTipoDeFolio> result = new ArrayList<>();
+        for (TipoDeFolio e : list) {
+            result.add(e.getDto());
         }
+        return ResponseEntity.ok(result);
     }
 
     @GetMapping("/{id}")
     @Operation(summary = "Obtener tipo de folio por ID")
-    public ResponseEntity<TipoDeFolio> getById(@PathVariable Integer id) {
-        try {
-            TipoDeFolio e = getJpaController().findTipoDeFolio(id);
-            return e != null ? ResponseEntity.ok(e) : ResponseEntity.notFound().build();
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
-        }
+    public ResponseEntity<DtoTipoDeFolio> getById(@PathVariable Integer id) {
+        TipoDeFolio e = getJpaController().findTipoDeFolio(id);
+        return e != null ? ResponseEntity.ok(e.getDto()) : ResponseEntity.notFound().build();
     }
 
     @PostMapping
     @Operation(summary = "Crear tipo de folio")
-    public ResponseEntity<Void> create(@RequestBody TipoDeFolio tipoDeFolio) {
+    public ResponseEntity<Object> create(@RequestBody TipoDeFolio tipoDeFolio) {
         try {
             getJpaController().create(tipoDeFolio);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
         }
     }
 
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar tipo de folio")
-    public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody TipoDeFolio tipoDeFolio) {
+    public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody TipoDeFolio tipoDeFolio) {
         try {
             tipoDeFolio.setIdTipoFolio(id);
             getJpaController().edit(tipoDeFolio);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.internalServerError().body(e.getMessage());
         }
     }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar tipo de folio")
-    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+    public ResponseEntity<Object> delete(@PathVariable Integer id) {
         try {
             getJpaController().destroy(id);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body("No se puede eliminar: el tipo de folio está referenciado por otros registros.");
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fixed 500 errors in 5 controllers caused by Jackson trying to serialize raw JPA entities with lazy-loaded `@OneToMany` collections
- Fixed `EscrituraController.getEscribanosDisponibles()` returning raw `Persona` entities
- Improved DELETE error handling: returns **409 Conflict** with descriptive message instead of 500 when FK constraints are violated

## Root Cause

Controllers were returning raw JPA entity objects (e.g., `List<TipoDeFolio>`) directly from endpoints. The entities have `@OneToMany` relationships that trigger lazy loading during Jackson serialization, which fails after the JPA session closes.

**Fix pattern** (same as `ConceptoController` which already worked):
```java
// Before (500 error)
return ResponseEntity.ok(getJpaController().findTipoDeFolioEntities());

// After (fixed)
List<TipoDeFolio> list = getJpaController().findTipoDeFolioEntities();
List<DtoTipoDeFolio> result = new ArrayList<>();
for (TipoDeFolio e : list) {
    result.add(e.getDto());
}
return ResponseEntity.ok(result);
```

## Controllers Fixed

| Controller | CU | Endpoints |
|-----------|-----|-----------|
| TipoDeFolioController | CU36, CU40, CU58, CU68 | GET /api/v1/tipo-folio |
| TipoDeDocumentoController | CU27, CU32, CU38, CU65 | GET /api/v1/tipo-de-documento |
| EstadoDeGestionController | CU30, CU35, CU67 | GET /api/v1/estado-gestion |
| TestimonioController | CU07, CU08, CU12, CU44 | GET /api/v1/testimonio |
| MovimientoTestimonioController | CU10, CU12, CU44 | GET /api/v1/movimiento-testimonio |
| EscrituraController | CU48, CU51 | GET /api/v1/escrituras/escribanos-disponibles |

## Testing

- [ ] All 61 existing tests pass (`mvn test -pl backend-api`)
- [ ] Bruno tests for affected endpoints should now return 200

Closes #336
Closes #337
Closes #338