### PR TITLE
fix: Enable frontend service in Docker Compose

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -27,6 +27,9 @@ RUN mvn package -pl backend-api -am -DskipTests -B -q
 # =============================================
 FROM eclipse-temurin:21-jre-alpine AS runner
 
+# Install wget for healthcheck
+RUN apk add --no-cache wget
+
 WORKDIR /app
 
 # Create non-root user for security

--- a/backend-api/pom.xml
+++ b/backend-api/pom.xml
@@ -41,6 +41,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,10 +39,11 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1" ]
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 60s
     networks:
       - notary-network
 
@@ -90,11 +91,11 @@ services:
       backend:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/ || exit 1" ]
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/ || exit 1" ]
       interval: 15s
       timeout: 10s
       retries: 5
-      start_period: 30s
+      start_period: 60s
     networks:
       - notary-network
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,6 +19,9 @@ FROM node:22-alpine AS runner
 
 WORKDIR /app
 
+# Install wget for healthcheck
+RUN apk add --no-cache wget
+
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
@@ -27,7 +30,9 @@ RUN addgroup --system --gid 1001 nodejs && \
 
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
-COPY --from=builder /app/public ./public 2>/dev/null || true
+
+# Only copy public directory if it exists
+RUN test -d /app/public && cp -r /app/public ./public || true
 
 USER nextjs
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6258,7 +6258,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Description
This PR enables the frontend service in docker-compose.yml to work properly with the Next.js application.

## Changes Made
- Fixed healthcheck syntax for backend service (changed from CMD to CMD-SHELL)
- Increased start_period for both backend and frontend services to 60s to allow proper startup time
- Frontend service now builds successfully and is accessible on port 3000
- All services (postgres, backend, frontend) are healthy and working together

## Testing
- All services start successfully with docker-compose up
- Frontend is accessible at http://localhost:3000
- Backend API is accessible at http://localhost:8080
- Health checks pass for all services

## Related Issue
Closes #356