### PR TITLE
[363] fix: resolve Next.js build failure and mount init-db scripts in Docker

### DIFF
--- a/backend-api/src/main/resources/config.properties
+++ b/backend-api/src/main/resources/config.properties
@@ -4,5 +4,5 @@
 protocolo=jdbc:postgresql://
 host=localhost:5432/notaire
 puerto=5432
-usuario_db=notaire
-contrasenia_db=notaire_password
+usuario_db=admin
+contrasenia_db=admin

--- a/backend-api/src/test/java/com/licensis/notaire/integration/BaseIntegrationTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/BaseIntegrationTest.java
@@ -14,8 +14,8 @@ public abstract class BaseIntegrationTest {
     protected static final PostgreSQLContainer<?> POSTGRESQL_CONTAINER = 
         new PostgreSQLContainer<>("postgres:16-alpine")
             .withDatabaseName("notaire_test")
-            .withUsername("notaire")
-            .withPassword("notaire_password")
+            .withUsername("admin")
+            .withPassword("admin")
             .withInitScript("init-db/01-schema.sql")
             .withInitScript("init-db/02-data.sql");
 

--- a/backend-api/src/test/resources/application-testcontainers.properties
+++ b/backend-api/src/test/resources/application-testcontainers.properties
@@ -4,8 +4,8 @@
 # Database Configuration
 spring.datasource.url=jdbc:postgresql://localhost:5432/notaire_test
 spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.username=notaire
-spring.datasource.password=notaire_password
+spring.datasource.username=admin
+spring.datasource.password=admin
 
 # JPA Configuration (validate only, let Flyway handle schema)
 spring.jpa.hibernate.ddl-auto=none

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./init-db:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-admin} -d ${POSTGRES_DB:-notaire}" ]
       interval: 10s

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 interface AppHeaderProps {
-  title: string;
+  title?: string;
   description?: string;
   actions?: React.ReactNode;
 }

--- a/init-db/migrate.load
+++ b/init-db/migrate.load
@@ -53,7 +53,7 @@
  * 
  * 3. Configurar conexión PostgreSQL:
  *    - PostgreSQL debe estar corriendo
- *    - Credenciales: notaire:notaire_password@localhost:5432/notaire
+ *    - Credenciales: admin:admin@localhost:5432/notaire
  * 
  * 4. Ejecutar la migración:
  *    cd init-db/
@@ -119,7 +119,7 @@
 
 LOAD DATABASE
      FROM mysql://root:admin@localhost:3306/notaire
-     INTO postgresql://notaire:notaire_password@localhost:5432/notaire
+     INTO postgresql://admin:admin@localhost:5432/notaire
 
 WITH include drop, create tables, create indexes, reset sequences,
      workers = 4, concurrency = 2


### PR DESCRIPTION
## Summary
- Fix Next.js build failure caused by `AppHeader` requiring a `title` prop
- Mount `init-db/` directory in `docker-compose.yml` for PostgreSQL initialization
- **Standardize all credentials to `admin/admin`** across database, backend, tests, and migration scripts

## Changes

### Fixed
- **AppHeader.tsx**: Made `title` prop optional — shared layout doesn't know page title
- **docker-compose.yml**: Added `./init-db:/docker-entrypoint-initdb.d:ro` volume to postgres service
- **config.properties**: `usuario_db=notaire` / `contrasenia_db=notaire_password` → `admin` / `admin`
- **migrate.load**: PostgreSQL connection string updated to `admin:admin`
- **BaseIntegrationTest.java**: Testcontainers credentials → `admin` / `admin`
- **application-testcontainers.properties**: Test DB credentials → `admin` / `admin`

### Credential Consistency
All services now use `admin` / `admin` as default:
| Service | Username | Password |
|---------|----------|----------|
| PostgreSQL (docker-compose) | admin | admin |
| Backend (application.properties) | admin | admin |
| Backend (config.properties) | admin | admin |
| Testcontainers (BaseIntegrationTest) | admin | admin |
| Test config (application-testcontainers) | admin | admin |
| Default login user (V2 migration) | admin | admin (MD5) |

## Testing
- [x] `npm run build` passes (29 routes compiled)
- [x] `npx tsc --noEmit` — no TypeScript errors
- [x] `mvn test` — 64 unit tests pass, BUILD SUCCESS
- [x] `docker compose config --quiet` — valid compose file

## Checklist
- [x] Code follows conventions
- [x] No hardcoded secrets (admin/admin is the documented default)
- [x] No TODO comments

## Issue Reference
Fixes #363