### PR TITLE
[#390] fix: comprehensive CRUD audit - HTTP status codes, broken endpoints, UI developer references

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/ConceptoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/ConceptoController.java
@@ -87,7 +87,7 @@ public class ConceptoController {
         }
         try {
             repository.deleteById(id);
-            return ResponseEntity.ok().build();
+            return ResponseEntity.noContent().build();
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body("No se puede eliminar: el concepto está referenciado por otros registros.");

--- a/backend-api/src/main/java/com/licensis/notaire/api/EscrituraController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/EscrituraController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
@@ -47,10 +48,9 @@ public class EscrituraController {
     public ResponseEntity<Escritura> create(@RequestBody Escritura entity) {
         try {
             Escritura saved = escrituraService.save(entity);
-            return ResponseEntity.ok(saved);
+            return ResponseEntity.status(HttpStatus.CREATED).body(saved);
         } catch (Exception e) {
             log.error("Failed to create escritura", e);
-            e.printStackTrace();
             return ResponseEntity.internalServerError().build();
         }
     }
@@ -73,7 +73,7 @@ public class EscrituraController {
     public ResponseEntity<Void> delete(@PathVariable Integer id) {
         if (escrituraService.findById(id).isPresent()) {
             escrituraService.deleteById(id);
-            return ResponseEntity.ok().build();
+            return ResponseEntity.noContent().build();
         }
         return ResponseEntity.notFound().build();
     }

--- a/backend-api/src/main/java/com/licensis/notaire/api/EstadoDeGestionController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/EstadoDeGestionController.java
@@ -44,6 +44,9 @@ public class EstadoDeGestionController {
     @Operation(summary = "Crear estado de gestion")
     public ResponseEntity<Object> create(@RequestBody DtoEstadoDeGestion dto) {
         try {
+            if (dto.getVersion() == null) {
+                dto.setVersion(0);
+            }
             EstadoDeGestion entity = new EstadoDeGestion();
             entity.setAtributo(dto);
             repository.save(entity);
@@ -63,6 +66,9 @@ public class EstadoDeGestionController {
         try {
             EstadoDeGestion entity = existing.get();
             dto.setIdEstadoGestion(id);
+            if (dto.getVersion() == null) {
+                dto.setVersion(entity.getVersion());
+            }
             entity.setAtributo(dto);
             repository.save(entity);
             return ResponseEntity.ok().build();

--- a/backend-api/src/main/java/com/licensis/notaire/api/PersonaController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/PersonaController.java
@@ -70,6 +70,9 @@ public class PersonaController {
                 .map(existing -> {
                     persona.setIdPersona(id);
                     persona.setVersion(existing.getVersion());
+                    if (persona.getFkIdTipoIdentificacion() == null) {
+                        persona.setFkIdTipoIdentificacion(existing.getFkIdTipoIdentificacion());
+                    }
                     Persona updated = personaService.save(persona);
                     return ResponseEntity.ok(updated);
                 })

--- a/backend-api/src/main/java/com/licensis/notaire/api/PersonaController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/PersonaController.java
@@ -57,7 +57,7 @@ public class PersonaController {
                 persona.setFkIdTipoIdentificacion(defaultTipo);
             }
             Persona saved = personaService.save(persona);
-            return ResponseEntity.ok(saved);
+            return ResponseEntity.status(HttpStatus.CREATED).body(saved);
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
         }
@@ -81,7 +81,7 @@ public class PersonaController {
     public ResponseEntity<Void> deletePersona(@PathVariable Integer id) {
         if (personaService.findById(id).isPresent()) {
             personaService.deleteById(id);
-            return ResponseEntity.ok().build();
+            return ResponseEntity.noContent().build();
         }
         return ResponseEntity.notFound().build();
     }

--- a/backend-api/src/main/java/com/licensis/notaire/api/PresupuestoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/PresupuestoController.java
@@ -85,7 +85,7 @@ public class PresupuestoController {
     public ResponseEntity<Void> delete(@PathVariable Integer id) {
         try {
             presupuestoService.deleteById(id);
-            return ResponseEntity.ok().build();
+            return ResponseEntity.noContent().build();
         } catch (ResourceNotFoundException e) {
             return ResponseEntity.notFound().build();
         }

--- a/backend-api/src/main/java/com/licensis/notaire/api/TipoDeDocumentoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TipoDeDocumentoController.java
@@ -83,7 +83,7 @@ public class TipoDeDocumentoController {
         }
         try {
             repository.deleteById(id);
-            return ResponseEntity.ok().build();
+            return ResponseEntity.noContent().build();
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body("No se puede eliminar: el tipo de documento está referenciado por otros registros.");

--- a/backend-api/src/main/java/com/licensis/notaire/api/TipoDeTramiteController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TipoDeTramiteController.java
@@ -93,7 +93,7 @@ public class TipoDeTramiteController {
         }
         try {
             repository.deleteById(id);
-            return ResponseEntity.ok().build();
+            return ResponseEntity.noContent().build();
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body("No se puede eliminar: el tipo de tramite está referenciado por otros registros.");

--- a/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
@@ -98,7 +98,7 @@ public class UsuarioController {
         }
         try {
             usuarioRepository.deleteById(id);
-            return ResponseEntity.ok().build();
+            return ResponseEntity.noContent().build();
         } catch (Exception e) {
             log.error("Failed to delete usuario id {}", id, e);
             return ResponseEntity.status(HttpStatus.CONFLICT).build();

--- a/backend-api/src/main/java/com/licensis/notaire/negocio/Item.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/Item.java
@@ -19,6 +19,7 @@ import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -65,6 +66,7 @@ public class Item implements Serializable
     private String observaciones;
     @JoinColumn(name = "fk_id_presupuesto", referencedColumnName = "id_presupuesto")
     @ManyToOne(fetch = FetchType.EAGER)
+    @JsonIgnore
     private Presupuesto fkIdPresupuesto;
 
     /**

--- a/backend-api/src/main/resources/db/migration/V3__add_missing_entity_columns.sql
+++ b/backend-api/src/main/resources/db/migration/V3__add_missing_entity_columns.sql
@@ -1,0 +1,33 @@
+-- =============================================================================
+-- V3__add_missing_entity_columns.sql
+-- =============================================================================
+-- Author: Claude
+-- Date: 2026-05-09
+-- Description: Add columns present in JPA entities but absent from V1 schema.
+--              These omissions cause 500 errors on GET /api/v1/items and
+--              PUT /api/v1/personas/{id} (via eager Folio -> TipoDeFolio join).
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- UP Migration
+-- -----------------------------------------------------------------------------
+
+-- items table is missing 'observaciones' (Item.java declares @Column("observaciones"))
+ALTER TABLE items ADD COLUMN IF NOT EXISTS observaciones text;
+
+-- tipos_de_folio table is missing 'observaciones' and 'habilitado'
+-- (TipoDeFolio.java declares both columns)
+ALTER TABLE tipos_de_folio ADD COLUMN IF NOT EXISTS observaciones text;
+ALTER TABLE tipos_de_folio ADD COLUMN IF NOT EXISTS habilitado boolean NOT NULL DEFAULT true;
+
+-- testimonios table is missing 'observado'
+-- (Testimonio.java declares @Column("observado"))
+ALTER TABLE testimonios ADD COLUMN IF NOT EXISTS observado boolean NOT NULL DEFAULT false;
+
+-- -----------------------------------------------------------------------------
+-- Verification
+-- -----------------------------------------------------------------------------
+-- SELECT column_name FROM information_schema.columns
+-- WHERE table_name = 'items' AND column_name = 'observaciones';
+-- SELECT column_name FROM information_schema.columns
+-- WHERE table_name = 'tipos_de_folio' AND column_name IN ('observaciones', 'habilitado');

--- a/backend-api/src/test/java/com/licensis/notaire/integration/BusinessWorkflowIntegrationTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/BusinessWorkflowIntegrationTest.java
@@ -111,7 +111,7 @@ class BusinessWorkflowIntegrationTest {
 
         @Test
         @Order(2)
-        @DisplayName("CU18 — Create persona returns 200")
+        @DisplayName("CU18 — Create persona returns 201")
         void createPersonaReturns200() throws Exception {
             mockMvc.perform(post("/api/v1/personas")
                             .contentType(MediaType.APPLICATION_JSON)
@@ -126,7 +126,7 @@ class BusinessWorkflowIntegrationTest {
                                       "fkIdTipoIdentificacion": {"idTipoIdentificacion": 1}
                                     }
                                     """))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isCreated());
         }
 
         @Test
@@ -317,7 +317,7 @@ class BusinessWorkflowIntegrationTest {
 
         @Test
         @Order(2)
-        @DisplayName("CU05 — Create escritura returns 200")
+        @DisplayName("CU05 — Create escritura returns 201")
         void createEscrituraReturns200() throws Exception {
             mockMvc.perform(post("/api/v1/escrituras")
                             .contentType(MediaType.APPLICATION_JSON)
@@ -329,7 +329,7 @@ class BusinessWorkflowIntegrationTest {
                                       "fechaEscrituracion": "2025-01-15"
                                     }
                                     """))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isCreated());
         }
 
         @Test

--- a/frontend/src/app/dashboard/administracion/auditoria/page.tsx
+++ b/frontend/src/app/dashboard/administracion/auditoria/page.tsx
@@ -59,7 +59,7 @@ export default function AuditoriaPage() {
     <div>
       <AppHeader
         title="Auditoría del Sistema"
-        description="Registro completo de operaciones realizadas por los usuarios (CU73)"
+        description="Registro completo de operaciones realizadas por los usuarios"
       />
       <DataTable
         data={registros}

--- a/frontend/src/app/dashboard/administracion/conceptos/page.tsx
+++ b/frontend/src/app/dashboard/administracion/conceptos/page.tsx
@@ -73,7 +73,7 @@ export default function ConceptosPage() {
     <div>
       <AppHeader
         title="Conceptos"
-        description="CU29, CU66 — Catálogo de conceptos de presupuesto"
+        description="Catálogo de conceptos utilizados en presupuestos"
         actions={<Button onClick={openCreate}><NotaireIcon src="/icons/actions/agregar.png" alt="Agregar" size={16} className="mr-1" />Nuevo concepto</Button>}
       />
       <DataTable data={conceptos} columns={columns} isLoading={isLoading} keyExtractor={(c) => c.idConcepto!} emptyMessage="No hay conceptos" />

--- a/frontend/src/app/dashboard/administracion/documentos/page.tsx
+++ b/frontend/src/app/dashboard/administracion/documentos/page.tsx
@@ -1,23 +1,160 @@
 "use client";
+import { useState } from "react";
+import { toast } from "sonner";
+import { NotaireIcon } from "@/components/ui/notaire-icon";
 import { AppHeader } from "@/components/layout/AppHeader";
 import { DataTable, type Column } from "@/components/shared/DataTable";
-import { useQuery } from "@tanstack/react-query";
-import { apiGet } from "@/lib/api-client";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { FormContainer, FormSection, FormField, FormActions } from "@/theme/form-patterns";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiGet, apiPost, apiPut, apiDelete } from "@/lib/api-client";
 import type { TipoDeDocumento } from "@/types";
 
+const EMPTY: Partial<TipoDeDocumento> = { nombre: "" };
+
 export default function DocumentosPage() {
+  const qc = useQueryClient();
   const { data: tipos = [], isLoading } = useQuery({
-    queryKey: ["tipos-documento"],
-    queryFn: () => apiGet<TipoDeDocumento[]>("/catalogos/tipos-documento"),
+    queryKey: ["tiposDocumento"],
+    queryFn: () => apiGet<TipoDeDocumento[]>("/tipo-de-documento"),
   });
+
+  const createMutation = useMutation({
+    mutationFn: (data: Partial<TipoDeDocumento>) => apiPost<void>("/tipo-de-documento", data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tiposDocumento"] }),
+  });
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: Partial<TipoDeDocumento> }) =>
+      apiPut<void>(`/tipo-de-documento/${id}`, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tiposDocumento"] }),
+  });
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => apiDelete(`/tipo-de-documento/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tiposDocumento"] }),
+  });
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [deleteId, setDeleteId] = useState<number | null>(null);
+  const [editing, setEditing] = useState<Partial<TipoDeDocumento>>(EMPTY);
+  const [isEditMode, setIsEditMode] = useState(false);
+
+  function openCreate() {
+    setEditing(EMPTY);
+    setIsEditMode(false);
+    setModalOpen(true);
+  }
+
+  function openEdit(t: TipoDeDocumento) {
+    setEditing(t);
+    setIsEditMode(true);
+    setModalOpen(true);
+  }
+
+  async function handleSave() {
+    if (!editing.nombre?.trim()) {
+      toast.error("El nombre es requerido");
+      return;
+    }
+    try {
+      if (isEditMode && editing.idTipoDeDocumento) {
+        await updateMutation.mutateAsync({ id: editing.idTipoDeDocumento, data: editing });
+        toast.success("Tipo de documento actualizado");
+      } else {
+        await createMutation.mutateAsync(editing);
+        toast.success("Tipo de documento creado");
+      }
+      setModalOpen(false);
+    } catch {
+      toast.error("Error al guardar el tipo de documento");
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteId) return;
+    try {
+      await deleteMutation.mutateAsync(deleteId);
+      toast.success("Tipo de documento eliminado");
+    } catch {
+      toast.error("No se puede eliminar: el tipo de documento está referenciado por otros registros.");
+    } finally {
+      setDeleteId(null);
+    }
+  }
+
   const columns: Column<TipoDeDocumento>[] = [
-    { key: "id", header: "ID", render: (t) => t.idTipoDeDocumento, className: "w-12" },
+    { key: "id", header: "ID", render: (t) => <span className="text-xs text-muted-foreground">{t.idTipoDeDocumento}</span>, className: "w-12" },
     { key: "nombre", header: "Nombre", render: (t) => <span className="font-medium">{t.nombre}</span> },
+    {
+      key: "actions", header: "", className: "w-24",
+      render: (t) => (
+        <div className="flex gap-2 justify-end">
+          <Button size="sm" variant="ghost" onClick={() => openEdit(t)}>
+            <NotaireIcon src="/icons/actions/generar.png" alt="Editar" size={16} />
+          </Button>
+          <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive" onClick={() => setDeleteId(t.idTipoDeDocumento!)}>
+            <NotaireIcon src="/icons/actions/borrar.png" alt="Eliminar" size={16} />
+          </Button>
+        </div>
+      ),
+    },
   ];
+
   return (
     <div>
-      <AppHeader title="Tipos de Documento" description="CU27, CU65 — Catálogo de tipos de documento notarial" />
-      <DataTable data={tipos} columns={columns} isLoading={isLoading} keyExtractor={(t) => t.idTipoDeDocumento!} emptyMessage="No hay tipos de documento" />
+      <AppHeader
+        title="Tipos de Documento"
+        description="Catálogo de tipos de documento notarial"
+        actions={
+          <Button onClick={openCreate} data-testid="btn-nuevo-tipo-documento">
+            <NotaireIcon src="/icons/actions/agregar.png" alt="Agregar" size={16} className="mr-1" />
+            Nuevo Tipo
+          </Button>
+        }
+      />
+      <DataTable
+        data={tipos}
+        columns={columns}
+        isLoading={isLoading}
+        keyExtractor={(t) => t.idTipoDeDocumento!}
+        emptyMessage="No hay tipos de documento registrados"
+      />
+
+      <Dialog open={modalOpen} onOpenChange={setModalOpen}>
+        <DialogContent>
+          <FormContainer>
+            <FormSection title={isEditMode ? "Editar tipo de documento" : "Nuevo tipo de documento"}>
+              <FormField label="Nombre" required>
+                <Input
+                  value={editing.nombre ?? ""}
+                  onChange={(e) => setEditing({ ...editing, nombre: e.target.value })}
+                  placeholder="Ej: DNI, Escritura"
+                  data-testid="input-nombre-documento"
+                />
+              </FormField>
+            </FormSection>
+            <FormActions align="right">
+              <Button variant="secondary" onClick={() => setModalOpen(false)}>
+                <NotaireIcon src="/icons/actions/cerrar.png" alt="Cancelar" size={16} className="mr-1" />
+                Cancelar
+              </Button>
+              <Button onClick={handleSave} disabled={createMutation.isPending || updateMutation.isPending}>
+                <NotaireIcon src="/icons/actions/guardar.png" alt="Guardar" size={16} className="mr-1 brightness-0 invert" />
+                {isEditMode ? "Actualizar" : "Guardar"}
+              </Button>
+            </FormActions>
+          </FormContainer>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={!!deleteId}
+        onOpenChange={(v) => !v && setDeleteId(null)}
+        onConfirm={handleDelete}
+        loading={deleteMutation.isPending}
+      />
     </div>
   );
 }

--- a/frontend/src/app/dashboard/administracion/estados-gestion/page.tsx
+++ b/frontend/src/app/dashboard/administracion/estados-gestion/page.tsx
@@ -57,7 +57,7 @@ export default function EstadosGestionPage() {
     <div>
       <AppHeader
         title="Estados de Gestión"
-        description="CU67 — Estados del ciclo de vida de las gestiones notariales"
+        description="Estados del ciclo de vida de las gestiones notariales"
         actions={
           <Button onClick={openCreate} data-testid="btn-nuevo-estado">
             <NotaireIcon src="/icons/actions/agregar.png" alt="Agregar" size={16} className="mr-1" />

--- a/frontend/src/app/dashboard/administracion/folios/page.tsx
+++ b/frontend/src/app/dashboard/administracion/folios/page.tsx
@@ -59,7 +59,7 @@ export default function FoliosAdminPage() {
     <div>
       <AppHeader
         title="Folios"
-        description="CU28, CU40, CU58, CU63, CU68 — Gestión de folios notariales y su disponibilidad"
+        description="Gestión de folios notariales y su disponibilidad"
         actions={
           <Button onClick={openCreate} data-testid="btn-nuevo-folio">
             <NotaireIcon src="/icons/actions/agregar.png" alt="Agregar" size={16} className="mr-1" />

--- a/frontend/src/app/dashboard/administracion/items/page.tsx
+++ b/frontend/src/app/dashboard/administracion/items/page.tsx
@@ -148,7 +148,7 @@ export default function ItemsPage() {
     <div>
       <AppHeader
         title="Ítems de Presupuesto"
-        description="CU01, CU39 — Gestionar ítems y conceptos en presupuestos"
+        description="Gestionar ítems y conceptos en presupuestos"
         actions={
           <Button onClick={openCreate} data-testid="btn-nuevo-item">
             <Plus className="h-4 w-4" />

--- a/frontend/src/app/dashboard/administracion/page.tsx
+++ b/frontend/src/app/dashboard/administracion/page.tsx
@@ -6,13 +6,13 @@ import { AppHeader } from "@/components/layout/AppHeader";
 import { NotaireIcon } from "@/components/ui/notaire-icon";
 
 const adminModules = [
-  { label: "Usuarios", href: "/dashboard/administracion/usuarios", pngIcon: "/icons/admin/usuarios.png", description: "CU20, CU21, CU23" },
-  { label: "Conceptos", href: "/dashboard/administracion/conceptos", pngIcon: "/icons/admin/conceptos.png", description: "CU29, CU66" },
-  { label: "Tipos de Documento", href: "/dashboard/administracion/documentos", pngIcon: "/icons/admin/documentos.png", description: "CU27, CU65" },
-  { label: "Folios", href: "/dashboard/administracion/folios", pngIcon: "/icons/admin/folios.png", description: "CU28, CU40, CU58, CU63, CU68" },
-  { label: "Tipos de Trámite", href: "/dashboard/administracion/tramites", pngIcon: "/icons/admin/tramites.png", description: "CU26, CU57, CU64" },
-  { label: "Estados de Gestión", href: "/dashboard/administracion/estados-gestion", pngIcon: "/icons/admin/estadosGestion.png", description: "CU67" },
-  { label: "Plantillas Presupuesto", href: "/dashboard/administracion/plantillas", pngIcon: "/icons/admin/plantillaPresupuesto.png", description: "CU39, CU49, CU55" },
+  { label: "Usuarios", href: "/dashboard/administracion/usuarios", pngIcon: "/icons/admin/usuarios.png", description: "Gestión de usuarios y roles del sistema" },
+  { label: "Conceptos", href: "/dashboard/administracion/conceptos", pngIcon: "/icons/admin/conceptos.png", description: "Catálogo de conceptos de presupuesto" },
+  { label: "Tipos de Documento", href: "/dashboard/administracion/documentos", pngIcon: "/icons/admin/documentos.png", description: "Catálogo de tipos de documento notarial" },
+  { label: "Folios", href: "/dashboard/administracion/folios", pngIcon: "/icons/admin/folios.png", description: "Gestión de folios notariales" },
+  { label: "Tipos de Trámite", href: "/dashboard/administracion/tramites", pngIcon: "/icons/admin/tramites.png", description: "Catálogo de tipos de trámite disponibles" },
+  { label: "Estados de Gestión", href: "/dashboard/administracion/estados-gestion", pngIcon: "/icons/admin/estadosGestion.png", description: "Estados del ciclo de vida de las gestiones" },
+  { label: "Plantillas Presupuesto", href: "/dashboard/administracion/plantillas", pngIcon: "/icons/admin/plantillaPresupuesto.png", description: "Plantillas reutilizables para presupuestos" },
 ];
 
 export default function AdministracionPage() {

--- a/frontend/src/app/dashboard/administracion/plantillas/page.tsx
+++ b/frontend/src/app/dashboard/administracion/plantillas/page.tsx
@@ -62,7 +62,7 @@ export default function PlantillasPage() {
     <div>
       <AppHeader
         title="Plantillas de Presupuesto"
-        description="CU39, CU49, CU55 — Plantillas reutilizables para armar presupuestos"
+        description="Plantillas reutilizables para armar presupuestos"
         actions={
           <Button onClick={openCreate} data-testid="btn-nueva-plantilla">
             <NotaireIcon src="/icons/actions/agregar.png" alt="Agregar" size={16} className="mr-1" />

--- a/frontend/src/app/dashboard/administracion/tramites/page.tsx
+++ b/frontend/src/app/dashboard/administracion/tramites/page.tsx
@@ -126,6 +126,16 @@ export default function TramitesPage() {
                   placeholder="Descripción del tipo de trámite"
                 />
               </FormField>
+              <CheckboxField
+                label="Se archiva"
+                checked={editing.seArchiva ?? false}
+                onChange={(v) => setEditing({ ...editing, seArchiva: v })}
+              />
+              <CheckboxField
+                label="Se inscribe"
+                checked={editing.seInscribe ?? false}
+                onChange={(v) => setEditing({ ...editing, seInscribe: v })}
+              />
             </FormSection>
             <FormActions align="right">
               <Button variant="secondary" onClick={() => setModalOpen(false)}>

--- a/frontend/src/app/dashboard/administracion/tramites/page.tsx
+++ b/frontend/src/app/dashboard/administracion/tramites/page.tsx
@@ -4,64 +4,94 @@ import { toast } from "sonner";
 import { NotaireIcon } from "@/components/ui/notaire-icon";
 import { AppHeader } from "@/components/layout/AppHeader";
 import { DataTable, type Column } from "@/components/shared/DataTable";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { FormContainer, FormSection, FormField, FormActions, CheckboxField } from "@/theme/form-patterns";
-import { useQuery } from "@tanstack/react-query";
-import { apiGet, apiPost } from "@/lib/api-client";
+import { useTiposTramite, useCreateTipoTramite, useUpdateTipoTramite, useDeleteTipoTramite } from "@/hooks/useTiposTramite";
 import type { TipoDeTramite } from "@/types";
 
+const EMPTY: Partial<TipoDeTramite> = { nombre: "", descripcion: "" };
+
 export default function TramitesPage() {
-  const { data = [], isLoading, refetch } = useQuery({
-    queryKey: ["tipos-tramite"],
-    queryFn: () => apiGet<TipoDeTramite[]>("/catalogos/tipos-tramite"),
-  });
+  const { data = [], isLoading } = useTiposTramite();
+  const createMutation = useCreateTipoTramite();
+  const updateMutation = useUpdateTipoTramite();
+  const deleteMutation = useDeleteTipoTramite();
 
   const [modalOpen, setModalOpen] = useState(false);
-  const [nombre, setNombre] = useState("");
-  const [descripcion, setDescripcion] = useState("");
-  const [seArchiva, setSeArchiva] = useState(false);
-  const [seInscribe, setSeInscribe] = useState(false);
-  const [saving, setSaving] = useState(false);
+  const [deleteId, setDeleteId] = useState<number | null>(null);
+  const [editing, setEditing] = useState<Partial<TipoDeTramite>>(EMPTY);
+  const [isEditMode, setIsEditMode] = useState(false);
 
   function openCreate() {
-    setNombre("");
-    setDescripcion("");
-    setSeArchiva(false);
-    setSeInscribe(false);
+    setEditing(EMPTY);
+    setIsEditMode(false);
+    setModalOpen(true);
+  }
+
+  function openEdit(t: TipoDeTramite) {
+    setEditing(t);
+    setIsEditMode(true);
     setModalOpen(true);
   }
 
   async function handleSave() {
-    if (!nombre.trim()) {
+    if (!editing.nombre?.trim()) {
       toast.error("El nombre es requerido");
       return;
     }
-    setSaving(true);
     try {
-      await apiPost("/catalogos/tipos-tramite", { nombre: nombre.trim(), descripcion: descripcion.trim(), seArchiva, seInscribe });
-      toast.success("Tipo de trámite creado");
+      if (isEditMode && editing.idTipoDeTramite) {
+        await updateMutation.mutateAsync({ id: editing.idTipoDeTramite, data: editing });
+        toast.success("Tipo de trámite actualizado");
+      } else {
+        await createMutation.mutateAsync(editing);
+        toast.success("Tipo de trámite creado");
+      }
       setModalOpen(false);
-      refetch();
     } catch {
-      toast.error("Error al crear el tipo de trámite");
+      toast.error("Error al guardar el tipo de trámite");
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteId) return;
+    try {
+      await deleteMutation.mutateAsync(deleteId);
+      toast.success("Tipo de trámite eliminado");
+    } catch {
+      toast.error("Error al eliminar");
     } finally {
-      setSaving(false);
+      setDeleteId(null);
     }
   }
 
   const columns: Column<TipoDeTramite>[] = [
-    { key: "id", header: "ID", render: (t) => t.idTipoDeTramite, className: "w-12" },
+    { key: "id", header: "ID", render: (t) => <span className="text-xs text-muted-foreground">{t.idTipoDeTramite}</span>, className: "w-12" },
     { key: "nombre", header: "Nombre", render: (t) => <span className="font-medium">{t.nombre}</span> },
     { key: "desc", header: "Descripción", render: (t) => t.descripcion ?? "—" },
+    {
+      key: "actions", header: "", className: "w-24",
+      render: (t) => (
+        <div className="flex gap-2 justify-end">
+          <Button size="sm" variant="ghost" onClick={() => openEdit(t)}>
+            <NotaireIcon src="/icons/actions/generar.png" alt="Editar" size={16} />
+          </Button>
+          <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive" onClick={() => setDeleteId(t.idTipoDeTramite!)}>
+            <NotaireIcon src="/icons/actions/borrar.png" alt="Eliminar" size={16} />
+          </Button>
+        </div>
+      ),
+    },
   ];
 
   return (
     <div>
       <AppHeader
         title="Tipos de Trámite"
-        description="CU26, CU57, CU64 — Catálogo de tipos de trámite disponibles"
+        description="Catálogo de tipos de trámite disponibles para gestiones notariales"
         actions={
           <Button onClick={openCreate} data-testid="btn-nuevo-tipo-tramite">
             <NotaireIcon src="/icons/actions/agregar.png" alt="Agregar" size={16} className="mr-1" />
@@ -69,52 +99,54 @@ export default function TramitesPage() {
           </Button>
         }
       />
-      <DataTable data={data} columns={columns} isLoading={isLoading} keyExtractor={(t) => t.idTipoDeTramite!} emptyMessage="No hay tipos de trámite" />
+      <DataTable
+        data={data}
+        columns={columns}
+        isLoading={isLoading}
+        keyExtractor={(t) => t.idTipoDeTramite!}
+        emptyMessage="No hay tipos de trámite registrados"
+      />
 
       <Dialog open={modalOpen} onOpenChange={setModalOpen}>
         <DialogContent>
           <FormContainer>
-            <FormSection title="Nuevo Tipo de Trámite">
+            <FormSection title={isEditMode ? "Editar tipo de trámite" : "Nuevo tipo de trámite"}>
               <FormField label="Nombre" required>
                 <Input
-                  value={nombre}
-                  onChange={(e) => setNombre(e.target.value)}
+                  value={editing.nombre ?? ""}
+                  onChange={(e) => setEditing({ ...editing, nombre: e.target.value })}
                   placeholder="Ej: Compraventa"
-                  aria-label="Nombre"
+                  data-testid="input-nombre-tramite"
                 />
               </FormField>
               <FormField label="Descripción">
                 <Input
-                  value={descripcion}
-                  onChange={(e) => setDescripcion(e.target.value)}
+                  value={editing.descripcion ?? ""}
+                  onChange={(e) => setEditing({ ...editing, descripcion: e.target.value })}
                   placeholder="Descripción del tipo de trámite"
-                  aria-label="Descripción"
                 />
               </FormField>
-              <CheckboxField
-                label="Se archiva"
-                checked={seArchiva}
-                onChange={(checked) => setSeArchiva(checked)}
-              />
-              <CheckboxField
-                label="Se inscribe"
-                checked={seInscribe}
-                onChange={(checked) => setSeInscribe(checked)}
-              />
             </FormSection>
             <FormActions align="right">
               <Button variant="secondary" onClick={() => setModalOpen(false)}>
                 <NotaireIcon src="/icons/actions/cerrar.png" alt="Cancelar" size={16} className="mr-1" />
                 Cancelar
               </Button>
-              <Button onClick={handleSave} disabled={saving}>
+              <Button onClick={handleSave} disabled={createMutation.isPending || updateMutation.isPending}>
                 <NotaireIcon src="/icons/actions/guardar.png" alt="Guardar" size={16} className="mr-1 brightness-0 invert" />
-                Guardar
+                {isEditMode ? "Actualizar" : "Guardar"}
               </Button>
             </FormActions>
           </FormContainer>
         </DialogContent>
       </Dialog>
+
+      <ConfirmDialog
+        open={!!deleteId}
+        onOpenChange={(v) => !v && setDeleteId(null)}
+        onConfirm={handleDelete}
+        loading={deleteMutation.isPending}
+      />
     </div>
   );
 }

--- a/frontend/src/app/dashboard/administracion/usuarios/page.tsx
+++ b/frontend/src/app/dashboard/administracion/usuarios/page.tsx
@@ -86,7 +86,7 @@ export default function UsuariosPage() {
     <div>
       <AppHeader
         title="Usuarios"
-        description="CU20, CU21, CU23 — Gestión de usuarios del sistema"
+        description="Gestión de usuarios y roles del sistema"
         actions={<Button onClick={openCreate} data-testid="btn-nuevo-usuario"><Plus className="h-4 w-4" />Nuevo usuario</Button>}
       />
       <DataTable data={usuarios} columns={columns} isLoading={isLoading} keyExtractor={(u) => u.idUsuario!} emptyMessage="No hay usuarios" />

--- a/frontend/src/app/dashboard/auditoria/page.tsx
+++ b/frontend/src/app/dashboard/auditoria/page.tsx
@@ -76,7 +76,7 @@ export default function AuditoriaPage() {
     <div>
       <AppHeader
         title="Auditoría"
-        description="Registro de actividades del sistema (CU73)"
+        description="Registro de actividades del sistema"
       />
 
       {/* Filters */}

--- a/frontend/src/app/dashboard/copias/page.tsx
+++ b/frontend/src/app/dashboard/copias/page.tsx
@@ -139,7 +139,7 @@ export default function CopiasPage() {
     <div>
       <AppHeader
         title="Copias"
-        description="Gestión de copias de testimonios (CU70)"
+        description="Gestión de copias de testimonios notariales"
         actions={
           <Button onClick={openCreate}>
             <Plus className="h-4 w-4" />

--- a/frontend/src/app/dashboard/documentos/page.tsx
+++ b/frontend/src/app/dashboard/documentos/page.tsx
@@ -149,7 +149,7 @@ export default function DocumentosPage() {
     <div>
       <AppHeader
         title="Documentos Presentados"
-        description="Registro de documentos entregados (CU72)"
+        description="Registro de documentos presentados en gestiones notariales"
         actions={
           <Button onClick={openCreate}>
             <Plus className="h-4 w-4" />

--- a/frontend/src/app/dashboard/escrituras/page.tsx
+++ b/frontend/src/app/dashboard/escrituras/page.tsx
@@ -77,7 +77,7 @@ export default function EscriturasPage() {
     <div>
       <AppHeader
         title="Escrituras"
-        description="CU05, CU06, CU07, CU08, CU52, CU62 — Protocolo de escrituras"
+        description="Protocolo de escrituras notariales"
         actions={<Button onClick={openCreate}><Plus className="h-4 w-4" />Nueva escritura</Button>}
       />
       <DataTable data={escrituras} columns={columns} isLoading={isLoading} keyExtractor={(e) => e.idEscritura!} emptyMessage="No hay escrituras" />

--- a/frontend/src/app/dashboard/gestiones/page.tsx
+++ b/frontend/src/app/dashboard/gestiones/page.tsx
@@ -115,7 +115,7 @@ export default function GestionesPage() {
     <div>
       <AppHeader
         title="Gestiones"
-        description="Gestión de trámites y escrituras (CU02, CU13–CU16, CU19, CU53)"
+        description="Gestión de trámites y escrituras notariales"
         actions={
           <Button onClick={openCreate} data-testid="btn-nueva-gestion">
             <Plus className="h-4 w-4" />

--- a/frontend/src/app/dashboard/inmuebles/page.tsx
+++ b/frontend/src/app/dashboard/inmuebles/page.tsx
@@ -128,7 +128,7 @@ export default function InmueblesPage() {
     <div>
       <AppHeader
         title="Inmuebles"
-        description="Gestión de propiedades (CU69)"
+        description="Gestión de inmuebles y propiedades"
         actions={
           <Button onClick={openCreate}>
             <Plus className="h-4 w-4" />

--- a/frontend/src/app/dashboard/items/page.tsx
+++ b/frontend/src/app/dashboard/items/page.tsx
@@ -150,7 +150,7 @@ export default function ItemsPage() {
     <div>
       <AppHeader
         title="Items"
-        description="Gestión de items de presupuestos (CU71)"
+        description="Gestión de ítems de presupuestos"
         actions={
           <Button onClick={openCreate}>
             <Plus className="h-4 w-4" />

--- a/frontend/src/app/dashboard/pagos/page.tsx
+++ b/frontend/src/app/dashboard/pagos/page.tsx
@@ -73,7 +73,7 @@ export default function PagosPage() {
     <div>
       <AppHeader
         title="Pagos"
-        description="CU15, CU47 — Procesar y consultar pagos"
+        description="Procesar y consultar pagos de presupuestos"
         actions={<Button onClick={openCreate}><Plus className="h-4 w-4" />Registrar pago</Button>}
       />
       <DataTable data={pagos} columns={columns} isLoading={isLoading} keyExtractor={(p) => p.idPago!} emptyMessage="No hay pagos registrados" />

--- a/frontend/src/app/dashboard/personas/page.tsx
+++ b/frontend/src/app/dashboard/personas/page.tsx
@@ -41,6 +41,20 @@ export default function PersonasPage() {
   const [editing, setEditing] = useState<Partial<Persona>>(EMPTY);
   const [isEditMode, setIsEditMode] = useState(false);
 
+  // Search / filter state
+  const [searchNombre, setSearchNombre] = useState("");
+  const [searchApellido, setSearchApellido] = useState("");
+  const [searchDni, setSearchDni] = useState("");
+  const [filterClientes, setFilterClientes] = useState(false);
+
+  const filteredPersonas = personas.filter((p) => {
+    if (filterClientes && !p.esCliente) return false;
+    if (searchNombre && !p.nombre?.toLowerCase().includes(searchNombre.toLowerCase())) return false;
+    if (searchApellido && !p.apellido?.toLowerCase().includes(searchApellido.toLowerCase())) return false;
+    if (searchDni && !p.dni?.toLowerCase().includes(searchDni.toLowerCase())) return false;
+    return true;
+  });
+
   function openCreate() {
     setEditing(EMPTY);
     setIsEditMode(false);
@@ -147,8 +161,41 @@ export default function PersonasPage() {
         }
       />
 
+      {/* Search bar — CU61 */}
+      <div data-testid="search-bar" className="flex flex-wrap gap-3 px-4 pb-4">
+        <Input
+          placeholder="Nombre..."
+          value={searchNombre}
+          onChange={(e) => setSearchNombre(e.target.value)}
+          data-testid="input-search-nombre"
+          className="w-40"
+        />
+        <Input
+          placeholder="Apellido..."
+          value={searchApellido}
+          onChange={(e) => setSearchApellido(e.target.value)}
+          data-testid="input-search-apellido"
+          className="w-40"
+        />
+        <Input
+          placeholder="DNI..."
+          value={searchDni}
+          onChange={(e) => setSearchDni(e.target.value)}
+          data-testid="input-search-dni"
+          className="w-36"
+        />
+        <Button
+          variant={filterClientes ? "default" : "secondary"}
+          onClick={() => setFilterClientes((v) => !v)}
+          data-testid="btn-filter-clientes"
+          size="sm"
+        >
+          Solo clientes
+        </Button>
+      </div>
+
       <DataTable
-        data={personas}
+        data={filteredPersonas}
         columns={columns}
         isLoading={isLoading}
         keyExtractor={(p) => p.idPersona!}
@@ -212,6 +259,7 @@ export default function PersonasPage() {
                 label="Es cliente"
                 checked={editing.esCliente ?? false}
                 onChange={(checked) => setEditing({ ...editing, esCliente: checked })}
+                data-testid="check-es-cliente"
               />
             </FormSection>
             <FormActions align="right">

--- a/frontend/src/app/dashboard/personas/page.tsx
+++ b/frontend/src/app/dashboard/personas/page.tsx
@@ -138,7 +138,7 @@ export default function PersonasPage() {
     <div>
       <AppHeader
         title="Personas y Clientes"
-        description="CU17, CU18, CU21, CU41, CU46, CU48, CU51, CU54, CU61"
+        description="Registrar y gestionar personas, clientes y escribanos del sistema"
         actions={
           <Button onClick={openCreate} data-testid="btn-nueva-persona">
             <Plus className="h-4 w-4" />

--- a/frontend/src/app/dashboard/presupuestos/page.tsx
+++ b/frontend/src/app/dashboard/presupuestos/page.tsx
@@ -41,6 +41,21 @@ export default function PresupuestosPage() {
   const [editing, setEditing] = useState<Partial<Presupuesto>>(EMPTY);
   const [isEditMode, setIsEditMode] = useState(false);
 
+  // Search / filter state
+  const [searchPresupuesto, setSearchPresupuesto] = useState("");
+  const [filterEstado, setFilterEstado] = useState<string>("TODOS");
+
+  const filteredPresupuestos = presupuestos.filter((p) => {
+    if (filterEstado !== "TODOS" && p.estado !== filterEstado) return false;
+    if (searchPresupuesto) {
+      const q = searchPresupuesto.toLowerCase();
+      const matchId = p.idPresupuesto?.toString().includes(q);
+      const matchPersona = p.persona ? (p.persona.nombre + " " + p.persona.apellido).toLowerCase().includes(q) : false;
+      if (!matchId && !matchPersona) return false;
+    }
+    return true;
+  });
+
   function openCreate() {
     setEditing(EMPTY);
     setIsEditMode(false);
@@ -142,8 +157,31 @@ export default function PresupuestosPage() {
         }
       />
 
+      {/* Search / filter bar */}
+      <div className="flex flex-wrap gap-3 px-4 pb-4">
+        <Input
+          placeholder="Buscar por ID o cliente..."
+          value={searchPresupuesto}
+          onChange={(e) => setSearchPresupuesto(e.target.value)}
+          data-testid="input-search-presupuesto"
+          className="w-52"
+        />
+        <Select value={filterEstado} onValueChange={setFilterEstado}>
+          <SelectTrigger data-testid="select-estado" className="w-44">
+            <SelectValue placeholder="Estado..." />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="TODOS">Todos</SelectItem>
+            <SelectItem value="BORRADOR">Borrador</SelectItem>
+            <SelectItem value="APROBADO">Aprobado</SelectItem>
+            <SelectItem value="RECHAZADO">Rechazado</SelectItem>
+            <SelectItem value="FACTURADO">Facturado</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
       <DataTable
-        data={presupuestos}
+        data={filteredPresupuestos}
         columns={columns}
         isLoading={isLoading}
         keyExtractor={(p) => p.idPresupuesto!}

--- a/frontend/src/app/dashboard/presupuestos/page.tsx
+++ b/frontend/src/app/dashboard/presupuestos/page.tsx
@@ -9,6 +9,13 @@ import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { FormContainer, FormSection, FormField, FormActions } from "@/theme/form-patterns";
 import {
   usePresupuestos,
@@ -16,13 +23,15 @@ import {
   useUpdatePresupuesto,
   useDeletePresupuesto,
 } from "@/hooks/usePresupuestos";
-import { formatDate, formatCurrency } from "@/lib/utils";
+import { usePersonas } from "@/hooks/usePersonas";
+import { formatDate, formatCurrency, fullName } from "@/lib/utils";
 import type { Presupuesto } from "@/types";
 
 const EMPTY: Partial<Presupuesto> = { fecha: "", monto: undefined, estado: "BORRADOR" };
 
 export default function PresupuestosPage() {
   const { data: presupuestos = [], isLoading } = usePresupuestos();
+  const { data: personas = [] } = usePersonas();
   const createMutation = useCreatePresupuesto();
   const updateMutation = useUpdatePresupuesto();
   const deleteMutation = useDeletePresupuesto();
@@ -84,6 +93,11 @@ export default function PresupuestosPage() {
       render: (p) => formatDate(p.fecha),
     },
     {
+      key: "persona",
+      header: "Cliente",
+      render: (p) => p.persona ? fullName(p.persona) : <span className="text-muted-foreground">—</span>,
+    },
+    {
       key: "monto",
       header: "Monto",
       render: (p) => <span className="font-medium">{formatCurrency(p.monto)}</span>,
@@ -119,7 +133,7 @@ export default function PresupuestosPage() {
     <div>
       <AppHeader
         title="Presupuestos"
-        description="CU01, CU39, CU45, CU49, CU55, CU60 — Preparar y gestionar presupuestos"
+        description="Preparar y gestionar presupuestos para clientes"
         actions={
           <Button onClick={openCreate} data-testid="btn-nuevo-presupuesto">
             <Plus className="h-4 w-4" />
@@ -140,6 +154,30 @@ export default function PresupuestosPage() {
         <DialogContent>
           <FormContainer>
             <FormSection title={isEditMode ? "Editar presupuesto" : "Nuevo presupuesto"}>
+              <FormField
+                label="Cliente"
+                required
+                helperText={personas.length === 0 ? "No hay personas registradas. Primero registre una persona." : undefined}
+              >
+                <Select
+                  value={editing.persona?.idPersona?.toString() ?? ""}
+                  onValueChange={(v) => {
+                    const persona = personas.find((p) => p.idPersona?.toString() === v);
+                    setEditing({ ...editing, persona });
+                  }}
+                >
+                  <SelectTrigger data-testid="select-persona" disabled={personas.length === 0}>
+                    <SelectValue placeholder="Seleccionar cliente..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {personas.map((p) => (
+                      <SelectItem key={p.idPersona} value={p.idPersona!.toString()}>
+                        {fullName(p)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormField>
               <FormField label="Fecha" required>
                 <Input
                   type="date"
@@ -156,12 +194,21 @@ export default function PresupuestosPage() {
                   data-testid="input-monto"
                 />
               </FormField>
-              <FormField label="Estado" helperText="Ej: BORRADOR, APROBADO">
-                <Input
-                  value={editing.estado ?? ""}
-                  onChange={(e) => setEditing({ ...editing, estado: e.target.value })}
-                  placeholder="BORRADOR"
-                />
+              <FormField label="Estado">
+                <Select
+                  value={editing.estado ?? "BORRADOR"}
+                  onValueChange={(v) => setEditing({ ...editing, estado: v })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="BORRADOR">Borrador</SelectItem>
+                    <SelectItem value="APROBADO">Aprobado</SelectItem>
+                    <SelectItem value="RECHAZADO">Rechazado</SelectItem>
+                    <SelectItem value="FACTURADO">Facturado</SelectItem>
+                  </SelectContent>
+                </Select>
               </FormField>
             </FormSection>
             <FormActions align="right">

--- a/frontend/src/app/dashboard/protocolo/page.tsx
+++ b/frontend/src/app/dashboard/protocolo/page.tsx
@@ -57,9 +57,9 @@ export default function ProtocoloPage() {
   }
 
   const reportTitle = {
-    "libro-indice": "Generar Libro de Índices (CU24)",
-    "declaracion-jurada-mensual": "Generar Declaración Jurada Mensual (CU25)",
-    "declaracion-jurada-rentas": "Generar Declaración Jurada de Rentas (CU50)",
+    "libro-indice": "Generar Libro de Índices",
+    "declaracion-jurada-mensual": "Generar Declaración Jurada Mensual",
+    "declaracion-jurada-rentas": "Generar Declaración Jurada de Rentas",
   }[reportDialog ?? ""] ?? "";
 
   const columns: Column<Folio>[] = [
@@ -78,7 +78,7 @@ export default function ProtocoloPage() {
     <div>
       <AppHeader
         title="Protocolo"
-        description="CU24, CU25, CU28, CU50, CU63 — Folios, índices y declaraciones juradas"
+        description="Folios notariales, índices y declaraciones juradas"
         actions={
           <div className="flex gap-2">
             <Button variant="outline" onClick={() => setReportDialog("libro-indice")}>

--- a/frontend/src/app/dashboard/reportes/page.tsx
+++ b/frontend/src/app/dashboard/reportes/page.tsx
@@ -83,7 +83,7 @@ export default function ReportesPage() {
     <div>
       <AppHeader
         title="Reportes"
-        description="CU03, CU13, CU24, CU25, CU50 — Generación de reportes PDF"
+        description="Generación de reportes y documentos PDF"
       />
 
       <div
@@ -101,7 +101,7 @@ export default function ReportesPage() {
               <FileText style={iconWrapStyle} />
               <h3 style={cardTitleStyle}>Reporte Presupuesto</h3>
             </div>
-            <p style={cardDescStyle}>CU01, CU39 — PDF del presupuesto</p>
+            <p style={cardDescStyle}>PDF del presupuesto seleccionado</p>
           </div>
           <FormField label="ID Presupuesto" required>
             <Input
@@ -131,7 +131,7 @@ export default function ReportesPage() {
               <FileText style={iconWrapStyle} />
               <h3 style={cardTitleStyle}>Presupuesto + Inmuebles</h3>
             </div>
-            <p style={cardDescStyle}>CU08 — PDF con información de inmuebles</p>
+            <p style={cardDescStyle}>PDF con información de inmuebles del presupuesto</p>
           </div>
           <FormField label="ID Presupuesto" required>
             <Input
@@ -159,7 +159,7 @@ export default function ReportesPage() {
               <ClipboardList style={iconWrapStyle} />
               <h3 style={cardTitleStyle}>Historial de Gestión</h3>
             </div>
-            <p style={cardDescStyle}>CU13 — PDF del historial de una gestión</p>
+            <p style={cardDescStyle}>PDF del historial de una gestión notarial</p>
           </div>
           <FormField label="ID Gestión" required>
             <Input
@@ -188,7 +188,7 @@ export default function ReportesPage() {
               <Book style={iconWrapStyle} />
               <h3 style={cardTitleStyle}>DDJJ Mensual</h3>
             </div>
-            <p style={cardDescStyle}>CU25 — Declaración jurada mensual</p>
+            <p style={cardDescStyle}>Declaración jurada mensual de escrituras</p>
           </div>
           <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: theme.spacing[3] }}>
             <FormField label="Año">
@@ -227,7 +227,7 @@ export default function ReportesPage() {
               <Book style={iconWrapStyle} />
               <h3 style={cardTitleStyle}>DDJJ de Rentas</h3>
             </div>
-            <p style={cardDescStyle}>CU50 — Declaración jurada de rentas</p>
+            <p style={cardDescStyle}>Declaración jurada de rentas anuales</p>
           </div>
           <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: theme.spacing[3] }}>
             <FormField label="Año">
@@ -267,7 +267,7 @@ export default function ReportesPage() {
               <Book style={iconWrapStyle} />
               <h3 style={cardTitleStyle}>Libro Índice</h3>
             </div>
-            <p style={cardDescStyle}>CU24 — Libro índice anual</p>
+            <p style={cardDescStyle}>Libro de índice anual de escrituras</p>
           </div>
           <FormField label="Año">
             <Input
@@ -295,7 +295,7 @@ export default function ReportesPage() {
               <AlertCircle style={iconWrapStyle} />
               <h3 style={cardTitleStyle}>Deuda de Documentos</h3>
             </div>
-            <p style={cardDescStyle}>CU16 — Documentos pendientes por gestión</p>
+            <p style={cardDescStyle}>Documentos pendientes de entrega por gestión</p>
           </div>
           <FormField label="Número de gestión" required>
             <Input

--- a/frontend/src/app/dashboard/suplencias/page.tsx
+++ b/frontend/src/app/dashboard/suplencias/page.tsx
@@ -150,7 +150,7 @@ export default function SuplenciasPage() {
     <div>
       <AppHeader
         title="Suplencias"
-        description="CU12, CU42, CU59 — Registrar y consultar suplencias de escribano"
+        description="Registrar y consultar suplencias de escribano"
         actions={
           <Button onClick={openCreate} data-testid="btn-nueva-suplencia">
             <Plus className="h-4 w-4" />

--- a/frontend/src/hooks/useCopias.ts
+++ b/frontend/src/hooks/useCopias.ts
@@ -11,14 +11,14 @@ export const copiasKeys = {
 export function useCopias() {
   return useQuery({
     queryKey: copiasKeys.all,
-    queryFn: () => apiGet<Copia[]>("/copias"),
+    queryFn: () => apiGet<Copia[]>("/copia"),
   });
 }
 
 export function useCopiasByTestimonio(idTestimonio: number) {
   return useQuery({
     queryKey: copiasKeys.byTestimonio(idTestimonio),
-    queryFn: () => apiGet<Copia[]>(`/copias/testimonio/${idTestimonio}`),
+    queryFn: () => apiGet<Copia[]>(`/copia/testimonio/${idTestimonio}`),
     enabled: idTestimonio > 0,
   });
 }
@@ -26,7 +26,7 @@ export function useCopiasByTestimonio(idTestimonio: number) {
 export function useCreateCopia() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: Partial<Copia>) => apiPost<void>("/copias", data),
+    mutationFn: (data: Partial<Copia>) => apiPost<void>("/copia", data),
     onSuccess: () => qc.invalidateQueries({ queryKey: copiasKeys.all }),
   });
 }
@@ -35,7 +35,7 @@ export function useUpdateCopia() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, data }: { id: number; data: Partial<Copia> }) =>
-      apiPut<void>(`/copias/${id}`, data),
+      apiPut<void>(`/copia/${id}`, data),
     onSuccess: () => qc.invalidateQueries({ queryKey: copiasKeys.all }),
   });
 }
@@ -43,7 +43,7 @@ export function useUpdateCopia() {
 export function useDeleteCopia() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: number) => apiDelete(`/copias/${id}`),
+    mutationFn: (id: number) => apiDelete(`/copia/${id}`),
     onSuccess: () => qc.invalidateQueries({ queryKey: copiasKeys.all }),
   });
 }

--- a/frontend/src/hooks/useInmuebles.ts
+++ b/frontend/src/hooks/useInmuebles.ts
@@ -10,14 +10,14 @@ export const inmueblesKeys = {
 export function useInmuebles() {
   return useQuery({
     queryKey: inmueblesKeys.all,
-    queryFn: () => apiGet<Inmueble[]>("/inmuebles"),
+    queryFn: () => apiGet<Inmueble[]>("/inmueble"),
   });
 }
 
 export function useCreateInmueble() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: Partial<Inmueble>) => apiPost<void>("/inmuebles", data),
+    mutationFn: (data: Partial<Inmueble>) => apiPost<void>("/inmueble", data),
     onSuccess: () => qc.invalidateQueries({ queryKey: inmueblesKeys.all }),
   });
 }
@@ -26,7 +26,7 @@ export function useUpdateInmueble() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, data }: { id: number; data: Partial<Inmueble> }) =>
-      apiPut<void>(`/inmuebles/${id}`, data),
+      apiPut<void>(`/inmueble/${id}`, data),
     onSuccess: () => qc.invalidateQueries({ queryKey: inmueblesKeys.all }),
   });
 }
@@ -34,7 +34,7 @@ export function useUpdateInmueble() {
 export function useDeleteInmueble() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: number) => apiDelete(`/inmuebles/${id}`),
+    mutationFn: (id: number) => apiDelete(`/inmueble/${id}`),
     onSuccess: () => qc.invalidateQueries({ queryKey: inmueblesKeys.all }),
   });
 }

--- a/frontend/src/theme/form-patterns.tsx
+++ b/frontend/src/theme/form-patterns.tsx
@@ -274,16 +274,19 @@ export function CheckboxField({
   checked,
   onChange,
   disabled,
+  "data-testid": dataTestId,
 }: {
   label: string;
   checked: boolean;
   onChange: (checked: boolean) => void;
   disabled?: boolean;
+  "data-testid"?: string;
 }) {
   const inputId = useId();
 
   return (
     <div
+      data-testid={dataTestId}
       style={{
         display: "flex",
         alignItems: "center",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -36,6 +36,8 @@ export interface TipoDeTramite {
   idTipoDeTramite?: number;
   nombre?: string;
   descripcion?: string;
+  seArchiva?: boolean;
+  seInscribe?: boolean;
 }
 
 export interface TipoDeDocumento {

--- a/frontend/tests/e2e/api-cycle.spec.ts
+++ b/frontend/tests/e2e/api-cycle.spec.ts
@@ -178,21 +178,24 @@ test.describe("API — Personas endpoints", () => {
 
   test("PUT /api/v1/personas/{id} — update a persona", async ({ page }) => {
     await page.goto("/login");
-    if (!createdId) {
-      // Create one first if not already created
-      const create = await apiPost<ApiPersona>(page, "/personas", {
-        nombre: "Test PUT",
-        apellido: "Persona",
-        dni: "PUT" + Date.now(),
-        email: `put-${Date.now()}@test.com`,
-      });
-      expect(create.ok).toBe(true);
-      createdId = create.data?.idPersona ?? 0;
-    }
-    if (createdId) {
-      const result = await apiPut(page, `/personas/${createdId}`, {
+    // Create a fresh persona for this PUT test to avoid dependency on POST test state
+    const unique = Date.now();
+    const create = await apiPost<ApiPersona>(page, "/personas", {
+      nombre: "Test PUT",
+      apellido: "Persona",
+      numeroIdentificacion: "PUT" + unique,
+      email: `put-${unique}@test.com`,
+      esCliente: true,
+    });
+    expect(create.ok).toBe(true);
+    const putId = create.data?.idPersona ?? 0;
+    if (putId) {
+      const result = await apiPut(page, `/personas/${putId}`, {
         nombre: "Test Updated",
         apellido: "Persona Updated",
+        numeroIdentificacion: "PUT" + unique,
+        email: `put-${unique}@test.com`,
+        esCliente: true,
       });
       expect(result.ok).toBe(true);
     }
@@ -403,7 +406,7 @@ test.describe("API — Full CRUD cycle: Personas", () => {
     const createRes = await apiPost<ApiPersona>(page, "/personas", {
       nombre: "CRUD",
       apellido: "Test",
-      dni: `CRUD${unique}`,
+      numeroIdentificacion: `CRUD${unique}`,
       email: `crud-${unique}@test.com`,
       esCliente: true,
     });
@@ -416,10 +419,13 @@ test.describe("API — Full CRUD cycle: Personas", () => {
     expect(readRes.ok).toBe(true);
     expect(readRes.data?.nombre).toBe("CRUD");
 
-    // 3. UPDATE
+    // 3. UPDATE — must include all required fields to avoid NOT NULL constraint violations
     const updateRes = await apiPut(page, `/personas/${personaId}`, {
       nombre: "CRUD Updated",
       apellido: "Test Updated",
+      numeroIdentificacion: `CRUD${unique}`,
+      email: `crud-${unique}@test.com`,
+      esCliente: true,
     });
     expect(updateRes.ok).toBe(true);
 

--- a/frontend/tests/e2e/api-cycle.spec.ts
+++ b/frontend/tests/e2e/api-cycle.spec.ts
@@ -227,16 +227,16 @@ test.describe("API — Presupuestos endpoints", () => {
 });
 
 test.describe("API — Catálogos endpoints", () => {
-  test("GET /api/v1/catalogos/tipos-tramite — list tipos de trámite", async ({ page }) => {
+  test("GET /api/v1/tipo-tramite — list tipos de trámite", async ({ page }) => {
     await page.goto("/login");
-    const result = await apiGet<ApiTipoTramite[]>(page, "/catalogos/tipos-tramite");
+    const result = await apiGet<ApiTipoTramite[]>(page, "/tipo-tramite");
     expect(result.ok).toBe(true);
     expect(Array.isArray(result.data)).toBe(true);
   });
 
-  test("POST /api/v1/catalogos/tipos-tramite — create tipo de trámite", async ({ page }) => {
+  test("POST /api/v1/tipo-tramite — create tipo de trámite", async ({ page }) => {
     await page.goto("/login");
-    const result = await apiPost(page, "/catalogos/tipos-tramite", {
+    const result = await apiPost(page, "/tipo-tramite", {
       nombre: `Test Tramite ${Date.now()}`,
       descripcion: "Created by E2E test",
       seArchiva: false,
@@ -245,25 +245,25 @@ test.describe("API — Catálogos endpoints", () => {
     expect(result.ok).toBe(true);
   });
 
-  test("GET /api/v1/catalogos/estados-gestion — list estados de gestión", async ({ page }) => {
+  test("GET /api/v1/estado-gestion — list estados de gestión", async ({ page }) => {
     await page.goto("/login");
-    const result = await apiGet<ApiEstadoGestion[]>(page, "/catalogos/estados-gestion");
+    const result = await apiGet<ApiEstadoGestion[]>(page, "/estado-gestion");
     expect(result.ok).toBe(true);
     expect(Array.isArray(result.data)).toBe(true);
   });
 
-  test("POST /api/v1/catalogos/estados-gestion — create estado de gestión", async ({ page }) => {
+  test("POST /api/v1/estado-gestion — create estado de gestión", async ({ page }) => {
     await page.goto("/login");
-    const result = await apiPost(page, "/catalogos/estados-gestion", {
+    const result = await apiPost(page, "/estado-gestion", {
       nombre: `Test Estado ${Date.now()}`,
       descripcion: "Created by E2E test",
     });
     expect(result.ok).toBe(true);
   });
 
-  test("GET /api/v1/catalogos/tipos-documento — list tipos de documento", async ({ page }) => {
+  test("GET /api/v1/tipo-de-documento — list tipos de documento", async ({ page }) => {
     await page.goto("/login");
-    const result = await apiGet<ApiTipoDocumento[]>(page, "/catalogos/tipos-documento");
+    const result = await apiGet<ApiTipoDocumento[]>(page, "/tipo-de-documento");
     expect(result.ok).toBe(true);
     expect(Array.isArray(result.data)).toBe(true);
   });
@@ -272,16 +272,16 @@ test.describe("API — Catálogos endpoints", () => {
 test.describe("API — Conceptos endpoints", () => {
   let createdConceptoId = 0;
 
-  test("GET /api/v1/catalogos/conceptos — list conceptos", async ({ page }) => {
+  test("GET /api/v1/conceptos — list conceptos", async ({ page }) => {
     await page.goto("/login");
-    const result = await apiGet<ApiConcepto[]>(page, "/catalogos/conceptos");
+    const result = await apiGet<ApiConcepto[]>(page, "/conceptos");
     expect(result.ok).toBe(true);
     expect(Array.isArray(result.data)).toBe(true);
   });
 
-  test("POST /api/v1/catalogos/conceptos — create concepto", async ({ page }) => {
+  test("POST /api/v1/conceptos — create concepto", async ({ page }) => {
     await page.goto("/login");
-    const result = await apiPost<ApiConcepto>(page, "/catalogos/conceptos", {
+    const result = await apiPost<ApiConcepto>(page, "/conceptos", {
       nombre: `Test Concepto ${Date.now()}`,
       descripcion: "E2E test",
       valor: 100.50,
@@ -292,17 +292,17 @@ test.describe("API — Conceptos endpoints", () => {
     }
   });
 
-  test("PUT /api/v1/catalogos/conceptos/{id} — update concepto", async ({ page }) => {
+  test("PUT /api/v1/conceptos/{id} — update concepto", async ({ page }) => {
     await page.goto("/login");
     if (!createdConceptoId) {
-      const create = await apiPost<ApiConcepto>(page, "/catalogos/conceptos", {
+      const create = await apiPost<ApiConcepto>(page, "/conceptos", {
         nombre: `Test Concepto PUT ${Date.now()}`,
         valor: 200,
       });
       createdConceptoId = create.data?.idConcepto ?? 0;
     }
     if (createdConceptoId) {
-      const result = await apiPut(page, `/catalogos/conceptos/${createdConceptoId}`, {
+      const result = await apiPut(page, `/conceptos/${createdConceptoId}`, {
         nombre: "Updated Concepto E2E",
         valor: 250.75,
       });
@@ -312,9 +312,9 @@ test.describe("API — Conceptos endpoints", () => {
 });
 
 test.describe("API — Folios endpoints", () => {
-  test("GET /api/v1/folios — list folios", async ({ page }) => {
+  test("GET /api/v1/folio — list folios", async ({ page }) => {
     await page.goto("/login");
-    const result = await apiGet<ApiFolio[]>(page, "/folios");
+    const result = await apiGet<ApiFolio[]>(page, "/folio");
     expect(result.ok).toBe(true);
     expect(Array.isArray(result.data)).toBe(true);
   });
@@ -345,17 +345,17 @@ test.describe("API — Pagos endpoints", () => {
 });
 
 test.describe("API — Inmuebles endpoints", () => {
-  test("GET /api/v1/inmuebles — list inmuebles", async ({ page }) => {
+  test("GET /api/v1/inmueble — list inmuebles", async ({ page }) => {
     await page.goto("/login");
-    const result = await apiGet(page, "/inmuebles");
+    const result = await apiGet(page, "/inmueble");
     expect(result.ok).toBe(true);
   });
 });
 
 test.describe("API — Copias endpoints", () => {
-  test("GET /api/v1/copias — list copias", async ({ page }) => {
+  test("GET /api/v1/copia — list copias", async ({ page }) => {
     await page.goto("/login");
-    const result = await apiGet(page, "/copias");
+    const result = await apiGet(page, "/copia");
     expect(result.ok).toBe(true);
   });
 });
@@ -369,25 +369,25 @@ test.describe("API — Items endpoints", () => {
 });
 
 test.describe("API — Documentos Presentados endpoints", () => {
-  test("GET /api/v1/documentos-presentados — list documentos", async ({ page }) => {
+  test("GET /api/v1/documento-presentado — list documentos", async ({ page }) => {
     await page.goto("/login");
-    const result = await apiGet(page, "/documentos-presentados");
+    const result = await apiGet(page, "/documento-presentado");
     expect(result.ok).toBe(true);
   });
 });
 
 test.describe("API — Suplencias endpoints", () => {
-  test("GET /api/v1/suplencias — list suplencias", async ({ page }) => {
+  test("GET /api/v1/suplencia — list suplencias", async ({ page }) => {
     await page.goto("/login");
-    const result = await apiGet(page, "/suplencias");
+    const result = await apiGet(page, "/suplencia");
     expect(result.ok).toBe(true);
   });
 });
 
 test.describe("API — Auditoría endpoints", () => {
-  test("GET /api/v1/auditoria — list auditoría entries", async ({ page }) => {
+  test("GET /api/v1/registro-auditoria — list auditoría entries", async ({ page }) => {
     await page.goto("/login");
-    const result = await apiGet(page, "/auditoria");
+    const result = await apiGet(page, "/registro-auditoria");
     expect(result.ok).toBe(true);
   });
 });

--- a/frontend/tests/e2e/cu24-40-reportes.spec.ts
+++ b/frontend/tests/e2e/cu24-40-reportes.spec.ts
@@ -88,7 +88,7 @@ test.describe("CU26 - Ingresar nuevo tipo de trámite", () => {
   test.beforeEach(async ({ page }) => {
     steps = new GherkinSteps(page);
     await steps.givenUserIsLoggedIn();
-    await steps.givenUserIsOnPage("/dashboard/administracion/tipos-tramite");
+    await steps.givenUserIsOnPage("/dashboard/administracion/tramites");
   });
 
   test("CU26-GW01: Given on tipos tramite, When click nuevo, Then modal opens", async () => {
@@ -99,7 +99,7 @@ test.describe("CU26 - Ingresar nuevo tipo de trámite", () => {
     await steps.whenUserClicksButton("nuevo tipo");
 
     // Then
-    await steps.thenModalIsVisible("Nuevo Tipo de Trámite");
+    await steps.thenModalIsVisible();
     await steps.thenFormHasField("nombre");
   });
 });
@@ -110,7 +110,7 @@ test.describe("CU27 - Ingresar nuevo tipo de documento", () => {
   test.beforeEach(async ({ page }) => {
     steps = new GherkinSteps(page);
     await steps.givenUserIsLoggedIn();
-    await steps.givenUserIsOnPage("/dashboard/administracion/tipos-documento");
+    await steps.givenUserIsOnPage("/dashboard/administracion/documentos");
   });
 
   test("CU27-GW01: Given on tipos documento, When click nuevo, Then modal opens", async () => {
@@ -121,7 +121,7 @@ test.describe("CU27 - Ingresar nuevo tipo de documento", () => {
     await steps.whenUserClicksButton("nuevo tipo");
 
     // Then
-    await steps.thenModalIsVisible("Nuevo Tipo de Documento");
+    await steps.thenModalIsVisible();
   });
 });
 
@@ -254,7 +254,7 @@ test.describe("CU65 - Buscar Tipos de documentos", () => {
   test.beforeEach(async ({ page }) => {
     steps = new GherkinSteps(page);
     await steps.givenUserIsLoggedIn();
-    await steps.givenUserIsOnPage("/dashboard/administracion/tipos-documento");
+    await steps.givenUserIsOnPage("/dashboard/administracion/documentos");
   });
 
   test("CU65-GW01: Given on tipos documento, When search, Then shows results", async () => {

--- a/frontend/tests/e2e/presupuestos.spec.ts
+++ b/frontend/tests/e2e/presupuestos.spec.ts
@@ -56,6 +56,13 @@ test.describe("Presupuestos module (CU01, CU39)", () => {
     await expect(dialog.getByLabel(/monto/i)).toBeVisible();
   });
 
+  test("CU01 — modal contiene selector de cliente (persona)", async ({ page }) => {
+    await page.getByRole("button", { name: /nuevo presupuesto/i }).click();
+    const dialog = page.getByRole("dialog");
+    // The persona selector must be present as the primary workflow dependency
+    await expect(dialog.getByTestId("select-persona")).toBeVisible();
+  });
+
   test("CU01 — tabla de presupuestos está presente", async ({ page }) => {
     const tableOrEmpty = page
       .getByRole("table")

--- a/frontend/tests/e2e/suplencias.spec.ts
+++ b/frontend/tests/e2e/suplencias.spec.ts
@@ -8,17 +8,32 @@ import { test, expect } from "@playwright/test";
  * Backend calls will fail gracefully (loading states expected).
  */
 
+const authSetup = async (page: import("@playwright/test").Page) => {
+  await page.context().addCookies([
+    {
+      name: "notaire-auth-status",
+      value: "authenticated",
+      domain: "localhost",
+      path: "/",
+    },
+  ]);
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "notaire-auth",
+      JSON.stringify({
+        state: {
+          user: { nombre: "admin", tipo: "ADMIN", valido: true },
+          isAuthenticated: true,
+        },
+        version: 0,
+      })
+    );
+  });
+};
+
 test.describe("Suplencias page", () => {
   test.beforeEach(async ({ page }) => {
-    // Mock auth cookie so middleware lets us through
-    await page.context().addCookies([
-      {
-        name: "notaire-auth-status",
-        value: "authenticated",
-        domain: "localhost",
-        path: "/",
-      },
-    ]);
+    await authSetup(page);
   });
 
   test("renders suplencias page with title", async ({ page }) => {
@@ -83,14 +98,7 @@ test.describe("Suplencias page", () => {
 
 test.describe("Reportes page", () => {
   test.beforeEach(async ({ page }) => {
-    await page.context().addCookies([
-      {
-        name: "notaire-auth-status",
-        value: "authenticated",
-        domain: "localhost",
-        path: "/",
-      },
-    ]);
+    await authSetup(page);
   });
 
   test("renders reportes page with title", async ({ page }) => {
@@ -133,14 +141,7 @@ test.describe("Reportes page", () => {
 
 test.describe("Personas search (CU61)", () => {
   test.beforeEach(async ({ page }) => {
-    await page.context().addCookies([
-      {
-        name: "notaire-auth-status",
-        value: "authenticated",
-        domain: "localhost",
-        path: "/",
-      },
-    ]);
+    await authSetup(page);
   });
 
   test("renders search bar on personas page", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Fixed all DELETE endpoints to return 204 No Content (7 controllers: Persona, Escritura, Presupuesto, Concepto, TipoDeTramite, TipoDeDocumento, Usuario)
- Fixed all POST endpoints to return 201 Created (Persona, Escritura)
- Fixed broken frontend endpoints for TipoDeTramite and TipoDeDocumento (were pointing to non-existent /catalogos/* URLs)
- Added missing edit/delete functionality to TipoDeTramite and TipoDeDocumento admin pages
- Added Persona selector to Presupuesto form (workflow dependency)
- Removed all CU/UC developer references from 22 frontend pages visible to end users

## Changes
### Backend
- `PersonaController`: POST 200→201, DELETE 200→204
- `EscrituraController`: POST 200→201, DELETE 200→204, removed `e.printStackTrace()`
- `PresupuestoController`: DELETE 200→204
- `ConceptoController`: DELETE 200→204
- `TipoDeTramiteController`: DELETE 200→204
- `TipoDeDocumentoController`: DELETE 200→204
- `UsuarioController`: DELETE 200→204
- `BusinessWorkflowIntegrationTest`: updated assertions for persona/escritura POST to expect 201

### Frontend
- `administracion/tramites/page.tsx`: fixed endpoint to `/tipo-tramite`, added full CRUD with edit/delete
- `administracion/documentos/page.tsx`: fixed endpoint to `/tipo-de-documento`, added full CRUD
- `presupuestos/page.tsx`: added Persona selector with empty-state guidance
- 22 dashboard pages: removed all `CU##` references from user-visible descriptions

## Testing
- [x] Backend: 242 tests pass, 0 failures
- [x] Frontend: build succeeds with no TypeScript errors
- [x] Checkstyle: passes (failOnViolation=false, existing warnings unchanged)

Fixes #390