### PR TITLE
chore: full-stack quality hardening — fix 23 E2E 500s, schema-drift guard, coverage ratchet, a11y, docs

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -19,9 +19,16 @@ JaCoCo is used to measure code coverage during test execution.
 
 ### Configuration
 
-Minimum coverage requirements (configured in `pom.xml`):
-- **Line coverage**: 80%
-- **Branch coverage**: 80%
+Coverage is split into an **aspirational target** and an **enforced ratchet floor**:
+
+- **Long-term target**: 80% line / 80% branch.
+- **Enforced gate** (`jacoco:check`, bound to `mvn verify`, BUNDLE scope, legacy
+  `jpa`/`servicios.Administrador*` packages excluded): a ratchet floor set just below
+  the current real coverage — **28% line / 14% branch** as of 2026-05-29 (actual:
+  ~29% line / ~15% branch). The build fails if coverage drops below the floor.
+- **Policy**: raise the floor as coverage improves; never lower it. The historical
+  per-class 80% rule was bound to `<phase>none</phase>` and never ran, so the prior
+  "80% enforced" claim was inaccurate.
 
 ### Running Coverage
 
@@ -169,7 +176,7 @@ The complete quality gate in CI:
 1. **Build** - Compilation
 2. **Unit Tests** - JUnit tests
 3. **Integration Tests** - Spring Boot tests
-4. **Coverage** - JaCoCo (80% minimum)
+4. **Coverage** - JaCoCo (enforced ratchet floor; 80% target)
 5. **Security** - Trivy vulnerability scan
 6. **Code Quality** - Checkstyle + SpotBugs
 

--- a/.claude/rules/database-migrations.md
+++ b/.claude/rules/database-migrations.md
@@ -6,6 +6,18 @@ This file provides rules for database schema migrations using Flyway in the Nota
 
 The Notaire project uses **Flyway** for database schema versioning. All database changes MUST be managed through Flyway migrations.
 
+> ⚠️ **Important caveat — the Docker stack does not run Flyway.** In Docker the
+> schema is created from `init-db/01-schema.sql` (mounted into the postgres
+> container), which runs before the app starts; Flyway then finds the tables
+> already present and stays dormant (no `flyway_schema_history` is created).
+> As a result `db/migration/V3..V5` (written to add entity columns) never took
+> effect in Docker, which caused production 500s. **Until the two sources are
+> reconciled, any schema change must be applied to BOTH `init-db/01-schema.sql`
+> (authoritative for Docker) AND a new Flyway migration (for the local/Flyway
+> path).** Validate alignment with `mvn test -Ppg-integration`
+> (`InitDbSchemaValidationIntegrationTest`). Reconciling to a single source of
+> truth is a tracked follow-up.
+
 ## Mandatory Rules
 
 ### 1. NEVER Modify Existing Migrations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,9 @@ Package root: `com.licensis.notaire`
 
 **Key architectural note:** The `jpa` package contains `*JpaController` classes (not REST controllers) — these are large data-access classes migrated from the original monolith. They are being superseded by the `repository` package (Spring Data repos). New code should use `repository`, not `jpa`.
 
-**Database:** PostgreSQL 16 via Docker. Schema managed by `init-db/` SQL scripts. `ddl-auto=update` locally, `none` in Docker. ORM: Hibernate (PostgreSQLDialect).
+**Database:** PostgreSQL 16 via Docker. ORM: Hibernate (PostgreSQLDialect), `ddl-auto=none` (Hibernate never creates/alters the schema).
+
+> ⚠️ **Schema source of truth:** In the Docker stack the schema is built **only** from `init-db/01-schema.sql` (mounted into the postgres container). Flyway is on the classpath and `spring.flyway.enabled=true`, but it is **dormant in Docker** — the `init-db` scripts create the schema first, so the `db/migration/V*` files never run there. **Therefore `init-db/01-schema.sql` is the authoritative Docker schema and MUST stay aligned with the JPA entities.** Adding/renaming an entity column without updating `init-db` causes runtime 500s (`column ... does not exist`). The H2 unit tests cannot catch this (they generate their schema from the entities); the guard is `InitDbSchemaValidationIntegrationTest` — run `mvn test -Ppg-integration`. See `.claude/rules/database-migrations.md`.
 
 **Reports:** JasperReports (`.jasper`/`.jrxml`) in `src/main/resources/reportes/`. The `ReporteController` handles report generation.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ mvn test -pl backend-api -Dtest="**/unit/*"
 # Integration tests only (require running PostgreSQL; H2-based tests work standalone)
 mvn test -pl backend-api -Dtest="**/integration/*"
 
-# Coverage check (80% minimum enforced by JaCoCo)
+# Coverage check (enforced ratchet floor via JaCoCo on `mvn verify`; 80% is the target)
 mvn jacoco:check -pl backend-api
 mvn jacoco:report -pl backend-api  # HTML report at backend-api/target/site/jacoco/index.html
 

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ Total               440+   ~37,000+
 
 | Módulo | Cobertura Líneas | Cobertura Branches | Estado |
 |:-------|:----------------|:-------------------|:-------|
-| backend-api | ≥ 80% | ≥ 80% | ✅ Verificado por JaCoCo |
+| backend-api | ~29% (objetivo 80%) | ~15% (objetivo 80%) | ⚙️ Piso mínimo aplicado por JaCoCo (`mvn verify`), con ratchet ascendente |
 
 ### Ciclo de Vida del Proyecto
 
@@ -585,8 +585,8 @@ mvn verify -pl backend-api
 |:-----|:----------|:------------|
 | ✅ Tests unitarios | 100% passing | JUnit 5 + Surefire |
 | ✅ Tests integración | 100% passing | Spring Boot Test |
-| ✅ Cobertura de línea | ≥ 80% | JaCoCo |
-| ✅ Cobertura de branches | ≥ 80% | JaCoCo |
+| ⚙️ Cobertura de línea | piso ~28% (objetivo 80%) | JaCoCo (ratchet) |
+| ⚙️ Cobertura de branches | piso ~14% (objetivo 80%) | JaCoCo (ratchet) |
 | ✅ Vulnerabilidades críticas | 0 | Trivy |
 | ✅ Code style | Sin violaciones | Checkstyle (Google Style) |
 | ✅ Bug detection | Sin errores | SpotBugs (Max effort) |

--- a/backend-api/pom.xml
+++ b/backend-api/pom.xml
@@ -257,24 +257,41 @@
                     </execution>
                     <execution>
                         <id>check</id>
-                        <phase>none</phase>
+                        <!--
+                            Enforced ratchet floor (runs on `mvn verify`). The long-term
+                            target is 80% (see docs/code-quality), but the current real
+                            coverage of the non-legacy code is ~29% line / ~15% branch, so
+                            the gate is set just below that to prevent regressions while we
+                            climb. Raise these minimums as coverage improves; do not lower.
+                        -->
+                        <phase>verify</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>
                         <configuration>
+                            <excludes>
+                                <exclude>com/licensis/notaire/jpa/**/*</exclude>
+                                <exclude>com/licensis/notaire/negocio/ControllerNegocio*</exclude>
+                                <exclude>com/licensis/notaire/servicios/AdministradorJpa*</exclude>
+                                <exclude>com/licensis/notaire/servicios/AdministradorReportes*</exclude>
+                                <exclude>com/licensis/notaire/servicios/AdministradorSesion*</exclude>
+                                <exclude>com/licensis/notaire/servicios/AdministradorValidaciones*</exclude>
+                                <exclude>com/licensis/notaire/servicios/Conexion*</exclude>
+                                <exclude>com/licensis/notaire/NotaireBackendApplication*</exclude>
+                            </excludes>
                             <rules>
                                 <rule>
-                                    <element>CLASS</element>
+                                    <element>BUNDLE</element>
                                     <limits>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.28</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.14</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/backend-api/pom.xml
+++ b/backend-api/pom.xml
@@ -198,6 +198,20 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!--
+                        Heavyweight Testcontainers (real PostgreSQL) integration tests are
+                        excluded from the fast default test run because mixing a full
+                        container-backed Spring context into the H2 surefire batch
+                        destabilizes the in-memory tests. Run them on demand with the
+                        'pg-integration' profile: mvn test -Ppg-integration
+                    -->
+                    <excludedGroups>pg-integration</excludedGroups>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <version>3.5.5</version>
             </plugin>
@@ -331,4 +345,27 @@
             </plugin>
         </plugins>
     </reporting>
+
+    <profiles>
+        <!--
+            Runs the heavyweight Testcontainers (real PostgreSQL) integration tests,
+            e.g. InitDbSchemaValidationIntegrationTest, which validate the entities
+            against the production init-db schema. Requires Docker.
+            Usage: mvn test -Ppg-integration
+        -->
+        <profile>
+            <id>pg-integration</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration combine.self="override">
+                            <groups>pg-integration</groups>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/backend-api/src/main/resources/application.properties
+++ b/backend-api/src/main/resources/application.properties
@@ -35,6 +35,10 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 
 # Flyway Configuration
+# NOTE: In the Docker stack the schema is created from init-db/01-schema.sql
+# (mounted into the postgres container), so Flyway is effectively dormant there.
+# init-db/01-schema.sql is the source of truth for the Docker database and MUST
+# stay aligned with the JPA entities (guarded by InitDbSchemaValidationIntegrationTest).
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true
 spring.flyway.baseline-version=0
@@ -43,7 +47,6 @@ spring.flyway.out-of-order=false
 spring.flyway.validate-on-migrate=true
 spring.flyway.clean-disabled=true
 spring.flyway.connect-retries=3
-spring.flyway.repair-at-start=true
 
 # ===== OBSERVABILITY & MONITORING CONFIGURATION =====
 

--- a/backend-api/src/main/resources/application.properties
+++ b/backend-api/src/main/resources/application.properties
@@ -88,10 +88,12 @@ spring.security.user.roles=ACTUATOR,ADMIN
 
 # Logging Configuration
 logging.level.root=${LOG_LEVEL_ROOT:INFO}
-logging.level.com.licensis.notaire=${LOG_LEVEL_APP:DEBUG}
+# Default to INFO for production; override locally with LOG_LEVEL_APP=DEBUG etc.
+# (DEBUG defaults flooded logs — Spring Security logs every request at DEBUG.)
+logging.level.com.licensis.notaire=${LOG_LEVEL_APP:INFO}
 logging.level.org.springframework.web=INFO
 logging.level.org.springframework.boot=INFO
-logging.level.org.springframework.security=DEBUG
+logging.level.org.springframework.security=${LOG_LEVEL_SECURITY:INFO}
 logging.level.org.hibernate=WARN
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} - %logger{36} - %msg%n
 logging.file.name=logs/notaire-backend.log

--- a/backend-api/src/test/java/com/licensis/notaire/integration/BaseIntegrationTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/BaseIntegrationTest.java
@@ -1,23 +1,66 @@
 package com.licensis.notaire.integration;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
 
+/**
+ * Base class for integration tests that run against a real PostgreSQL container
+ * whose schema is created from the project's {@code init-db} SQL scripts — the
+ * same scripts that build the production Docker database.
+ *
+ * <p>This is deliberate: it exercises the actual deployed schema (not a schema
+ * generated from the JPA entities), at production fidelity ({@code ddl-auto=none},
+ * same as Docker). Endpoint smoke tests in subclasses then fail on any
+ * missing-column / missing-table drift that would produce a runtime 500 — the
+ * exact failure class that previously broke testimonio, movimiento-testimonio,
+ * tipo-folio and items. The scripts are mounted into {@code /docker-entrypoint-initdb.d}
+ * (which supports multiple ordered files, unlike {@code withInitScript}).</p>
+ *
+ * <p>Requires Docker. Tests are skipped automatically when Docker is unavailable.</p>
+ */
 @Testcontainers(disabledWithoutDocker = true)
 public abstract class BaseIntegrationTest {
 
     @Container
     @SuppressWarnings("resource")
-    protected static final PostgreSQLContainer<?> POSTGRESQL_CONTAINER = 
+    protected static final PostgreSQLContainer<?> POSTGRESQL_CONTAINER =
         new PostgreSQLContainer<>("postgres:16-alpine")
             .withDatabaseName("notaire_test")
             .withUsername("admin")
             .withPassword("admin")
-            .withInitScript("init-db/01-schema.sql")
-            .withInitScript("init-db/02-data.sql");
+            .withCopyFileToContainer(
+                MountableFile.forHostPath(initDbScript("01-schema.sql")),
+                "/docker-entrypoint-initdb.d/01-schema.sql")
+            .withCopyFileToContainer(
+                MountableFile.forHostPath(initDbScript("02-data.sql")),
+                "/docker-entrypoint-initdb.d/02-data.sql");
+
+    /**
+     * Resolve an {@code init-db} script on the host filesystem, walking up from the
+     * working directory so the path works whether the build runs from the module
+     * directory or the repository root.
+     *
+     * @param fileName the script file name (e.g. {@code 01-schema.sql})
+     * @return absolute path to the script
+     */
+    private static Path initDbScript(String fileName) {
+        Path dir = Paths.get("").toAbsolutePath();
+        for (int depth = 0; depth < 5 && dir != null; depth++) {
+            Path candidate = dir.resolve("init-db").resolve(fileName);
+            if (candidate.toFile().exists()) {
+                return candidate;
+            }
+            dir = dir.getParent();
+        }
+        throw new IllegalStateException("Could not locate init-db/" + fileName + " from " + Paths.get("").toAbsolutePath());
+    }
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) {
@@ -25,9 +68,14 @@ public abstract class BaseIntegrationTest {
         registry.add("spring.datasource.username", POSTGRESQL_CONTAINER::getUsername);
         registry.add("spring.datasource.password", POSTGRESQL_CONTAINER::getPassword);
         registry.add("spring.datasource.driver-class-name", POSTGRESQL_CONTAINER::getDriverClassName);
-        // Hibernate validates schema (created by init scripts)
-        registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
-        // Disable Flyway in tests (scripts run via Testcontainers)
+        // Production fidelity: schema comes from init-db, Hibernate does not touch it.
+        // Subclass endpoint smoke tests catch missing-column/table drift at query time.
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+        // Schema is created by the init scripts, not Flyway.
         registry.add("spring.flyway.enabled", () -> "false");
+        // Keep this container-backed context lightweight so it does not starve the
+        // rest of the (H2-based) suite of connections/threads when run together.
+        registry.add("spring.datasource.hikari.maximum-pool-size", () -> "2");
+        registry.add("spring.datasource.hikari.minimum-idle", () -> "0");
     }
 }

--- a/backend-api/src/test/java/com/licensis/notaire/integration/InitDbSchemaValidationIntegrationTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/InitDbSchemaValidationIntegrationTest.java
@@ -1,0 +1,87 @@
+package com.licensis.notaire.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Guards against drift between the JPA entities and {@code init-db/01-schema.sql},
+ * the schema that builds the production Docker database.
+ *
+ * <p>The Docker database is created exclusively from the {@code init-db} scripts
+ * (Flyway is dormant in Docker). Previously every read of an endpoint whose entity
+ * referenced a column missing from {@code init-db} failed with HTTP 500
+ * (InvalidDataAccessResourceUsageException). The pre-existing H2 tests could not
+ * catch this because they use {@code ddl-auto=create}, generating the schema from
+ * the entities themselves.</p>
+ *
+ * <p>This test boots the full application against a PostgreSQL container created
+ * from the real {@code init-db} scripts at production fidelity ({@code ddl-auto=none}),
+ * then smoke tests the endpoint families that previously returned 500. A missing
+ * column or table reintroduced into the entities (or removed from init-db) makes
+ * the corresponding request return 500 and fails the build.</p>
+ */
+@SpringBootTest
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Tag("pg-integration")
+@DisplayName("init-db Schema vs Entity Validation")
+class InitDbSchemaValidationIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    @Test
+    @DisplayName("Should boot the application against the real init-db schema")
+    void shouldLoadContextAgainstInitDbSchema() {
+        // Reaching this point means @SpringBootTest started against a PostgreSQL
+        // container whose schema came from init-db/01-schema.sql (production fidelity).
+    }
+
+    @Test
+    @DisplayName("Should return 200 for GET /api/v1/testimonio against the real schema")
+    void shouldListTestimoniosWhenSchemaMatchesEntities() throws Exception {
+        mockMvc.perform(get("/api/v1/testimonio")).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should return 200 for GET /api/v1/movimiento-testimonio against the real schema")
+    void shouldListMovimientosTestimonioWhenSchemaMatchesEntities() throws Exception {
+        mockMvc.perform(get("/api/v1/movimiento-testimonio")).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should return 200 for GET /api/v1/tipo-folio against the real schema")
+    void shouldListTiposDeFolioWhenSchemaMatchesEntities() throws Exception {
+        mockMvc.perform(get("/api/v1/tipo-folio")).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should return 200 for GET /api/v1/items against the real schema")
+    void shouldListItemsWhenSchemaMatchesEntities() throws Exception {
+        mockMvc.perform(get("/api/v1/items")).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should return 200 for GET /api/v1/personas (Folio to TipoDeFolio join) against the real schema")
+    void shouldListPersonasWhenSchemaMatchesEntities() throws Exception {
+        mockMvc.perform(get("/api/v1/personas")).andExpect(status().isOk());
+    }
+}

--- a/backend-api/src/test/java/com/licensis/notaire/integration/PreviouslyBrokenEndpointsIntegrationTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/PreviouslyBrokenEndpointsIntegrationTest.java
@@ -1,0 +1,100 @@
+package com.licensis.notaire.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Behavioural regression tests for the controllers whose read endpoints previously
+ * returned HTTP 500 due to entity/schema drift (testimonio, movimiento-testimonio,
+ * tipo-folio, items). Runs on the H2 profile for fast feedback and covers the list
+ * and not-found branches. The schema-level guard lives in
+ * {@link InitDbSchemaValidationIntegrationTest}.
+ */
+@SpringBootTest
+@ActiveProfiles("test-h2")
+@DisplayName("Previously-broken read endpoints")
+class PreviouslyBrokenEndpointsIntegrationTest {
+
+    private static final int MISSING_ID = 999_999;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    @Test
+    @DisplayName("Should return a JSON array for GET /api/v1/testimonio")
+    void shouldListTestimoniosWhenRequested() throws Exception {
+        mockMvc.perform(get("/api/v1/testimonio"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    @DisplayName("Should return 404 for GET /api/v1/testimonio/{id} when absent")
+    void shouldReturnNotFoundWhenTestimonioMissing() throws Exception {
+        mockMvc.perform(get("/api/v1/testimonio/" + MISSING_ID))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Should return a JSON array for GET /api/v1/movimiento-testimonio")
+    void shouldListMovimientosTestimonioWhenRequested() throws Exception {
+        mockMvc.perform(get("/api/v1/movimiento-testimonio"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    @DisplayName("Should return 404 for GET /api/v1/movimiento-testimonio/{id} when absent")
+    void shouldReturnNotFoundWhenMovimientoTestimonioMissing() throws Exception {
+        mockMvc.perform(get("/api/v1/movimiento-testimonio/" + MISSING_ID))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Should return a JSON array for GET /api/v1/tipo-folio")
+    void shouldListTiposDeFolioWhenRequested() throws Exception {
+        mockMvc.perform(get("/api/v1/tipo-folio"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    @DisplayName("Should return 404 for GET /api/v1/tipo-folio/{id} when absent")
+    void shouldReturnNotFoundWhenTipoDeFolioMissing() throws Exception {
+        mockMvc.perform(get("/api/v1/tipo-folio/" + MISSING_ID))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Should return a JSON array for GET /api/v1/items")
+    void shouldListItemsWhenRequested() throws Exception {
+        mockMvc.perform(get("/api/v1/items"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    @DisplayName("Should return 404 for GET /api/v1/items/{id} when absent")
+    void shouldReturnNotFoundWhenItemMissing() throws Exception {
+        mockMvc.perform(get("/api/v1/items/" + MISSING_ID))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/docs/01-business/00-FUNCTIONAL-BASELINE.md
+++ b/docs/01-business/00-FUNCTIONAL-BASELINE.md
@@ -1,0 +1,290 @@
+---
+title: Notaire — Whole-System Functional Baseline
+version: 1.0
+date: 2026-05-29
+status: Baseline (analyst-produced)
+author: Functional Analysis
+---
+
+# Notaire — Whole-System Functional Baseline
+
+A consolidated, cross-cutting functional view of the Notaire system: the **actor
+map**, the **use-case inventory with implementation status**, and the **core data
+model (ERD)**. It links the detailed artifacts under `docs/01-business/` and reflects
+the *actual* implementation state verified on 2026-05-29 (full Docker stack + backend
+`mvn verify` + Playwright E2E), not just documented intent.
+
+> **Scope note.** The use-case catalog (`03_CU - Casos de Uso`) marks all 68 CUs as
+> *Terminado* (documentation status). This baseline reconciles that against measured
+> reality: backend endpoints are essentially complete; several **frontend interaction
+> flows remain stubbed**, most notably the Gestiones document/testimonio lifecycle.
+
+## 1. System Overview
+
+Notaire is a notary-office (escribanía) management system, refactored from a Java
+Swing monolith into a three-tier architecture:
+
+- **backend-api** — Spring Boot 4 REST API (`/api/v1/**`), PostgreSQL 16, Hibernate.
+- **frontend** — Next.js 16 / React 19 web client (the active client; ES/EN i18n).
+- **frontend-swing** — legacy Swing client (REST client only).
+
+Functional domains (modules): **Presupuestos**, **Gestiones**, **Pagos**,
+**Clientes/Personas**, **Protocolos** (folios/reportes), **Administración** (catálogos,
+usuarios, plantillas), and **Auditoría**.
+
+## 2. Actor Map
+
+Source: `docs/01-business/03-actors` (`Lista de actores.md`).
+
+| Actor | Type | Responsibility |
+|-------|------|----------------|
+| **Recepcionista** | Human (primary) | Information & budgets (presupuestos); basic ABM of personas/clientes. |
+| **Gestor** | Human (primary) | Initiates and controls trámites (gestiones). |
+| **Escribano** | Human (primary) | Authors and signs escrituras/actas; administers folios. |
+| **Cliente** | Human (subject) | Person who requests/performs trámites; full data record. |
+| **Persona** | Human (subject) | Walk-in contact; minimal data; may become a Cliente. |
+| **Usuario (autenticado)** | System role | Any logged-in operator; actions recorded in Auditoría. |
+| **Motor de Reportes** | External system | JasperReports engine (libro de índices, DDJJ, presupuesto PDF). |
+| **Subsistema de Auditoría** | Internal system | Records create/update/delete operations per user. |
+
+```mermaid
+graph LR
+    Rec[Recepcionista]
+    Ges[Gestor]
+    Esc[Escribano]
+    subgraph Notaire
+      P[Presupuestos]
+      G[Gestiones / Escrituras / Testimonios]
+      Pg[Pagos]
+      C[Clientes / Personas]
+      Pr[Protocolos / Folios / Reportes]
+      Ad[Administración / Catálogos / Usuarios]
+      Au[(Auditoría)]
+    end
+    Rec --> P
+    Rec --> C
+    Ges --> G
+    Ges --> Pr
+    Esc --> G
+    Esc --> Pr
+    Esc --> Ad
+    Pr --> Rep[[Motor de Reportes]]
+    P --> Au
+    G --> Au
+    Ad --> Au
+```
+
+## 3. Use-Case Inventory & Implementation Status
+
+68 use cases (CU01–CU68), GitHub issues **#154–#221**. Sources:
+`docs/01-business/02-use-cases` and `docs/testing/CU-API-MATRIX.csv`.
+
+**Legend**
+- **Grado**: Esencial (E) · Necesario (N) · Estaría Bueno (B)
+- **API**: ✅ endpoint verified 200 (2026-05-29) · ⚠️ exists, no contract test
+- **UI**: ✅ realized & E2E-passing · ⚠️ page exists, interaction flow stubbed (E2E `test.skip`) · ❌ no UI flow
+
+> Backend column reflects live probes after this baseline's session, which fixed the
+> previously-500 reads (CU07/08 testimonio, CU10/12/44 movimiento-testimonio,
+> CU36/40/58/68 tipo-folio, items). UI column reflects which Gherkin E2E flows are
+> active vs `skip`-ped.
+
+### Presupuestos
+| CU | Name | Grado | API | UI |
+|----|------|:----:|:--:|:--:|
+| CU01 | Preparar Presupuesto | E | ✅ | ⚠️ create flow |
+| CU45 | Modificar presupuesto | E | ✅ | ✅ |
+| CU60 | Buscar Presupuesto | N | ✅ | ✅ |
+
+### Gestiones (incl. Escrituras / Testimonios)
+| CU | Name | Grado | API | UI |
+|----|------|:----:|:--:|:--:|
+| CU02 | Iniciar Gestión | E | ✅ | ⚠️ create/detail |
+| CU03 | Listar documentos y certificados necesarios | E | ✅ | ❌ pending |
+| CU04 | Registrar documentación cliente | E | ✅ | ❌ pending |
+| CU05 | Preparar escritura | E | ✅ | ✅ |
+| CU06 | Firmar escritura | E | ✅ | ⚠️ firmar flow |
+| CU07 | Generar testimonio | E | ✅ *(fixed)* | ❌ pending |
+| CU08 | Verificar Testimonio | N | ✅ *(fixed)* | ❌ pending |
+| CU09 | Registrar deudas documentos de Cliente | E | ✅ | ⚠️ |
+| CU10 | Registrar movimientos doc. entidades externas | E | ✅ *(fixed)* | ⚠️ |
+| CU11 | Ingresar para inscripción | E | ✅ | ❌ pending |
+| CU12 | Retirar testimonio | N | ✅ *(fixed)* | ❌ pending |
+| CU13 | Ver historial de gestión | B | ✅ | ⚠️ filter |
+| CU14 | Consultar estado gestión | N | ✅ | ⚠️ (merged into Ver Detalle) |
+| CU16 | Archivar Gestión | N | ✅ | ⚠️ archivar flow |
+| CU42 | Informar próximos vencimientos | N | ✅ | ⚠️ dashboard alert |
+| CU43 | Reingresar documentación | E | ✅ | ⚠️ |
+| CU44 | Reingresar testimonio | E | ✅ *(fixed)* | ⚠️ |
+| CU52 | Modificar Escritura | E | ✅ | ⚠️ edit flow |
+| CU53 | Modificar Gestión | E | ✅ | ✅ |
+| CU56 | Registrar inscripción | E | ✅ | ⚠️ |
+| CU62 | Buscar Escritura | N | ✅ | ⚠️ search |
+
+### Pagos
+| CU | Name | Grado | API | UI |
+|----|------|:----:|:--:|:--:|
+| CU15 | Procesar pago | B | ✅ | ⚠️ create/detail (business logic noted incomplete) |
+| CU47 | Consultar Pago | B | ✅ | ⚠️ filter |
+
+### Clientes / Personas
+| CU | Name | Grado | API | UI |
+|----|------|:----:|:--:|:--:|
+| CU17 | Dar Alta persona | E | ✅ | ✅ |
+| CU18 | Dar Alta Cliente | E | ✅ | ⚠️ alta-cliente flow |
+| CU19 | Buscar gestiones de un Cliente | N | ✅ | ✅ |
+| CU41 | Modificar Cliente | E | ✅ | ✅ |
+| CU46 | Ver detalle cliente | E | ✅ | ✅ |
+| CU54 | Modificar Persona | E | ✅ | ✅ |
+| CU61 | Buscar persona o cliente | N | ✅ | ✅ |
+
+### Protocolos (Folios / Reportes)
+| CU | Name | Grado | API | UI |
+|----|------|:----:|:--:|:--:|
+| CU24 | Generar libro de índices | B | ⚠️ no test | ⚠️ |
+| CU25 | Generar Declaración Jurada del mes | B | ⚠️ no test | ⚠️ |
+| CU28 | Ingresar nuevos folios | E | ✅ | ✅ |
+| CU33 | Modificar folio | E | ✅ | ✅ |
+| CU50 | Generar Declaración Jurada de Rentas | B | ⚠️ no test | ⚠️ |
+| CU63 | Buscar Folios | N | ✅ | ⚠️ search |
+
+### Administración (Catálogos / Usuarios / Plantillas / Escribanos)
+| CU | Name | Grado | API | UI |
+|----|------|:----:|:--:|:--:|
+| CU20 | Dar alta usuario | E | ✅ | ✅ |
+| CU21 | Modificar Usuario | E | ✅ | ⚠️ edit modal |
+| CU22 | Registrar Suplencia | E | ✅ | ✅ |
+| CU26 | Ingresar nuevo tipo de trámite | E | ✅ | ✅ |
+| CU27 | Ingresar nuevo tipo de documento | E | ✅ | ✅ |
+| CU29 | Ingresar nuevo concepto | E | ✅ | ✅ |
+| CU30 | Ingresar nuevo estado de Gestión | E | ✅ | ✅ |
+| CU31 | Modificar tipo de trámite | E | ✅ | ✅ |
+| CU32 | Modificar tipo de documento | E | ✅ | ✅ |
+| CU34 | Modificar concepto | E | ✅ | ✅ |
+| CU35 | Modificar estado de Gestión | E | ✅ | ✅ |
+| CU36 | Ingresar tipos de folio | E | ✅ *(fixed)* | ✅ |
+| CU37 | Eliminar concepto | E | ✅ | ✅ |
+| CU38 | Eliminar tipo de documento | E | ✅ | ✅ |
+| CU39 | Crear Plantilla Presupuesto | E | ✅ | ⚠️ plantillas flow |
+| CU40 | Modificar Tipo de folio | E | ✅ *(fixed)* | ✅ |
+| CU48 | Dar alta escribano | E | ✅ | ⚠️ alta-escribano flow |
+| CU49 | Eliminar Plantilla Presupuesto | E | ✅ | ✅ |
+| CU51 | Modificar escribano | E | ✅ | ✅ |
+| CU55 | Modificar Plantilla Presupuesto | E | ✅ | ✅ |
+| CU57 | Eliminar tipo de trámite | E | ✅ | ✅ |
+| CU58 | Eliminar Tipo de folio | E | ✅ *(fixed)* | ✅ |
+| CU59 | Consultar Suplencias | N | ✅ | ⚠️ filter/detail |
+| CU64 | Buscar Tipo de trámite | N | ✅ | ✅ |
+| CU65 | Buscar Tipos de documentos | N | ✅ | ⚠️ search |
+| CU66 | Buscar Conceptos | N | ✅ | ⚠️ search |
+| CU67 | Buscar Estados de Gestión | N | ✅ | ✅ |
+| CU68 | Buscar tipos de folios | N | ✅ *(fixed)* | ✅ |
+
+### Auditoría
+| CU | Name | Grado | API | UI |
+|----|------|:----:|:--:|:--:|
+| CU23 | Ver registro de actividades de usuario | N | ✅ | ⚠️ ver-actividades flow |
+
+## 4. Gap Summary
+
+- **Backend API: functionally complete.** All 68 CUs map to controllers/endpoints;
+  every read endpoint probed returns 200 after this session's schema fixes. Remaining
+  backend weaknesses are *contract-test gaps* (CU22 POST suplencia, CU24/25/50 report
+  endpoints have no Bruno test) and noted incomplete business logic in **CU15 Procesar
+  pago**.
+- **Primary functional gap — Gestiones document/testimonio lifecycle (CU03, CU04,
+  CU07, CU08, CU11, CU12):** backend ready, but **no frontend UI flow exists** (E2E
+  explicitly `skip`-ped, "UI buttons/pages not implemented yet"). This is the highest-
+  value next build: the testimonio/inscripción/retiro workflow is core notarial work.
+- **Secondary gaps — stubbed interaction flows (⚠️):** several create/edit/detail/
+  search modals are skipped in E2E although the list pages work. A per-screen UI audit
+  should confirm which are genuinely missing vs merely untested.
+- **Reports (CU24/25/50):** endpoints exist but lack tests and a confirmed UI entry.
+
+## 5. Core Data Model (ERD)
+
+28 tables (PostgreSQL `public`). Authoritative for the Docker schema:
+`init-db/01-schema.sql`. Detailed attributes: `docs/01-business/04-data-model`.
+
+```mermaid
+erDiagram
+    personas ||--o{ presupuestos : "solicita"
+    personas ||--o{ gestiones_de_escrituras : "es cliente"
+    personas ||--o{ identificaciones : "tiene"
+    tipos_identificacion ||--o{ identificaciones : "clasifica"
+    tipos_identificacion ||--o{ personas : "tipo"
+    personas ||--o{ copias : "retira"
+    personas ||--o{ folios : "escribano"
+    personas ||--o{ suplencias : "titular/suplente"
+    personas ||--o| usuarios : "es"
+
+    presupuestos ||--o{ items : "compone"
+    presupuestos ||--o{ pagos : "recibe"
+    presupuestos ||--o| tramites : "asociado"
+
+    gestiones_de_escrituras ||--o{ tramites : "agrupa"
+    gestiones_de_escrituras ||--o{ historial : "registra"
+    estados_de_gestion ||--o{ gestiones_de_escrituras : "estado"
+    estados_de_gestion ||--o{ historial : "estado"
+
+    tramites }o--|| tipos_de_tramite : "de tipo"
+    tramites }o--o| escrituras : "produce"
+    tramites }o--o| inmuebles : "sobre"
+    tramites ||--o{ tramites_personas : "intervinientes"
+    tramites_personas }o--|| personas : "interviene"
+    tramites ||--o{ documentos_presentados : "requiere"
+    documentos_presentados }o--|| tipos_de_documento : "de tipo"
+
+    escrituras ||--o{ testimonios : "genera"
+    escrituras ||--o{ folios : "se asienta"
+    testimonios ||--o{ movimientos_testimonio : "movimientos"
+    testimonios ||--o{ copias : "copias"
+    folios ||--o{ folios_copias : ""
+    copias ||--o{ folios_copias : ""
+    tipos_de_folio ||--o{ folios : "tipo"
+
+    tipos_de_tramite ||--o{ plantilla_tramites : "plantilla"
+    tipos_de_documento ||--o{ plantilla_tramites : "doc requerido"
+    tipos_de_tramite ||--o{ plantilla_presupuestos : "plantilla"
+    conceptos ||--o{ plantilla_presupuestos : "concepto"
+
+    usuarios ||--o{ registro_auditoria : "audita"
+```
+
+**Aggregate roots / hubs.** `personas` (people: clientes, escribanos, intervinientes)
+and `tramites` (the work unit linking gestión, presupuesto, escritura, inmueble) are
+the most connected entities. The escritura → testimonio → movimiento/copia → folio
+chain is the notarial-output core.
+
+**Catalog (reference) tables.** `tipos_de_documento`, `tipos_de_tramite`,
+`tipos_de_folio`, `tipos_identificacion`, `estados_de_gestion`, `conceptos`.
+
+**Schema integrity note.** The Docker schema is built only from `init-db/01-schema.sql`
+(Flyway is dormant in Docker). Entity↔schema drift here is what previously broke
+CU07/08 etc.; it is now guarded by `InitDbSchemaValidationIntegrationTest`
+(`mvn test -Ppg-integration`). See `.claude/rules/database-migrations.md`.
+
+## 6. Traceability
+
+| Artifact | Location |
+|----------|----------|
+| Actors | `docs/01-business/03-actors/` |
+| Use cases (detail) | `docs/01-business/02-use-cases/` |
+| Use-case progress | `docs/business/03_CU - Casos de Uso/Progreso Sistema - CASOS DE USO.csv` |
+| CU ↔ API ↔ test matrix | `docs/testing/CU-API-MATRIX.csv` |
+| Functional requirements | `docs/01-business/01-requirements/` (`requerimientos.csv`) |
+| Data model (detail) | `docs/01-business/04-data-model/` |
+| Authoritative Docker schema | `init-db/01-schema.sql` |
+| GitHub issue traceability | CU → #154–#221 |
+
+## 7. Recommendations (functional)
+
+1. **Build the Gestiones document/testimonio UI** (CU03/04/07/08/11/12) — backend is
+   ready; this is the largest functional gap and core notarial value.
+2. **Per-screen UI audit** to resolve ⚠️ flows into ✅ realized or ❌ missing, then
+   convert the corresponding E2E `test.skip` into active assertions.
+3. **Complete CU15 (Procesar pago) business logic** and add the missing contract tests
+   (CU22 POST suplencia; CU24/25/50 report endpoints).
+4. **Reconcile the dual schema source** (init-db vs Flyway) to a single source of truth.
+5. **Refresh `CU-API-MATRIX.csv`** — its 500-ERROR rows for testimonio/movimiento/
+   tipo-folio are now stale (resolved 2026-05-29).

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -89,6 +89,15 @@
     letter-spacing: -0.015em;
   }
 
+  /* Global keyboard focus indicator (WCAG: visible focus on all interactive
+     elements). :focus-visible targets keyboard navigation only, so pointer
+     interactions remain visually clean. Components with their own focus ring
+     still work; this is the accessible baseline for everything else. */
+  :focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+
   /* Apple-style scrollbar */
   ::-webkit-scrollbar {
     width: 8px;
@@ -154,9 +163,21 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto !important;
+  }
+
   *, *::before, *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  /* Neutralise the decorative button scale so motion-sensitive users get no
+     movement (the transforms are otherwise driven by transitions above). */
+  .apple-button:hover,
+  .apple-button:active {
+    transform: none !important;
   }
 }

--- a/init-db/01-schema.sql
+++ b/init-db/01-schema.sql
@@ -66,7 +66,9 @@ CREATE TABLE tipos_de_documento (
 CREATE TABLE tipos_de_folio (
   version integer NOT NULL,
   id_tipo_folio SERIAL PRIMARY KEY,
-  nombre text NOT NULL
+  nombre text NOT NULL,
+  observaciones text,
+  habilitado boolean NOT NULL DEFAULT true
 );
 
 -- Table: tipos_de_tramite
@@ -263,6 +265,7 @@ CREATE TABLE testimonios (
   numero_carpeta integer,
   numero_expediente integer,
   reingresado boolean NOT NULL,
+  observado boolean NOT NULL DEFAULT false,
   fk_id_escritura integer REFERENCES escrituras(id_escritura)
 );
 
@@ -302,8 +305,12 @@ CREATE TABLE folios_copias (
 -- Table: movimientos_testimonio
 CREATE TABLE movimientos_testimonio (
   version integer NOT NULL,
-  id_movimiento SERIAL PRIMARY KEY,
-  fecha_movimiento date NOT NULL,
+  id_movimiento_testimonio SERIAL PRIMARY KEY,
+  fecha_ingreso date NOT NULL,
+  fecha_salida date,
+  fecha_inscripcion date,
+  inscripta boolean NOT NULL DEFAULT false,
+  numero_carton integer NOT NULL DEFAULT 0,
   observaciones text,
   fk_id_testimonio integer REFERENCES testimonios(id_testimonio)
 );
@@ -316,6 +323,7 @@ CREATE TABLE items (
   valor real NOT NULL,
   porcentaje integer NOT NULL,
   concepto_fijo boolean NOT NULL,
+  observaciones text,
   fk_id_presupuesto integer REFERENCES presupuestos(id_presupuesto)
 );
 

--- a/init-db/01-schema.sql
+++ b/init-db/01-schema.sql
@@ -120,6 +120,14 @@ CREATE TABLE personas (
   es_escribano boolean NOT NULL DEFAULT false
 );
 
+-- Table: identificaciones (composite PK: persona + tipo de identificación)
+CREATE TABLE identificaciones (
+  fk_id_persona integer NOT NULL REFERENCES personas(id_persona),
+  fk_id_tipo_identificacion integer NOT NULL REFERENCES tipos_identificacion(id_tipo_identificacion),
+  numero integer NOT NULL,
+  PRIMARY KEY (fk_id_persona, fk_id_tipo_identificacion)
+);
+
 -- Table: inmuebles
 CREATE TABLE inmuebles (
   version integer NOT NULL,


### PR DESCRIPTION
## Summary

Full-stack quality-hardening pass, verified end-to-end (Docker stack + backend `mvn verify` + Playwright E2E). Delivered as scoped, individually-verified increments.

- **Fix broken API/E2E:** JPA entities referenced columns the Docker DB (`init-db/01-schema.sql`) lacked — Flyway migrations meant to add them never run in Docker. Aligned the schema → **Playwright E2E: 300 passed/23 failed → 323 passed/0 failed.**
- **Schema-drift guard:** added a Testcontainers test that validates entities against the real `init-db` schema (the H2 tests structurally couldn't); it found a second latent bug (missing `identificaciones` table), now fixed.
- **Coverage truth:** the "80% enforced" claim was false (gate bound to `<phase>none</phase>`; real ~29%/15%). Enabled a realistic **enforced ratchet floor** on `mvn verify` and corrected the docs.
- **A11y/UX:** global keyboard `:focus-visible` indicator + hardened `prefers-reduced-motion`.
- **Perf/logging:** quieted prod logging (Spring Security was hardcoded DEBUG, flooding logs per request).
- **Docs:** documented the init-db/Flyway dual-source reality; added a whole-system functional baseline (actors, 68-CU inventory with status, ERD).

## Changes

### Fixed
- `init-db/01-schema.sql` aligned with JPA entities: `testimonios.observado`; `movimientos_testimonio` (id/date renames + 4 cols); `tipos_de_folio.observaciones,habilitado`; `items.observaciones`; added `identificaciones` table. Resolves 500s on testimonio, movimiento-testimonio, tipo-folio, items, personas (CU07/08/10/12/36/40/44/58/68).

### Added
- `InitDbSchemaValidationIntegrationTest` (Testcontainers, real init-db schema, production-fidelity `ddl-auto=none`); run via `mvn test -Ppg-integration`.
- `PreviouslyBrokenEndpointsIntegrationTest` (H2 read/not-found coverage for the fixed controllers).
- Enforced JaCoCo ratchet gate (BUNDLE, 28% line / 14% branch) on `mvn verify`.
- Global `:focus-visible` outline; reduced-motion hardening.
- `docs/01-business/00-FUNCTIONAL-BASELINE.md` (actor map, 68-CU inventory, 28-table ERD).

### Modified
- Fixed the dead/broken `BaseIntegrationTest` (loads init-db via `/docker-entrypoint-initdb.d`).
- Removed invalid `spring.flyway.repair-at-start`; logging defaults → INFO (env-overridable).
- Corrected coverage claims in `CLAUDE.md`, `.claude/rules/code-quality.md`, `README.md`; documented schema source-of-truth in `CLAUDE.md` and `.claude/rules/database-migrations.md`.

## Testing
- Backend default suite: **421 passed / 0 failed**; `mvn verify` coverage gate met; spotbugs/checkstyle pass.
- `mvn test -Ppg-integration`: **6 passed / 0 failed**.
- Playwright E2E (full stack): **323 passed / 36 skipped / 0 failed**.

## Known / deferred (not in this PR)
- Reconcile the dual schema source (init-db vs Flyway) to a single source of truth.
- Build the Gestiones document/testimonio **UI** (CU03/04/07/08/11/12) — backend ready, frontend flow missing (the 36 skipped E2E).
- 25 hardcoded Apple-gray hex colors in table components (need token mapping + visual review).
- Coverage climb 29% → 80% (ratchet floor enforced in the meantime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)