### PR TITLE
[409] design: Framer Motion UI/UX polish (Apple-inspired animations)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.468.0",
+        "motion": "^12.40.0",
         "next": "^16.2.4",
         "next-intl": "^4.12.0",
         "react": "^19.0.0",
@@ -7050,6 +7051,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+      "integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.40.0",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -8645,6 +8673,47 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.40.0.tgz",
+      "integrity": "sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.40.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+      "integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.468.0",
+    "motion": "^12.40.0",
     "next": "^16.2.4",
     "next-intl": "^4.12.0",
     "react": "^19.0.0",

--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { AppSidebar } from "@/components/layout/AppSidebar";
 import { AppHeader } from "@/components/layout/AppHeader";
 import { useAuthStore } from "@/store/auth-store";
+import { AnimatePresence, PageTransition } from "@/components/motion";
 
 export default function DashboardLayout({
   children,
@@ -13,6 +14,7 @@ export default function DashboardLayout({
 }) {
   const { isAuthenticated } = useAuthStore();
   const router = useRouter();
+  const pathname = usePathname();
   // Delay auth check until after client hydration so Zustand can read localStorage.
   // Without this, the layout redirects before persist has loaded the stored auth state.
   const [mounted, setMounted] = useState(false);
@@ -35,7 +37,11 @@ export default function DashboardLayout({
       <AppSidebar />
       <div className="flex-1 flex flex-col">
         <AppHeader />
-        <main className="flex-1 overflow-y-auto p-6 lg:p-8">{children}</main>
+        <main className="flex-1 overflow-y-auto p-6 lg:p-8">
+          <AnimatePresence mode="wait" initial={false}>
+            <PageTransition key={pathname}>{children}</PageTransition>
+          </AnimatePresence>
+        </main>
       </div>
     </div>
   );

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ import { useTranslations, useLocale } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { NotaireIcon } from "@/components/ui/notaire-icon";
+import { Stagger, StaggerItem, HoverLift } from "@/components/motion";
 import { useAuthStore } from "@/store/auth-store";
 import { useGestiones } from "@/hooks/useGestiones";
 import { usePersonas } from "@/hooks/usePersonas";
@@ -56,16 +57,20 @@ export default function DashboardPage() {
   const visibleModules = modules.filter((m) => !m.adminOnly || isAdmin());
   const dateLocale = locale === "en" ? "en-US" : "es-AR";
 
+  const stats = [
+    { labelKey: "gestiones.label", value: gestiones?.length ?? 0, pngIcon: "/icons/modulos/gestion.png", tint: "bg-blue-500/10" },
+    { labelKey: "personas.label", value: personas?.length ?? 0, pngIcon: "/icons/modulos/clientes.png", tint: "bg-violet-500/10" },
+    { labelKey: "presupuestos.label", value: presupuestos?.length ?? 0, pngIcon: "/icons/modulos/presupuestos.png", tint: "bg-emerald-500/10" },
+  ] as const;
+
   return (
-    <div className="max-w-[1600px] mx-auto space-y-12 animate-in fade-in slide-in-from-bottom-4 duration-1000">
+    <div className="max-w-[1600px] mx-auto space-y-12">
       <div className="flex flex-col md:flex-row md:items-end justify-between gap-4">
         <div className="space-y-1.5">
           <h1 className="text-4xl font-semibold tracking-tight text-[#1d1d1f]">
             {td("hello")}, {user?.nombre?.split(" ")[0]}
           </h1>
-          <p className="text-xl text-[#86868b] font-medium">
-            {td("today")}
-          </p>
+          <p className="text-xl text-[#86868b] font-medium">{td("today")}</p>
         </div>
         <div className="bg-white/50 backdrop-blur-sm px-4 py-2 rounded-full border border-black/5 shadow-sm">
           <p className="text-sm font-semibold text-[#424245]">
@@ -74,43 +79,27 @@ export default function DashboardPage() {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <Card className="bg-white border-none apple-shadow rounded-[28px] overflow-hidden group hover:scale-[1.01] transition-transform duration-500">
-          <CardContent className="p-8 flex items-center justify-between">
-            <div className="space-y-1">
-              <p className="text-[13px] font-bold uppercase tracking-widest text-[#86868b]">{td("gestiones.label")}</p>
-              <p className="text-5xl font-semibold tracking-tighter text-[#1d1d1f]">{gestiones?.length ?? "0"}</p>
-            </div>
-            <div className="bg-blue-500/10 p-5 rounded-3xl">
-              <NotaireIcon src="/icons/modulos/gestion.png" alt={td("gestiones.label")} size={32} />
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="bg-white border-none apple-shadow rounded-[28px] overflow-hidden group hover:scale-[1.01] transition-transform duration-500">
-          <CardContent className="p-8 flex items-center justify-between">
-            <div className="space-y-1">
-              <p className="text-[13px] font-bold uppercase tracking-widest text-[#86868b]">{td("personas.label")}</p>
-              <p className="text-5xl font-semibold tracking-tighter text-[#1d1d1f]">{personas?.length ?? "0"}</p>
-            </div>
-            <div className="bg-violet-500/10 p-5 rounded-3xl">
-              <NotaireIcon src="/icons/modulos/clientes.png" alt={td("personas.label")} size={32} />
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="bg-white border-none apple-shadow rounded-[28px] overflow-hidden group hover:scale-[1.01] transition-transform duration-500">
-          <CardContent className="p-8 flex items-center justify-between">
-            <div className="space-y-1">
-              <p className="text-[13px] font-bold uppercase tracking-widest text-[#86868b]">{td("presupuestos.label")}</p>
-              <p className="text-5xl font-semibold tracking-tighter text-[#1d1d1f]">{presupuestos?.length ?? "0"}</p>
-            </div>
-            <div className="bg-emerald-500/10 p-5 rounded-3xl">
-              <NotaireIcon src="/icons/modulos/presupuestos.png" alt={td("presupuestos.label")} size={32} />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <Stagger className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {stats.map((stat) => (
+          <StaggerItem key={stat.labelKey}>
+            <HoverLift lift={4}>
+              <Card className="bg-white border-none apple-shadow rounded-[28px] overflow-hidden">
+                <CardContent className="p-8 flex items-center justify-between">
+                  <div className="space-y-1">
+                    <p className="text-[13px] font-bold uppercase tracking-widest text-[#86868b]">
+                      {td(stat.labelKey as Parameters<typeof td>[0])}
+                    </p>
+                    <p className="text-5xl font-semibold tracking-tighter text-[#1d1d1f]">{stat.value}</p>
+                  </div>
+                  <div className={`${stat.tint} p-5 rounded-3xl`}>
+                    <NotaireIcon src={stat.pngIcon} alt={td(stat.labelKey as Parameters<typeof td>[0])} size={32} />
+                  </div>
+                </CardContent>
+              </Card>
+            </HoverLift>
+          </StaggerItem>
+        ))}
+      </Stagger>
 
       <div className="space-y-6">
         <div className="flex items-center justify-between px-2">
@@ -120,35 +109,39 @@ export default function DashboardPage() {
           </Button>
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        <Stagger className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
           {visibleModules.map((mod) => {
             const Icon = mod.icon;
             return (
-              <Link key={mod.href} href={mod.href} className="group">
-                <Card className="h-full bg-white border-none apple-shadow rounded-[28px] hover:apple-shadow-lg transition-all duration-500 relative overflow-hidden">
-                  <div className={`absolute top-0 left-0 w-1.5 h-full bg-gradient-to-b ${mod.gradient} opacity-0 group-hover:opacity-100 transition-opacity duration-500`} />
-                  <CardHeader className="pb-4 p-8">
-                    <div className={`w-14 h-14 rounded-2xl flex items-center justify-center mb-6 bg-gradient-to-br ${mod.gradient} text-white shadow-lg shadow-blue-500/10 transition-transform duration-500 group-hover:scale-110`}>
-                      {mod.pngIcon ? (
-                        <NotaireIcon src={mod.pngIcon} alt={td(mod.labelKey as Parameters<typeof td>[0])} size={36} className="brightness-0 invert" />
-                      ) : Icon ? (
-                        <Icon className="h-7 w-7" />
-                      ) : null}
-                    </div>
-                    <CardTitle className="text-xl font-semibold text-[#1d1d1f] group-hover:text-[#0071e3] transition-colors duration-300">
-                      {td(mod.labelKey as Parameters<typeof td>[0])}
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="px-8 pb-8 pt-0">
-                    <CardDescription className="text-base text-[#86868b] leading-relaxed">
-                      {td(mod.descKey as Parameters<typeof td>[0])}
-                    </CardDescription>
-                  </CardContent>
-                </Card>
-              </Link>
+              <StaggerItem key={mod.href}>
+                <HoverLift className="h-full">
+                  <Link href={mod.href} className="group block h-full">
+                    <Card className="h-full bg-white border-none apple-shadow rounded-[28px] hover:apple-shadow-lg transition-shadow duration-500 relative overflow-hidden">
+                      <div className={`absolute top-0 left-0 w-1.5 h-full bg-gradient-to-b ${mod.gradient} opacity-0 group-hover:opacity-100 transition-opacity duration-500`} />
+                      <CardHeader className="pb-4 p-8">
+                        <div className={`w-14 h-14 rounded-2xl flex items-center justify-center mb-6 bg-gradient-to-br ${mod.gradient} text-white shadow-lg shadow-blue-500/10 transition-transform duration-500 group-hover:scale-110`}>
+                          {mod.pngIcon ? (
+                            <NotaireIcon src={mod.pngIcon} alt={td(mod.labelKey as Parameters<typeof td>[0])} size={36} className="brightness-0 invert" />
+                          ) : Icon ? (
+                            <Icon className="h-7 w-7" />
+                          ) : null}
+                        </div>
+                        <CardTitle className="text-xl font-semibold text-[#1d1d1f] group-hover:text-[#0071e3] transition-colors duration-300">
+                          {td(mod.labelKey as Parameters<typeof td>[0])}
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent className="px-8 pb-8 pt-0">
+                        <CardDescription className="text-base text-[#86868b] leading-relaxed">
+                          {td(mod.descKey as Parameters<typeof td>[0])}
+                        </CardDescription>
+                      </CardContent>
+                    </Card>
+                  </Link>
+                </HoverLift>
+              </StaggerItem>
             );
           })}
-        </div>
+        </Stagger>
       </div>
     </div>
   );

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Scale, Loader2 } from "lucide-react";
+import { motion } from "motion/react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -54,9 +55,14 @@ export default function LoginPage() {
       <div className="w-full max-w-[400px] space-y-8 animate-in fade-in duration-700">
         <div className="text-center space-y-4">
           <div className="flex justify-center">
-            <div className="bg-primary/10 p-4 rounded-[22px] shadow-sm">
+            <motion.div
+              className="bg-primary/10 p-4 rounded-[22px] shadow-sm"
+              initial={{ scale: 0.8, opacity: 0, rotate: -8 }}
+              animate={{ scale: 1, opacity: 1, rotate: 0 }}
+              transition={{ type: "spring", stiffness: 260, damping: 18 }}
+            >
               <Scale className="h-10 w-10 text-primary" />
-            </div>
+            </motion.div>
           </div>
           <div className="space-y-2">
             <h1 className="text-4xl font-semibold tracking-tight text-foreground">Notaire</h1>

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -3,11 +3,14 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { queryClient } from "@/lib/query-client";
+import { MotionConfig } from "motion/react";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
-      {children}
+      {/* reducedMotion="user" makes every motion primitive honour the OS
+          "Reduce Motion" accessibility setting automatically. */}
+      <MotionConfig reducedMotion="user">{children}</MotionConfig>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -11,6 +11,7 @@ import {
   Scale,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { motion } from "motion/react";
 import { cn } from "@/lib/utils";
 import { useAuthStore } from "@/store/auth-store";
 import { NotaireIcon } from "@/components/ui/notaire-icon";
@@ -97,24 +98,34 @@ export function AppSidebar() {
                 key={item.href}
                 href={item.href}
                 aria-label={label}
+                aria-current={active ? "page" : undefined}
                 className={cn(
-                  "flex items-center gap-3 px-4 py-2.5 rounded-[12px] text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1",
+                  "relative flex items-center gap-3 px-4 py-2.5 rounded-[12px] text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1",
                   active
-                    ? "bg-primary text-primary-foreground shadow-md shadow-primary/20"
+                    ? "text-primary-foreground"
                     : "text-[hsl(var(--sidebar-foreground))] hover:bg-[hsl(var(--sidebar-hover))] hover:text-[hsl(var(--sidebar-foreground))]"
                 )}
               >
-                {item.pngIcon ? (
-                  <NotaireIcon
-                    src={item.pngIcon}
-                    alt={label}
-                    size={20}
-                    className={cn("shrink-0", active ? "brightness-0 invert" : "")}
+                {active && (
+                  <motion.span
+                    layoutId="sidebar-active"
+                    className="absolute inset-0 rounded-[12px] bg-primary shadow-md shadow-primary/20"
+                    transition={{ type: "spring", stiffness: 380, damping: 32 }}
                   />
-                ) : Icon ? (
-                  <Icon className={cn("h-4 w-4 shrink-0", active ? "text-primary-foreground" : "text-[hsl(var(--sidebar-muted))]")} />
-                ) : null}
-                {label}
+                )}
+                <span className="relative z-10 flex items-center gap-3">
+                  {item.pngIcon ? (
+                    <NotaireIcon
+                      src={item.pngIcon}
+                      alt={label}
+                      size={20}
+                      className={cn("shrink-0", active ? "brightness-0 invert" : "")}
+                    />
+                  ) : Icon ? (
+                    <Icon className={cn("h-4 w-4 shrink-0", active ? "text-primary-foreground" : "text-[hsl(var(--sidebar-muted))]")} />
+                  ) : null}
+                  {label}
+                </span>
               </Link>
             );
           })}

--- a/frontend/src/components/motion/index.tsx
+++ b/frontend/src/components/motion/index.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+/**
+ * Motion primitives — Framer Motion (motion/react) wrappers tuned to the
+ * Apple design language used across Notaire.
+ *
+ * All animations are subtle, spring/ease-based and globally respect the user's
+ * `prefers-reduced-motion` setting (configured via <MotionConfig reducedMotion="user">
+ * in providers.tsx). Use these instead of ad-hoc motion.* declarations so the
+ * timing and easing stay consistent system-wide.
+ */
+
+import { motion, AnimatePresence, type Variants, type Transition } from "motion/react";
+import type { ReactNode } from "react";
+
+// Apple's standard easing curve (matches theme.transitions.timing.ease).
+export const easeApple = [0.4, 0, 0.2, 1] as const;
+
+export const springSoft: Transition = { type: "spring", stiffness: 260, damping: 26, mass: 0.9 };
+
+// ---------------------------------------------------------------------------
+// Variants
+// ---------------------------------------------------------------------------
+
+export const pageVariants: Variants = {
+  hidden: { opacity: 0, y: 10 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.4, ease: easeApple, when: "beforeChildren", staggerChildren: 0.045 },
+  },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.2, ease: easeApple } },
+};
+
+export const staggerContainer: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.05, delayChildren: 0.04 } },
+};
+
+export const fadeUpItem: Variants = {
+  hidden: { opacity: 0, y: 14 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.4, ease: easeApple } },
+};
+
+// ---------------------------------------------------------------------------
+// Components
+// ---------------------------------------------------------------------------
+
+interface MotionBoxProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/** Page-level entrance transition. Key it by pathname to re-run on navigation. */
+export function PageTransition({ children, className }: MotionBoxProps) {
+  return (
+    <motion.div className={className} initial="hidden" animate="visible" exit="exit" variants={pageVariants}>
+      {children}
+    </motion.div>
+  );
+}
+
+/** Container that staggers the entrance of its <StaggerItem> children. */
+export function Stagger({ children, className }: MotionBoxProps) {
+  return (
+    <motion.div className={className} initial="hidden" animate="visible" variants={staggerContainer}>
+      {children}
+    </motion.div>
+  );
+}
+
+/** Single item inside a <Stagger>. Fades and slides up in sequence. */
+export function StaggerItem({ children, className }: MotionBoxProps) {
+  return (
+    <motion.div className={className} variants={fadeUpItem}>
+      {children}
+    </motion.div>
+  );
+}
+
+/** Simple fade + rise on mount, with optional delay. */
+export function FadeIn({ children, className, delay = 0 }: MotionBoxProps & { delay?: number }) {
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: easeApple, delay }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+/** Interactive card wrapper with a tasteful hover lift and press feedback. */
+export function HoverLift({ children, className, lift = 6 }: MotionBoxProps & { lift?: number }) {
+  return (
+    <motion.div
+      className={className}
+      whileHover={{ y: -lift, transition: { ...springSoft } }}
+      whileTap={{ scale: 0.98 }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export { motion, AnimatePresence };

--- a/frontend/src/components/shared/DataTable.tsx
+++ b/frontend/src/components/shared/DataTable.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Table as TableIcon } from "lucide-react";
+import { motion } from "motion/react";
 import {
   Table,
   TableBody,
@@ -8,6 +10,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+
+const MotionTableRow = motion.create(TableRow);
 
 export interface Column<T> {
   key: string;
@@ -72,9 +76,12 @@ export function DataTable<T>({
               </TableCell>
             </TableRow>
           ) : (
-            data.map((row) => (
-              <TableRow
+            data.map((row, i) => (
+              <MotionTableRow
                 key={keyExtractor(row)}
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1], delay: Math.min(i * 0.03, 0.3) }}
                 className="border-b border-border/20 last:border-0 hover:bg-[#F5F5F7]/30 transition-colors duration-200 group"
               >
                 {columns.map((col) => (
@@ -82,7 +89,7 @@ export function DataTable<T>({
                     {col.render(row)}
                   </TableCell>
                 ))}
-              </TableRow>
+              </MotionTableRow>
             ))
           )}
         </TableBody>
@@ -90,8 +97,6 @@ export function DataTable<T>({
     </div>
   );
 }
-
-import { Table as TableIcon } from "lucide-react";
 
 function cn(...classes: (string | undefined | false)[]) {
   return classes.filter(Boolean).join(" ");


### PR DESCRIPTION
## Summary
- Introduces **Framer Motion** (`motion@12`, React 19 compatible) with a small, reusable, reduced-motion-aware primitives library and weaves it through the **shared infrastructure** so every concept page benefits.
- Keeps the centralized Apple design system (theme tokens + form patterns) as the single source of truth — no new hardcoded values.

## Changes
### Added
- `src/components/motion/index.tsx` — `PageTransition`, `Stagger`/`StaggerItem`, `FadeIn`, `HoverLift`, shared Apple easing + spring presets.
- Global `<MotionConfig reducedMotion="user">` in `providers.tsx` (honours OS *Reduce Motion*).

### Modified
- **DataTable**: staggered row entrance via `motion.create(TableRow)` — system-wide list polish across every concept page.
- **Dashboard layout**: route-aware page transitions (`AnimatePresence` keyed by pathname).
- **Dashboard**: staggered stat cards + module grid with spring hover-lift; de-duplicated the three stat cards into a mapped array.
- **Sidebar**: signature sliding active-route indicator via shared `layoutId` + `aria-current`.
- **Login**: spring pop-in on the brand mark.

## Testing
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — **109/109** unit tests pass
- [x] `npm run build` — succeeds (29/29 pages)

> Note: the repo's `npm run lint` (`next lint` + legacy `.eslintrc.json`) is broken on `main` due to the Next 16 / ESLint 9 deprecation and is out of scope here; the production build skips linting.

## Follow-ups (not in this PR)
- Add edit/delete to the three list-only admin catalog pages (estados-gestión, folios, plantillas); they currently support create + list. Tracked separately.

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)