### PR TITLE
[#418] fix: widen CuCheck.path type to fix tsc build error in E2E suite

### DIFF
--- a/frontend/tests/e2e/cu-matrix.spec.ts
+++ b/frontend/tests/e2e/cu-matrix.spec.ts
@@ -19,7 +19,7 @@ interface CuCheck {
   id: string;
   name: string;
   method: "GET" | "POST" | "PUT" | "DELETE" | "SEARCH";
-  path: string | ((page: Page) => Promise<string>);
+  path: string | ((page: Page) => string | Promise<string>);
   expectStatus?: number;
   skipIf?: boolean;
 }


### PR DESCRIPTION
## Summary
- Fixes the only hard build error found while validating `main`: **6 TypeScript errors** in `tests/e2e/cu-matrix.spec.ts` where the `CuCheck.path` type rejected the synchronous `() => string` resolvers used by several CU checks.

## Change
```ts
- path: string | ((page: Page) => Promise<string>);
+ path: string | ((page: Page) => string | Promise<string>);
```
The consumer already `await`s either form (`typeof cu.path === "function" ? await cu.path(page) : cu.path`), so this is purely a type widening — no runtime change.

## Testing
- `tsc --noEmit`: **No errors found** (was 6).
- vitest: 218 passed.
- Full `main` audit (context): `mvn clean install` green (430 backend tests, checkstyle, jacoco "All coverage checks met"), `next build` ok, swing 14 — this type error was the only failure.

## Notes
Checkstyle reports pre-existing non-blocking style warnings (`failOnViolation=false`) and SpotBugs is skipped on this JDK — both out of scope.

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)