### PR TITLE
[#426] fix: fix 500 error when creating documentos presentados

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/DocumentoPresentadoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/DocumentoPresentadoController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.List;
 
@@ -42,16 +43,31 @@ public class DocumentoPresentadoController {
         this.tipoRepository = tipoRepository;
     }
 
+    private DocumentoPresentado toEntity(DocumentoPresentadoRequest request) {
+        DocumentoPresentado entity = new DocumentoPresentado();
+        entity.setFkIdTipoDocumento(request.tipoId());
+        entity.setEntregado(request.entregado() != null ? request.entregado() : false);
+        entity.setNombre("");
+        entity.setQuienEntrega("");
+        entity.setPreparado(false);
+        entity.setVence(false);
+        if (request.fecha() != null) {
+            try {
+                entity.setFechaIngreso(DATE_FORMAT.parse(request.fecha()));
+            } catch (ParseException e) {
+                log.warn("Invalid fecha format: {}", request.fecha());
+            }
+        }
+        return entity;
+    }
+
     private DocumentoPresentadoResponse toResponse(DocumentoPresentado d) {
         TipoDocInfo tipo = null;
-        try {
-            // getFkIdTipoDocumento() returns primitive int — NPEs when the DB column is NULL
-            int tipoId = d.getFkIdTipoDocumento();
+        Integer tipoId = d.getFkIdTipoDocumentoNullable();
+        if (tipoId != null) {
             tipo = tipoRepository.findById(tipoId)
                     .map(t -> new TipoDocInfo(t.getIdTipoDocumento(), t.getNombre()))
                     .orElse(null);
-        } catch (NullPointerException e) {
-            log.debug("fk_id_tipo_documento is NULL for documento {}", d.getIdDocumentoPresentado());
         }
         String fecha = d.getFechaIngreso() != null ? DATE_FORMAT.format(d.getFechaIngreso()) : null;
         return new DocumentoPresentadoResponse(d.getIdDocumentoPresentado(), tipo, fecha, d.getEntregado());
@@ -74,8 +90,9 @@ public class DocumentoPresentadoController {
 
     @PostMapping
     @Operation(summary = "Crear nuevo documento presentado")
-    public ResponseEntity<Object> create(@RequestBody DocumentoPresentado entity) {
+    public ResponseEntity<Object> create(@RequestBody DocumentoPresentadoRequest request) {
         try {
+            DocumentoPresentado entity = toEntity(request);
             entity = repository.save(entity);
             return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(entity));
         } catch (Exception e) {
@@ -86,11 +103,12 @@ public class DocumentoPresentadoController {
 
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar documento presentado")
-    public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody DocumentoPresentado entity) {
+    public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody DocumentoPresentadoRequest request) {
         if (!repository.existsById(id)) {
             return ResponseEntity.notFound().build();
         }
         try {
+            DocumentoPresentado entity = toEntity(request);
             entity.setIdDocumentoPresentado(id);
             repository.save(entity);
             return ResponseEntity.ok().build();

--- a/backend-api/src/main/java/com/licensis/notaire/negocio/DocumentoPresentado.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/DocumentoPresentado.java
@@ -110,7 +110,7 @@ public class DocumentoPresentado implements Serializable
     @Column(name = "observaciones")
     private String observaciones;
     @JoinColumn(name = "fk_id_tramite", referencedColumnName = "id_tramite")
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @ManyToOne(optional = true, fetch = FetchType.LAZY)
     private Tramite fkIdTramite;
 
     public DocumentoPresentado()
@@ -417,6 +417,11 @@ public class DocumentoPresentado implements Serializable
     }
 
     public int getFkIdTipoDocumento()
+    {
+        return fkIdTipoDocumento;
+    }
+
+    public Integer getFkIdTipoDocumentoNullable()
     {
         return fkIdTipoDocumento;
     }

--- a/backend-api/src/main/resources/db/migration/V6__make_documentos_presentados_tramite_optional.sql
+++ b/backend-api/src/main/resources/db/migration/V6__make_documentos_presentados_tramite_optional.sql
@@ -1,0 +1,18 @@
+-- =============================================================================
+-- V6__make_documentos_presentados_tramite_optional.sql
+-- =============================================================================
+-- Author: Matias Miguez
+-- Date: 2026-06-05
+-- Description: Make fk_id_tramite nullable in documentos_presentados so that
+--              standalone documents can be created from the Documentos UI
+--              without requiring a tramite association upfront.
+--              Also relaxes reingresado to allow NULL for the same reason.
+-- =============================================================================
+
+-- Allow fk_id_tramite to be NULL
+ALTER TABLE documentos_presentados
+    ALTER COLUMN fk_id_tramite DROP NOT NULL;
+
+-- Allow reingresado to be NULL (entity field is Boolean, not primitive)
+ALTER TABLE documentos_presentados
+    ALTER COLUMN reingresado DROP NOT NULL;

--- a/backend-api/src/test/java/com/licensis/notaire/integration/DocumentoPresentadoControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/DocumentoPresentadoControllerTest.java
@@ -1,0 +1,135 @@
+package com.licensis.notaire.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@ActiveProfiles("test-h2")
+@DisplayName("DocumentoPresentado controller — create/update/delete via DTO")
+class DocumentoPresentadoControllerTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    @Test
+    @DisplayName("Should return 201 when creating documento presentado with tipoId, fecha and entregado")
+    void shouldCreateDocumentoPresentadoWithDtoFields() throws Exception {
+        String body = """
+                {"tipoId": null, "fecha": "2024-06-01", "entregado": false}
+                """;
+
+        mockMvc.perform(post("/api/v1/documento-presentado")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.idDocumentoPresentado").isNumber())
+                .andExpect(jsonPath("$.entregado").value(false));
+    }
+
+    @Test
+    @DisplayName("Should return 201 when creating documento presentado with entregado true")
+    void shouldCreateDocumentoPresentadoEntregado() throws Exception {
+        String body = """
+                {"tipoId": null, "fecha": "2024-07-15", "entregado": true}
+                """;
+
+        mockMvc.perform(post("/api/v1/documento-presentado")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.entregado").value(true));
+    }
+
+    @Test
+    @DisplayName("Should return 200 when listing documentos presentados")
+    void shouldListDocumentosPresentados() throws Exception {
+        mockMvc.perform(get("/api/v1/documento-presentado"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    @DisplayName("Should return 200 and update documento presentado")
+    void shouldUpdateDocumentoPresentado() throws Exception {
+        String createBody = """
+                {"tipoId": null, "fecha": "2024-01-01", "entregado": false}
+                """;
+
+        MvcResult result = mockMvc.perform(post("/api/v1/documento-presentado")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createBody))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        Integer id = mapper.readTree(response).get("idDocumentoPresentado").asInt();
+
+        String updateBody = """
+                {"tipoId": null, "fecha": "2024-12-31", "entregado": true}
+                """;
+
+        mockMvc.perform(put("/api/v1/documento-presentado/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateBody))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should return 404 when updating non-existent documento presentado")
+    void shouldReturn404WhenUpdatingMissingDocumento() throws Exception {
+        String body = """
+                {"tipoId": null, "fecha": "2024-01-01", "entregado": false}
+                """;
+
+        mockMvc.perform(put("/api/v1/documento-presentado/999999")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Should return 200 and delete an existing documento presentado")
+    void shouldDeleteDocumentoPresentado() throws Exception {
+        String createBody = """
+                {"tipoId": null, "fecha": "2024-05-10", "entregado": false}
+                """;
+
+        MvcResult result = mockMvc.perform(post("/api/v1/documento-presentado")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createBody))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        Integer id = mapper.readTree(result.getResponse().getContentAsString())
+                .get("idDocumentoPresentado").asInt();
+
+        mockMvc.perform(delete("/api/v1/documento-presentado/" + id))
+                .andExpect(status().isOk());
+    }
+}

--- a/frontend/src/app/dashboard/documentos/page.tsx
+++ b/frontend/src/app/dashboard/documentos/page.tsx
@@ -59,9 +59,9 @@ export default function DocumentosPage() {
   }
 
   async function handleSave() {
-    const data: Partial<DocumentoPresentado> = {
-      tipo: form.tipoId ? { idTipoDocumento: Number(form.tipoId) } as TipoDeDocumento : undefined,
-      fecha: form.fecha || undefined,
+    const data = {
+      tipoId: form.tipoId ? Number(form.tipoId) : null,
+      fecha: form.fecha || null,
       entregado: form.entregado,
     };
     try {

--- a/frontend/src/hooks/useDocumentosPresentados.ts
+++ b/frontend/src/hooks/useDocumentosPresentados.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiGet, apiPost, apiPut, apiDelete } from "@/lib/api-client";
-import type { DocumentoPresentado } from "@/types";
+import type { DocumentoPresentado, DocumentoPresentadoRequest } from "@/types";
 
 export const documentosPresentadosKeys = {
   all: ["documentosPresentados"] as const,
@@ -17,7 +17,7 @@ export function useDocumentosPresentados() {
 export function useCreateDocumentoPresentado() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: Partial<DocumentoPresentado>) => apiPost<void>("/documento-presentado", data),
+    mutationFn: (data: DocumentoPresentadoRequest) => apiPost<DocumentoPresentado>("/documento-presentado", data),
     onSuccess: () => qc.invalidateQueries({ queryKey: documentosPresentadosKeys.all }),
   });
 }
@@ -25,7 +25,7 @@ export function useCreateDocumentoPresentado() {
 export function useUpdateDocumentoPresentado() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, data }: { id: number; data: Partial<DocumentoPresentado> }) =>
+    mutationFn: ({ id, data }: { id: number; data: DocumentoPresentadoRequest }) =>
       apiPut<void>(`/documento-presentado/${id}`, data),
     onSuccess: () => qc.invalidateQueries({ queryKey: documentosPresentadosKeys.all }),
   });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -89,6 +89,12 @@ export interface DocumentoPresentado {
   fecha?: string;
 }
 
+export interface DocumentoPresentadoRequest {
+  tipoId: number | null;
+  fecha: string | null;
+  entregado: boolean;
+}
+
 export interface Historial {
   idHistorial?: number;
   estado?: EstadoDeGestion;

--- a/init-db/01-schema.sql
+++ b/init-db/01-schema.sql
@@ -255,9 +255,9 @@ CREATE TABLE documentos_presentados (
   observado boolean NOT NULL,
   observaciones text,
   entregado boolean DEFAULT false,
-  reingresado boolean NOT NULL,
+  reingresado boolean,
   quien_entrega text NOT NULL,
-  fk_id_tramite integer NOT NULL REFERENCES tramites(id_tramite),
+  fk_id_tramite integer REFERENCES tramites(id_tramite),
   fk_id_tipo_documento integer REFERENCES tipos_de_documento(id_tipo_documento)
 );
 


### PR DESCRIPTION
## Summary
- Introduced `DocumentoPresentadoRequest` DTO (`tipoId`, `fecha`, `entregado`) replacing raw entity in request body
- Added `toEntity()` mapper that sets all required fields with safe defaults
- Made `fk_id_tramite` and `reingresado` nullable to support standalone document creation
- Fixed NPE in `toResponse()` when `fkIdTipoDocumento` is null
- Updated frontend to send the new flat request format and added proper TypeScript type

## Testing
- [x] 6 TDD integration tests written first (confirmed failing), all now passing
- [x] Full `mvn verify -pl backend-api` passes
- [x] Flyway V6 migration added for DB schema change
- [x] `init-db/01-schema.sql` updated (Docker authoritative schema)

## Checklist
- [x] DTO boundary: controller no longer exposes JPA entity in request body
- [x] No hardcoded secrets
- [x] KIS and SRP applied
- [x] No dead code

Fixes #426