### PR TITLE
[#429] fix: add estado selector and required FK fields to Folio form

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/FolioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/FolioController.java
@@ -1,17 +1,22 @@
 package com.licensis.notaire.api;
 
 import com.licensis.notaire.dto.DtoFolio;
-import com.licensis.notaire.jpa.FolioJpaController;
-import com.licensis.notaire.config.JpaControllerProvider;
 import com.licensis.notaire.negocio.Folio;
+import com.licensis.notaire.negocio.Persona;
+import com.licensis.notaire.negocio.TipoDeFolio;
+import com.licensis.notaire.repository.FolioRepository;
+import com.licensis.notaire.repository.PersonaRepository;
+import com.licensis.notaire.repository.TipoDeFolioRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/v1/folio")
@@ -20,18 +25,32 @@ public class FolioController {
 
     private static final Logger log = LoggerFactory.getLogger(FolioController.class);
 
-    private FolioJpaController getJpaController() {
-        return new FolioJpaController(null, JpaControllerProvider.getEntityManagerFactory());
+    record FolioRequest(
+            int numero,
+            int anio,
+            String estado,
+            String observaciones,
+            Integer tipoFolioId,
+            Integer escribanoId
+    ) {}
+
+    private final FolioRepository folioRepository;
+    private final TipoDeFolioRepository tipoDeFolioRepository;
+    private final PersonaRepository personaRepository;
+
+    public FolioController(FolioRepository folioRepository,
+                           TipoDeFolioRepository tipoDeFolioRepository,
+                           PersonaRepository personaRepository) {
+        this.folioRepository = folioRepository;
+        this.tipoDeFolioRepository = tipoDeFolioRepository;
+        this.personaRepository = personaRepository;
     }
-    // JpaController instantiated dynamically
 
     @GetMapping
-    @Operation(summary = "Obtener todos los folio")
+    @Operation(summary = "Obtener todos los folios")
     public ResponseEntity<List<DtoFolio>> getAll() {
         try {
-            // Map to DTOs: serializing raw entities fails because their lazy
-            // associations are uninitialized Hibernate proxies.
-            List<DtoFolio> result = getJpaController().findFolioEntities().stream()
+            List<DtoFolio> result = folioRepository.findAll().stream()
                     .map(Folio::getDto)
                     .toList();
             return ResponseEntity.ok(result);
@@ -44,50 +63,85 @@ public class FolioController {
     @GetMapping("/{id}")
     @Operation(summary = "Obtener folio por ID")
     public ResponseEntity<DtoFolio> getById(@PathVariable Integer id) {
-        try {
-            Folio folio = getJpaController().findFolio(id);
-            if (folio == null) {
-                return ResponseEntity.notFound().build();
-            }
-            return ResponseEntity.ok(folio.getDto());
-        } catch (Exception e) {
-            return ResponseEntity.notFound().build();
-        }
+        return folioRepository.findById(id)
+                .map(f -> ResponseEntity.ok(f.getDto()))
+                .orElse(ResponseEntity.notFound().build());
     }
 
     @PostMapping
     @Operation(summary = "Crear nuevo folio")
-    public ResponseEntity<Object> create(@RequestBody Folio entity) {
+    public ResponseEntity<DtoFolio> create(@RequestBody FolioRequest request) {
+        if (request.tipoFolioId() == null || request.escribanoId() == null) {
+            return ResponseEntity.badRequest().build();
+        }
+        Optional<TipoDeFolio> tipo = tipoDeFolioRepository.findById(request.tipoFolioId());
+        Optional<Persona> escribano = personaRepository.findById(request.escribanoId());
+        if (tipo.isEmpty() || escribano.isEmpty()) {
+            return ResponseEntity.badRequest().build();
+        }
         try {
-            getJpaController().create(entity);
-            return ResponseEntity.status(HttpStatus.CREATED).body(entity);
+            Folio folio = new Folio();
+            folio.setNumero(request.numero());
+            folio.setAnio(request.anio());
+            folio.setEstado(request.estado());
+            folio.setObservaciones(request.observaciones());
+            folio.setFkIdTipoFolio(tipo.get());
+            folio.setFkIdPersonaEscribano(escribano.get());
+            Folio saved = folioRepository.save(folio);
+            return ResponseEntity.status(HttpStatus.CREATED).body(saved.getDto());
         } catch (Exception e) {
             log.error("Failed to create folio", e);
-            e.printStackTrace();
             return ResponseEntity.internalServerError().build();
         }
     }
 
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar folio")
-    public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody Folio entity) {
+    public ResponseEntity<DtoFolio> update(@PathVariable Integer id, @RequestBody FolioRequest request) {
+        Optional<Folio> existing = folioRepository.findById(id);
+        if (existing.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        Folio folio = existing.get();
+        folio.setNumero(request.numero());
+        folio.setAnio(request.anio());
+        folio.setEstado(request.estado());
+        folio.setObservaciones(request.observaciones());
+        if (request.tipoFolioId() != null) {
+            tipoDeFolioRepository.findById(request.tipoFolioId()).ifPresent(folio::setFkIdTipoFolio);
+        }
+        if (request.escribanoId() != null) {
+            personaRepository.findById(request.escribanoId()).ifPresent(folio::setFkIdPersonaEscribano);
+        }
         try {
-            entity.setIdFolio(id);
-            getJpaController().edit(entity);
-            return ResponseEntity.ok().build();
+            Folio saved = folioRepository.save(folio);
+            return ResponseEntity.ok(saved.getDto());
         } catch (Exception e) {
+            log.error("Failed to update folio {}", id, e);
             return ResponseEntity.internalServerError().build();
         }
     }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar folio")
+    @Transactional
     public ResponseEntity<Void> delete(@PathVariable Integer id) {
+        Optional<Folio> opt = folioRepository.findById(id);
+        if (opt.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
         try {
-            getJpaController().destroy(id);
-            return ResponseEntity.ok().build();
+            Folio folio = opt.get();
+            // TipoDeFolio.folioList is EAGER + CascadeType.ALL: Hibernate 6 would cascade-persist
+            // the removed entity back through that collection. Remove it first.
+            if (folio.getFkIdTipoFolio() != null && folio.getFkIdTipoFolio().getFolioList() != null) {
+                folio.getFkIdTipoFolio().getFolioList().remove(folio);
+            }
+            folioRepository.delete(folio);
+            return ResponseEntity.noContent().build();
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+            log.error("Failed to delete folio {}", id, e);
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
         }
     }
 }

--- a/backend-api/src/test/java/com/licensis/notaire/integration/BusinessWorkflowIntegrationTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/BusinessWorkflowIntegrationTest.java
@@ -384,9 +384,9 @@ class BusinessWorkflowIntegrationTest {
                                     {
                                       "numero": 9001,
                                       "anio": 2025,
-                                      "estado": "ACTIVO",
-                                      "fkIdPersonaEscribano": {"idPersona": 1},
-                                      "fkIdTipoFolio": {"idTipoFolio": 1}
+                                      "estado": "Nuevo",
+                                      "tipoFolioId": 1,
+                                      "escribanoId": 1
                                     }
                                     """))
                     .andExpect(status().isCreated());

--- a/backend-api/src/test/java/com/licensis/notaire/integration/FolioControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/FolioControllerTest.java
@@ -1,0 +1,166 @@
+package com.licensis.notaire.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@ActiveProfiles("test-h2")
+@DisplayName("CU28/CU33/CU63 — Folio CRUD with valid estados and required fields")
+class FolioControllerTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    /** Valid body with all required fields */
+    private String validBody(int numero, String estado) {
+        return """
+                {
+                  "numero": %d,
+                  "anio": 2026,
+                  "estado": "%s",
+                  "tipoFolioId": 1,
+                  "escribanoId": 1
+                }
+                """.formatted(numero, estado);
+    }
+
+    @Test
+    @DisplayName("Should create folio with estado Nuevo")
+    void shouldCreateFolioWithEstadoNuevo() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/folio")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody(9001, "Nuevo")))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        assertThat(mapper.readTree(response).get("estado").asText()).isEqualTo("Nuevo");
+    }
+
+    @Test
+    @DisplayName("Should create folio with estado Utilizado")
+    void shouldCreateFolioWithEstadoUtilizado() throws Exception {
+        mockMvc.perform(post("/api/v1/folio")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody(9002, "Utilizado")))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("Should create folio with estado Errose")
+    void shouldCreateFolioWithEstadoErrose() throws Exception {
+        mockMvc.perform(post("/api/v1/folio")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody(9003, "Errose")))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when tipoFolioId is missing")
+    void shouldReturn400WhenTipoFolioIdMissing() throws Exception {
+        String body = """
+                {"numero": 9004, "anio": 2026, "estado": "Nuevo", "escribanoId": 1}
+                """;
+        mockMvc.perform(post("/api/v1/folio")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when escribanoId is missing")
+    void shouldReturn400WhenEscribanoIdMissing() throws Exception {
+        String body = """
+                {"numero": 9005, "anio": 2026, "estado": "Nuevo", "tipoFolioId": 1}
+                """;
+        mockMvc.perform(post("/api/v1/folio")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Should list all folios")
+    void shouldListFolios() throws Exception {
+        mockMvc.perform(post("/api/v1/folio").contentType(MediaType.APPLICATION_JSON).content(validBody(9006, "Nuevo")))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/folio"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    @DisplayName("Should update folio estado from Nuevo to Utilizado")
+    void shouldUpdateFolioEstado() throws Exception {
+        MvcResult create = mockMvc.perform(post("/api/v1/folio")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody(9007, "Nuevo")))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Integer id = mapper.readTree(create.getResponse().getContentAsString()).get("idFolio").asInt();
+
+        String updateBody = """
+                {"numero": 9007, "anio": 2026, "estado": "Utilizado", "tipoFolioId": 1, "escribanoId": 1}
+                """;
+        MvcResult update = mockMvc.perform(put("/api/v1/folio/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateBody))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertThat(mapper.readTree(update.getResponse().getContentAsString()).get("estado").asText())
+                .isEqualTo("Utilizado");
+    }
+
+    @Test
+    @DisplayName("Should delete folio and return 404 on subsequent GET")
+    void shouldDeleteFolioAndReturnNotFound() throws Exception {
+        MvcResult create = mockMvc.perform(post("/api/v1/folio")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody(9008, "Nuevo")))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Integer id = mapper.readTree(create.getResponse().getContentAsString()).get("idFolio").asInt();
+
+        mockMvc.perform(delete("/api/v1/folio/" + id))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/v1/folio/" + id))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Should return 404 when deleting non-existent folio")
+    void shouldReturn404WhenDeletingNonExistentFolio() throws Exception {
+        mockMvc.perform(delete("/api/v1/folio/999999"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -406,8 +406,16 @@
         "numero": "Number",
         "tipo": "Type",
         "estado": "Status",
-        "year": "Year"
-      }
+        "year": "Year",
+        "escribano": "Notary",
+        "estadoPlaceholder": "Select status",
+        "tipoPlaceholder": "Select type",
+        "escribanoPlaceholder": "Select notary"
+      },
+      "updated": "Folio updated",
+      "deleted": "Folio deleted",
+      "errorDelete": "Error deleting folio",
+      "editFolio": "Edit Folio"
     },
     "tramites": {
       "title": "Case Types",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -406,8 +406,16 @@
         "numero": "Número",
         "tipo": "Tipo",
         "estado": "Estado",
-        "year": "Año"
-      }
+        "year": "Año",
+        "escribano": "Escribano",
+        "estadoPlaceholder": "Seleccionar estado",
+        "tipoPlaceholder": "Seleccionar tipo",
+        "escribanoPlaceholder": "Seleccionar escribano"
+      },
+      "updated": "Folio actualizado",
+      "deleted": "Folio eliminado",
+      "errorDelete": "Error al eliminar el folio",
+      "editFolio": "Editar Folio"
     },
     "tramites": {
       "title": "Tipos de Trámite",

--- a/frontend/src/app/dashboard/administracion/folios/page.tsx
+++ b/frontend/src/app/dashboard/administracion/folios/page.tsx
@@ -9,13 +9,33 @@ import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { FormContainer, FormSection, FormField, FormActions } from "@/theme/form-patterns";
 import { useQuery } from "@tanstack/react-query";
 import { apiGet, apiPost, apiPut, apiDelete } from "@/lib/api-client";
-import type { Folio } from "@/types";
+import type { Folio, Persona } from "@/types";
 
-const EMPTY: Partial<Folio> = { numero: undefined, anio: new Date().getFullYear(), estado: "", observaciones: "" };
+const ESTADOS_FOLIO = ["Nuevo", "Utilizado", "Errose"] as const;
+
+interface FolioFormState {
+  idFolio?: number;
+  numero?: number;
+  anio?: number;
+  estado: string;
+  observaciones: string;
+  tipoFolioId?: number;
+  escribanoId?: number;
+}
+
+const EMPTY: FolioFormState = {
+  numero: undefined,
+  anio: new Date().getFullYear(),
+  estado: "Nuevo",
+  observaciones: "",
+  tipoFolioId: undefined,
+  escribanoId: undefined,
+};
 
 export default function FoliosAdminPage() {
   const t = useTranslations("administracion.folios");
@@ -26,40 +46,68 @@ export default function FoliosAdminPage() {
     queryFn: () => apiGet<Folio[]>("/folio"),
   });
 
+  const { data: tiposFolio = [] } = useQuery({
+    queryKey: ["tipos-folio"],
+    queryFn: () => apiGet<{ idTipoFolio: number; nombre: string }[]>("/tipo-folio"),
+  });
+
+  const { data: escribanos = [] } = useQuery({
+    queryKey: ["escribanos-disponibles"],
+    queryFn: () => apiGet<Persona[]>("/escrituras/escribanos-disponibles"),
+  });
+
   const [modalOpen, setModalOpen] = useState(false);
-  const [editing, setEditing] = useState<Partial<Folio>>(EMPTY);
+  const [form, setForm] = useState<FolioFormState>(EMPTY);
   const [isEditMode, setIsEditMode] = useState(false);
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
   function openCreate() {
-    setEditing(EMPTY);
+    setForm(EMPTY);
     setIsEditMode(false);
     setModalOpen(true);
   }
 
   function openEdit(folio: Folio) {
-    setEditing(folio);
+    setForm({
+      idFolio: folio.idFolio,
+      numero: folio.numero,
+      anio: folio.anio,
+      estado: folio.estado ?? "Nuevo",
+      observaciones: folio.observaciones ?? "",
+      tipoFolioId: folio.tiposDeFolio?.idTipoFolio,
+      escribanoId: folio.personaEscribano?.idPersona,
+    });
     setIsEditMode(true);
     setModalOpen(true);
   }
 
   async function handleSave() {
-    if (editing.numero === undefined || editing.numero === null || Number.isNaN(editing.numero)) {
+    if (form.numero === undefined || form.numero === null || Number.isNaN(form.numero)) {
       toast.error(t("numberRequired"));
+      return;
+    }
+    if (!form.tipoFolioId) {
+      toast.error(t("fields.tipo") + " " + tc("required"));
+      return;
+    }
+    if (!form.escribanoId) {
+      toast.error(t("fields.escribano") + " " + tc("required"));
       return;
     }
     setSaving(true);
     try {
       const body = {
-        numero: editing.numero,
-        anio: editing.anio,
-        estado: editing.estado,
-        observaciones: editing.observaciones,
+        numero: form.numero,
+        anio: form.anio,
+        estado: form.estado,
+        observaciones: form.observaciones,
+        tipoFolioId: form.tipoFolioId,
+        escribanoId: form.escribanoId,
       };
-      if (isEditMode && editing.idFolio) {
-        await apiPut(`/folio/${editing.idFolio}`, body);
+      if (isEditMode && form.idFolio) {
+        await apiPut(`/folio/${form.idFolio}`, body);
         toast.success(t("updated"));
       } else {
         await apiPost("/folio", body);
@@ -93,7 +141,7 @@ export default function FoliosAdminPage() {
     { key: "id", header: tc("id"), render: (f) => <span className="text-xs text-muted-foreground">{f.idFolio}</span>, className: "w-12" },
     { key: "numero", header: t("fields.numero"), render: (f) => <span className="font-medium">{f.numero}</span> },
     { key: "anio", header: tc("year"), render: (f) => f.anio ?? "—" },
-    { key: "tipo", header: t("fields.tipo"), render: (f) => f.tipoDeFolio?.nombre ?? "—" },
+    { key: "tipo", header: t("fields.tipo"), render: (f) => f.tiposDeFolio?.nombre ?? f.tipoDeFolio?.nombre ?? "—" },
     {
       key: "estado",
       header: t("fields.estado"),
@@ -144,8 +192,8 @@ export default function FoliosAdminPage() {
               <FormField label={t("fields.numero")} required>
                 <Input
                   type="number"
-                  value={editing.numero ?? ""}
-                  onChange={(e) => setEditing({ ...editing, numero: e.target.value === "" ? undefined : Number(e.target.value) })}
+                  value={form.numero ?? ""}
+                  onChange={(e) => setForm({ ...form, numero: e.target.value === "" ? undefined : Number(e.target.value) })}
                   placeholder="1001"
                   data-testid="input-numero-folio"
                 />
@@ -153,16 +201,60 @@ export default function FoliosAdminPage() {
               <FormField label={tc("year")}>
                 <Input
                   type="number"
-                  value={editing.anio ?? ""}
-                  onChange={(e) => setEditing({ ...editing, anio: e.target.value === "" ? undefined : Number(e.target.value) })}
+                  value={form.anio ?? ""}
+                  onChange={(e) => setForm({ ...form, anio: e.target.value === "" ? undefined : Number(e.target.value) })}
                   placeholder={String(new Date().getFullYear())}
                 />
               </FormField>
-              <FormField label={t("fields.estado")}>
-                <Input value={editing.estado ?? ""} onChange={(e) => setEditing({ ...editing, estado: e.target.value })} />
+              <FormField label={t("fields.estado")} required>
+                <Select value={form.estado} onValueChange={(v) => setForm({ ...form, estado: v })}>
+                  <SelectTrigger data-testid="select-estado-folio">
+                    <SelectValue placeholder={t("fields.estadoPlaceholder")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ESTADOS_FOLIO.map((e) => (
+                      <SelectItem key={e} value={e}>{e}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormField>
+              <FormField label={t("fields.tipo")} required>
+                <Select
+                  value={form.tipoFolioId !== undefined ? String(form.tipoFolioId) : ""}
+                  onValueChange={(v) => setForm({ ...form, tipoFolioId: Number(v) })}
+                >
+                  <SelectTrigger data-testid="select-tipo-folio">
+                    <SelectValue placeholder={t("fields.tipoPlaceholder")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {tiposFolio.map((tf) => (
+                      <SelectItem key={tf.idTipoFolio} value={String(tf.idTipoFolio)}>{tf.nombre}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormField>
+              <FormField label={t("fields.escribano")} required>
+                <Select
+                  value={form.escribanoId !== undefined ? String(form.escribanoId) : ""}
+                  onValueChange={(v) => setForm({ ...form, escribanoId: Number(v) })}
+                >
+                  <SelectTrigger data-testid="select-escribano-folio">
+                    <SelectValue placeholder={t("fields.escribanoPlaceholder")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {escribanos.map((e) => (
+                      <SelectItem key={e.idPersona} value={String(e.idPersona)}>
+                        {e.apellido} {e.nombre}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </FormField>
               <FormField label={tc("observations")}>
-                <Input value={editing.observaciones ?? ""} onChange={(e) => setEditing({ ...editing, observaciones: e.target.value })} />
+                <Input
+                  value={form.observaciones}
+                  onChange={(e) => setForm({ ...form, observaciones: e.target.value })}
+                />
               </FormField>
             </FormSection>
             <FormActions align="right">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -71,6 +71,8 @@ export interface Folio {
   estado?: string;
   observaciones?: string;
   tipoDeFolio?: TipoDeFolio;
+  tiposDeFolio?: { idTipoFolio?: number; nombre?: string };
+  personaEscribano?: { idPersona?: number; registroEscribano?: number };
   disponible?: boolean;
   version?: number;
 }


### PR DESCRIPTION
## Summary
- Backend: rewrote `FolioController` with Spring Data JPA repositories and `FolioRequest` DTO (flat `tipoFolioId`/`escribanoId`)
- Backend: fixed delete — Hibernate 6 was cascade-persisting the removed `Folio` back through `TipoDeFolio.folioList` (EAGER + `CascadeType.ALL`); fix removes folio from that collection before deletion inside a `@Transactional` controller method
- Frontend: changed `estado` from free-text `Input` to `Select` with valid values `Nuevo`, `Utilizado`, `Errose`
- Frontend: added required `tipoFolioId` and `escribanoId` selectors populated from API

## Testing
- [x] 9 TDD integration tests added (`FolioControllerTest`)
- [x] `BusinessWorkflowIntegrationTest` updated to new DTO format
- [x] All 450 backend tests pass
- [x] TypeScript compiles without errors

## Checklist
- [x] No dead code
- [x] No hardcoded secrets
- [x] KIS and SRP applied

Fixes #429