### PR TITLE
[#432] feat: Conceptos — search filter and referential integrity on edit/delete

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/ConceptoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/ConceptoController.java
@@ -3,9 +3,9 @@ package com.licensis.notaire.api;
 import com.licensis.notaire.dto.DtoConcepto;
 import com.licensis.notaire.negocio.Concepto;
 import com.licensis.notaire.repository.ConceptoRepository;
+import com.licensis.notaire.repository.PlantillaPresupuestoRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.NotNull;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,9 +15,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @RestController
@@ -26,9 +28,12 @@ import java.util.Optional;
 public class ConceptoController {
 
     private final ConceptoRepository repository;
+    private final PlantillaPresupuestoRepository plantillaRepository;
 
-    public ConceptoController(ConceptoRepository repository) {
+    public ConceptoController(ConceptoRepository repository,
+                              PlantillaPresupuestoRepository plantillaRepository) {
         this.repository = repository;
+        this.plantillaRepository = plantillaRepository;
     }
 
     @GetMapping
@@ -38,6 +43,25 @@ public class ConceptoController {
                 .map(Concepto::getDto)
                 .toList();
         return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "Buscar conceptos por nombre")
+    public ResponseEntity<List<DtoConcepto>> searchConceptos(@RequestParam String nombre) {
+        List<DtoConcepto> result = repository.findByNombreContaining(nombre).stream()
+                .map(Concepto::getDto)
+                .toList();
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{id}/in-use")
+    @Operation(summary = "Verificar si un concepto está en uso")
+    public ResponseEntity<Map<String, Boolean>> isConceptoInUse(@PathVariable Integer id) {
+        if (!repository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        boolean inUse = !plantillaRepository.findByConceptoIdConcepto(id).isEmpty();
+        return ResponseEntity.ok(Map.of("inUse", inUse));
     }
 
     @GetMapping("/{id}")
@@ -69,11 +93,13 @@ public class ConceptoController {
         if (existing.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
+        if (!plantillaRepository.findByConceptoIdConcepto(id).isEmpty()) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("error", "Este concepto está en uso y no puede modificarse. Cree un nuevo concepto."));
+        }
         try {
             dto.setIdConcepto(id);
             Concepto entity = existing.get();
-            // Preserve the current enabled state when the payload omits it,
-            // otherwise setAtributos unboxes a null Boolean and throws an NPE.
             if (dto.getHabilitado() == null) {
                 dto.setHabilitado(entity.getHabilitado());
             }
@@ -91,12 +117,11 @@ public class ConceptoController {
         if (!repository.existsById(id)) {
             return ResponseEntity.notFound().build();
         }
-        try {
-            repository.deleteById(id);
-            return ResponseEntity.noContent().build();
-        } catch (Exception e) {
+        if (!plantillaRepository.findByConceptoIdConcepto(id).isEmpty()) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
-                    .body("No se puede eliminar: el concepto está referenciado por otros registros.");
+                    .body(Map.of("error", "No se puede eliminar: el concepto está siendo utilizado en plantillas de presupuesto."));
         }
+        repository.deleteById(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend-api/src/test/java/com/licensis/notaire/integration/ConceptoReferentialIntegrityTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/ConceptoReferentialIntegrityTest.java
@@ -1,0 +1,156 @@
+package com.licensis.notaire.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@ActiveProfiles("test-h2")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@DisplayName("CU34/CU37/CU66 — Concepto referential integrity (issue #432)")
+class ConceptoReferentialIntegrityTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    private int createConcepto(String nombre) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/conceptos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "nombre": "%s",
+                                  "descripcion": "Test",
+                                  "valor": 100,
+                                  "habilitado": true,
+                                  "porcentaje": 0,
+                                  "conceptoFijo": false
+                                }
+                                """.formatted(nombre)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return mapper.readTree(result.getResponse().getContentAsString()).get("idConcepto").asInt();
+    }
+
+    private void linkConceptoToPlantilla(int tipoTramiteId, int conceptoId) throws Exception {
+        mockMvc.perform(post("/api/v1/plantilla-presupuestos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "plantillaPresupuestoPK": {
+                                    "fkIdTipoTramite": %d,
+                                    "fkIdConcepto": %d
+                                  },
+                                  "tipoDeTramite": {"idTipoTramite": %d},
+                                  "concepto": {"idConcepto": %d}
+                                }
+                                """.formatted(tipoTramiteId, conceptoId, tipoTramiteId, conceptoId)))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("Should return inUse=false when no plantilla references the concepto")
+    void shouldReturnInUseFalseWhenConceptoIsNotReferenced() throws Exception {
+        int id = createConcepto("ConceptoFree_InUse");
+
+        mockMvc.perform(get("/api/v1/conceptos/" + id + "/in-use"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.inUse").value(false));
+    }
+
+    @Test
+    @DisplayName("Should return inUse=true when a plantilla references the concepto")
+    void shouldReturnInUseTrueWhenConceptoIsReferenced() throws Exception {
+        int id = createConcepto("ConceptoUsed_InUse");
+        linkConceptoToPlantilla(1, id);
+
+        mockMvc.perform(get("/api/v1/conceptos/" + id + "/in-use"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.inUse").value(true));
+    }
+
+    @Test
+    @DisplayName("Should return 409 when editing a concepto that is in use")
+    void shouldReturn409WhenEditingConceptoInUse() throws Exception {
+        int id = createConcepto("ConceptoEditBlocked");
+        linkConceptoToPlantilla(1, id);
+
+        mockMvc.perform(put("/api/v1/conceptos/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "nombre": "NombreModificado",
+                                  "descripcion": "Updated",
+                                  "valor": 200,
+                                  "habilitado": true
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @DisplayName("Should allow editing a concepto that is NOT in use")
+    void shouldAllowEditingConceptoNotInUse() throws Exception {
+        int id = createConcepto("ConceptoEditAllowed");
+
+        mockMvc.perform(put("/api/v1/conceptos/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "nombre": "ConceptoEditAllowed_Updated",
+                                  "descripcion": "Updated description",
+                                  "valor": 200,
+                                  "habilitado": true
+                                }
+                                """))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should return 409 when deleting a concepto that is in use")
+    void shouldReturn409WhenDeletingConceptoInUse() throws Exception {
+        int id = createConcepto("ConceptoDeleteBlocked");
+        linkConceptoToPlantilla(1, id);
+
+        mockMvc.perform(delete("/api/v1/conceptos/" + id))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @DisplayName("Should search conceptos by nombre")
+    void shouldSearchConceptosByNombre() throws Exception {
+        createConcepto("BuscarEsteConcepto");
+
+        mockMvc.perform(get("/api/v1/conceptos/search").param("nombre", "BuscarEste"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].nombre").value("BuscarEsteConcepto"));
+    }
+}

--- a/backend-api/src/test/java/com/licensis/notaire/integration/UsuarioDeleteControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/UsuarioDeleteControllerTest.java
@@ -59,8 +59,7 @@ class UsuarioDeleteControllerTest {
                   "nombre": "to_be_deleted",
                   "contrasenia": "pass",
                   "tipo": "EMPLEADO",
-                  "estado": true,
-                  "fkIdPersona": {"idPersona": 1}
+                  "activo": true
                 }
                 """;
 
@@ -97,8 +96,7 @@ class UsuarioDeleteControllerTest {
                   "nombre": "to_be_removed_from_list",
                   "contrasenia": "pass",
                   "tipo": "EMPLEADO",
-                  "estado": true,
-                  "fkIdPersona": {"idPersona": 1}
+                  "activo": true
                 }
                 """;
 
@@ -133,8 +131,7 @@ class UsuarioDeleteControllerTest {
                   "nombre": "user_with_audit",
                   "contrasenia": "pass",
                   "tipo": "EMPLEADO",
-                  "estado": true,
-                  "fkIdPersona": {"idPersona": 1}
+                  "activo": true
                 }
                 """;
         MvcResult result = mockMvc.perform(post("/api/v1/usuarios")

--- a/backend-api/src/test/java/com/licensis/notaire/unit/ConceptoControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/ConceptoControllerTest.java
@@ -35,12 +35,15 @@ class ConceptoControllerTest {
     @Mock
     private ConceptoRepository repository;
 
+    @Mock
+    private com.licensis.notaire.repository.PlantillaPresupuestoRepository plantillaRepository;
+
     private MockMvc mockMvc;
     private ObjectMapper mapper;
 
     @BeforeEach
     void setUp() {
-        ConceptoController controller = new ConceptoController(repository);
+        ConceptoController controller = new ConceptoController(repository, plantillaRepository);
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
         mapper = new ObjectMapper();
     }
@@ -185,11 +188,13 @@ class ConceptoControllerTest {
     }
 
     @Test
-    @DisplayName("DELETE /api/v1/conceptos/{id} should return 409 when delete fails")
-    void shouldReturn409WhenDeleteFails() throws Exception {
+    @DisplayName("DELETE /api/v1/conceptos/{id} should return 409 when concepto is in use")
+    void shouldReturn409WhenConceptoIsInUse() throws Exception {
+        com.licensis.notaire.negocio.PlantillaPresupuesto pp = new com.licensis.notaire.negocio.PlantillaPresupuesto();
         when(repository.existsById(1)).thenReturn(true);
-        doThrow(new RuntimeException("FK violation")).when(repository).deleteById(1);
+        when(plantillaRepository.findByConceptoIdConcepto(1)).thenReturn(List.of(pp));
         mockMvc.perform(delete("/api/v1/conceptos/1"))
-                .andExpect(status().isConflict());
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").exists());
     }
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -356,6 +356,7 @@
       "description": "Catalog of concepts used in quotes",
       "newConcepto": "New concept",
       "editConcepto": "Edit concept",
+      "searchPlaceholder": "Search by name...",
       "created": "Concept created",
       "updated": "Concept updated",
       "deleted": "Concept deleted",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -356,6 +356,7 @@
       "description": "Catálogo de conceptos utilizados en presupuestos",
       "newConcepto": "Nuevo concepto",
       "editConcepto": "Editar concepto",
+      "searchPlaceholder": "Buscar por nombre...",
       "created": "Concepto creado",
       "updated": "Concepto actualizado",
       "deleted": "Concepto eliminado",

--- a/frontend/src/app/dashboard/administracion/conceptos/page.tsx
+++ b/frontend/src/app/dashboard/administracion/conceptos/page.tsx
@@ -17,6 +17,22 @@ import type { Concepto } from "@/types";
 
 const EMPTY: Partial<Concepto> = { nombre: "", descripcion: "", valor: undefined };
 
+function extractApiError(err: unknown): string | null {
+  if (!(err instanceof Error)) return null;
+  const match = err.message.match(/\[409\]/);
+  if (!match) return null;
+  try {
+    const jsonStart = err.message.indexOf("{");
+    if (jsonStart !== -1) {
+      const body = JSON.parse(err.message.slice(jsonStart)) as { error?: string };
+      return body.error ?? null;
+    }
+  } catch {
+    // not JSON — return null
+  }
+  return null;
+}
+
 export default function ConceptosPage() {
   const t = useTranslations("administracion.conceptos");
   const tc = useTranslations("common");
@@ -30,6 +46,11 @@ export default function ConceptosPage() {
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [editing, setEditing] = useState<Partial<Concepto>>(EMPTY);
   const [isEditMode, setIsEditMode] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const filtered = conceptos.filter((c) =>
+    !search || c.nombre?.toLowerCase().includes(search.toLowerCase())
+  );
 
   function openCreate() { setEditing(EMPTY); setIsEditMode(false); setModalOpen(true); }
   function openEdit(c: Concepto) { setEditing(c); setIsEditMode(true); setModalOpen(true); }
@@ -45,7 +66,14 @@ export default function ConceptosPage() {
         toast.success(t("created"));
       }
       setModalOpen(false);
-    } catch { toast.error(t("errorSave")); }
+    } catch (err) {
+      const conflict = extractApiError(err);
+      if (conflict) {
+        toast.error(conflict);
+      } else {
+        toast.error(t("errorSave"));
+      }
+    }
   }
 
   async function handleDelete() {
@@ -53,8 +81,14 @@ export default function ConceptosPage() {
     try {
       await deleteMutation.mutateAsync(deleteId);
       toast.success(t("deleted"));
-    } catch { toast.error(t("errorDelete")); }
-    finally { setDeleteId(null); }
+    } catch (err) {
+      const conflict = extractApiError(err);
+      if (conflict) {
+        toast.error(conflict);
+      } else {
+        toast.error(t("errorDelete"));
+      }
+    } finally { setDeleteId(null); }
   }
 
   const columns: Column<Concepto>[] = [
@@ -80,7 +114,18 @@ export default function ConceptosPage() {
         description={t("description")}
         actions={<Button onClick={openCreate}><NotaireIcon src="/icons/actions/agregar.png" alt={tc("add")} size={16} className="mr-1" />{t("newConcepto")}</Button>}
       />
-      <DataTable data={conceptos} columns={columns} isLoading={isLoading} keyExtractor={(c) => c.idConcepto!} emptyMessage={t("noData")} />
+
+      <div className="px-4 pb-4">
+        <Input
+          placeholder={t("searchPlaceholder")}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-64"
+          data-testid="input-search-concepto"
+        />
+      </div>
+
+      <DataTable data={filtered} columns={columns} isLoading={isLoading} keyExtractor={(c) => c.idConcepto!} emptyMessage={t("noData")} />
 
       <Dialog open={modalOpen} onOpenChange={setModalOpen}>
         <DialogContent>


### PR DESCRIPTION
## Summary
- Adds search/filter input to the Conceptos admin page (client-side by name)
- Adds `GET /api/v1/conceptos/search?nombre=xxx` backend endpoint
- Adds `GET /api/v1/conceptos/{id}/in-use` to check if a concepto is referenced
- Blocks editing/deleting conceptos that are in use in `plantilla_presupuesto` with 409 + clear error message

## Changes

### Backend
- `ConceptoController`: inject `PlantillaPresupuestoRepository` to check in-use before PUT/DELETE
- New `GET /search` and `GET /{id}/in-use` endpoints
- PUT: returns 409 `{"error": "..."}` when concepto is referenced by a plantilla
- DELETE: proactive 409 before DB delete (replaces exception-catching approach)

### Frontend
- `conceptos/page.tsx`: adds search input and `extractApiError()` to surface 409 messages as toast

### Tests
- 6 new integration tests (`ConceptoReferentialIntegrityTest`) covering all cases
- Updated unit test to use in-use stubbing instead of deleteById exception
- Fixed pre-existing `UsuarioDeleteControllerTest` stale field name (`estado` → `activo`)

## Testing
- [x] 460 backend tests pass, 0 failures
- [x] TypeScript compiles clean

## Issue Reference
Fixes #432