### PR TITLE
[#433] feat: add referential integrity + search for tipos de documento

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/TipoDeDocumentoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TipoDeDocumentoController.java
@@ -2,6 +2,8 @@ package com.licensis.notaire.api;
 
 import com.licensis.notaire.dto.DtoTipoDeDocumento;
 import com.licensis.notaire.negocio.TipoDeDocumento;
+import com.licensis.notaire.repository.DocumentoPresentadoRepository;
+import com.licensis.notaire.repository.PlantillaTramiteRepository;
 import com.licensis.notaire.repository.TipoDeDocumentoRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @RestController
@@ -18,18 +21,31 @@ import java.util.Optional;
 public class TipoDeDocumentoController {
 
     private final TipoDeDocumentoRepository repository;
+    private final PlantillaTramiteRepository plantillaTramiteRepository;
+    private final DocumentoPresentadoRepository documentoPresentadoRepository;
 
-    public TipoDeDocumentoController(TipoDeDocumentoRepository repository) {
+    public TipoDeDocumentoController(TipoDeDocumentoRepository repository,
+                                     PlantillaTramiteRepository plantillaTramiteRepository,
+                                     DocumentoPresentadoRepository documentoPresentadoRepository) {
         this.repository = repository;
+        this.plantillaTramiteRepository = plantillaTramiteRepository;
+        this.documentoPresentadoRepository = documentoPresentadoRepository;
     }
 
     @GetMapping
     @Operation(summary = "Obtener todos los tipo-de-documento")
     public ResponseEntity<List<DtoTipoDeDocumento>> getAll() {
-        List<DtoTipoDeDocumento> result = repository.findAll().stream()
+        return ResponseEntity.ok(repository.findAll().stream()
                 .map(TipoDeDocumento::getDto)
-                .toList();
-        return ResponseEntity.ok(result);
+                .toList());
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "Buscar tipo-de-documento por nombre")
+    public ResponseEntity<List<DtoTipoDeDocumento>> search(@RequestParam String nombre) {
+        return ResponseEntity.ok(repository.findByNombreContaining(nombre).stream()
+                .map(TipoDeDocumento::getDto)
+                .toList());
     }
 
     @GetMapping("/{id}")
@@ -38,6 +54,17 @@ public class TipoDeDocumentoController {
         return repository.findById(id)
                 .map(e -> ResponseEntity.ok(e.getDto()))
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{id}/in-use")
+    @Operation(summary = "Verificar si el tipo de documento está en uso")
+    public ResponseEntity<Map<String, Boolean>> isInUse(@PathVariable Integer id) {
+        if (!repository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        boolean inUse = !plantillaTramiteRepository.findByTipoDeDocumentoIdTipoDocumento(id).isEmpty()
+                || documentoPresentadoRepository.existsByFkIdTipoDocumento(id);
+        return ResponseEntity.ok(Map.of("inUse", inUse));
     }
 
     @PostMapping
@@ -64,9 +91,17 @@ public class TipoDeDocumentoController {
         if (existing.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
+        if (!plantillaTramiteRepository.findByTipoDeDocumentoIdTipoDocumento(id).isEmpty()
+                || documentoPresentadoRepository.existsByFkIdTipoDocumento(id)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("error", "Este tipo de documento está en uso y no puede modificarse. Cree uno nuevo."));
+        }
         try {
             TipoDeDocumento entity = existing.get();
             dto.setIdTipoDocumento(id);
+            if (dto.getQuienEntrega() == null) {
+                dto.setQuienEntrega(entity.getQuienEntrega());
+            }
             entity.setAtributos(dto);
             repository.save(entity);
             return ResponseEntity.ok().build();
@@ -81,12 +116,12 @@ public class TipoDeDocumentoController {
         if (!repository.existsById(id)) {
             return ResponseEntity.notFound().build();
         }
-        try {
-            repository.deleteById(id);
-            return ResponseEntity.noContent().build();
-        } catch (Exception e) {
+        if (!plantillaTramiteRepository.findByTipoDeDocumentoIdTipoDocumento(id).isEmpty()
+                || documentoPresentadoRepository.existsByFkIdTipoDocumento(id)) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
-                    .body("No se puede eliminar: el tipo de documento está referenciado por otros registros.");
+                    .body(Map.of("error", "No se puede eliminar: el tipo de documento está siendo utilizado en plantillas o documentos presentados."));
         }
+        repository.deleteById(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend-api/src/main/java/com/licensis/notaire/repository/DocumentoPresentadoRepository.java
+++ b/backend-api/src/main/java/com/licensis/notaire/repository/DocumentoPresentadoRepository.java
@@ -19,4 +19,6 @@ public interface DocumentoPresentadoRepository extends JpaRepository<DocumentoPr
     List<DocumentoPresentado> findByObservado(Boolean observado);
 
     List<DocumentoPresentado> findByPreparado(Boolean preparado);
+
+    boolean existsByFkIdTipoDocumento(Integer fkIdTipoDocumento);
 }

--- a/backend-api/src/main/java/com/licensis/notaire/repository/TipoDeDocumentoRepository.java
+++ b/backend-api/src/main/java/com/licensis/notaire/repository/TipoDeDocumentoRepository.java
@@ -4,6 +4,7 @@ import com.licensis.notaire.negocio.TipoDeDocumento;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,4 +13,6 @@ public interface TipoDeDocumentoRepository extends JpaRepository<TipoDeDocumento
     Optional<TipoDeDocumento> findByNombre(String nombre);
 
     boolean existsByNombre(String nombre);
+
+    List<TipoDeDocumento> findByNombreContaining(String nombre);
 }

--- a/backend-api/src/test/java/com/licensis/notaire/integration/TipoDeDocumentoReferentialIntegrityTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/TipoDeDocumentoReferentialIntegrityTest.java
@@ -1,0 +1,144 @@
+package com.licensis.notaire.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.licensis.notaire.negocio.PlantillaTramite;
+import com.licensis.notaire.negocio.PlantillaTramitePK;
+import com.licensis.notaire.repository.PlantillaTramiteRepository;
+
+@SpringBootTest
+@ActiveProfiles("test-h2")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@DisplayName("TipoDeDocumento — referential integrity checks")
+class TipoDeDocumentoReferentialIntegrityTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private PlantillaTramiteRepository plantillaTramiteRepository;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    @Test
+    @DisplayName("Should return inUse=false when tipo de documento is not referenced")
+    void shouldReturnInUseFalseWhenNotReferenced() throws Exception {
+        int id = createTipoDocumento("Tipo_unused_" + System.nanoTime());
+
+        mockMvc.perform(get("/api/v1/tipo-de-documento/" + id + "/in-use"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.inUse").value(false));
+    }
+
+    @Test
+    @DisplayName("Should return inUse=true when tipo de documento is referenced by plantilla tramite")
+    void shouldReturnInUseTrueWhenReferencedByPlantillaTramite() throws Exception {
+        int id = createTipoDocumento("Tipo_used_" + System.nanoTime());
+        linkToPlantillaTramite(id);
+
+        mockMvc.perform(get("/api/v1/tipo-de-documento/" + id + "/in-use"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.inUse").value(true));
+    }
+
+    @Test
+    @DisplayName("Should return 409 when editing tipo de documento that is in use")
+    void shouldReturn409WhenEditingTipoDocumentoInUse() throws Exception {
+        int id = createTipoDocumento("Tipo_edit_conflict_" + System.nanoTime());
+        linkToPlantillaTramite(id);
+
+        String updateBody = """
+                {"nombre": "Nombre actualizado", "vence": false}
+                """;
+
+        mockMvc.perform(put("/api/v1/tipo-de-documento/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateBody))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @DisplayName("Should allow editing tipo de documento that is not in use")
+    void shouldAllowEditingTipoDocumentoNotInUse() throws Exception {
+        int id = createTipoDocumento("Tipo_edit_ok_" + System.nanoTime());
+
+        String updateBody = """
+                {"nombre": "Nombre actualizado ok", "vence": false}
+                """;
+
+        mockMvc.perform(put("/api/v1/tipo-de-documento/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateBody))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should return 409 when deleting tipo de documento that is in use")
+    void shouldReturn409WhenDeletingTipoDocumentoInUse() throws Exception {
+        int id = createTipoDocumento("Tipo_delete_conflict_" + System.nanoTime());
+        linkToPlantillaTramite(id);
+
+        mockMvc.perform(delete("/api/v1/tipo-de-documento/" + id))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @DisplayName("Should search tipos de documento by nombre")
+    void shouldSearchTiposDocumentoByNombre() throws Exception {
+        String uniqueName = "SearchableDoc_" + System.nanoTime();
+        createTipoDocumento(uniqueName);
+
+        mockMvc.perform(get("/api/v1/tipo-de-documento/search")
+                        .param("nombre", "SearchableDoc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.nombre =~ /.*SearchableDoc.*/)]").exists());
+    }
+
+    private int createTipoDocumento(String nombre) throws Exception {
+        String body = String.format("""
+                {"nombre": "%s", "vence": false}
+                """, nombre);
+
+        MvcResult result = mockMvc.perform(post("/api/v1/tipo-de-documento")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        return mapper.readTree(result.getResponse().getContentAsString())
+                .get("idTipoDocumento").asInt();
+    }
+
+    private void linkToPlantillaTramite(int idTipoDocumento) {
+        PlantillaTramitePK pk = new PlantillaTramitePK(1, idTipoDocumento);
+        PlantillaTramite plantilla = new PlantillaTramite(pk);
+        plantillaTramiteRepository.save(plantilla);
+    }
+}

--- a/backend-api/src/test/java/com/licensis/notaire/integration/UsuarioDeleteControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/UsuarioDeleteControllerTest.java
@@ -59,8 +59,7 @@ class UsuarioDeleteControllerTest {
                   "nombre": "to_be_deleted",
                   "contrasenia": "pass",
                   "tipo": "EMPLEADO",
-                  "estado": true,
-                  "fkIdPersona": {"idPersona": 1}
+                  "activo": true
                 }
                 """;
 
@@ -97,8 +96,7 @@ class UsuarioDeleteControllerTest {
                   "nombre": "to_be_removed_from_list",
                   "contrasenia": "pass",
                   "tipo": "EMPLEADO",
-                  "estado": true,
-                  "fkIdPersona": {"idPersona": 1}
+                  "activo": true
                 }
                 """;
 
@@ -133,8 +131,7 @@ class UsuarioDeleteControllerTest {
                   "nombre": "user_with_audit",
                   "contrasenia": "pass",
                   "tipo": "EMPLEADO",
-                  "estado": true,
-                  "fkIdPersona": {"idPersona": 1}
+                  "activo": true
                 }
                 """;
         MvcResult result = mockMvc.perform(post("/api/v1/usuarios")

--- a/backend-api/src/test/java/com/licensis/notaire/unit/SimpleControllersTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/SimpleControllersTest.java
@@ -503,8 +503,12 @@ class SimpleControllersTest {
     @DisplayName("TipoDeDocumentoController")
     class TipoDeDocumentoControllerTests {
         private final TipoDeDocumentoRepository repo = mock(TipoDeDocumentoRepository.class);
+        private final com.licensis.notaire.repository.PlantillaTramiteRepository plantillaRepo =
+                mock(com.licensis.notaire.repository.PlantillaTramiteRepository.class);
+        private final com.licensis.notaire.repository.DocumentoPresentadoRepository docPresentadoRepo =
+                mock(com.licensis.notaire.repository.DocumentoPresentadoRepository.class);
         private final org.springframework.test.web.servlet.MockMvc mvc =
-                standaloneSetup(new TipoDeDocumentoController(repo)).build();
+                standaloneSetup(new TipoDeDocumentoController(repo, plantillaRepo, docPresentadoRepo)).build();
 
         @Test
         @DisplayName("Cover all paths")
@@ -523,6 +527,8 @@ class SimpleControllersTest {
             when(repo.findById(2)).thenReturn(Optional.empty());
             when(repo.existsById(1)).thenReturn(true);
             when(repo.existsById(2)).thenReturn(false);
+            when(plantillaRepo.findByTipoDeDocumentoIdTipoDocumento(anyInt())).thenReturn(List.of());
+            when(docPresentadoRepo.existsByFkIdTipoDocumento(anyInt())).thenReturn(false);
 
             mvc.perform(get("/api/v1/tipo-de-documento")).andExpect(status().isOk());
             mvc.perform(get("/api/v1/tipo-de-documento/1")).andExpect(status().isOk());
@@ -543,7 +549,8 @@ class SimpleControllersTest {
                     .content(mapper.writeValueAsString(dto))).andExpect(status().isConflict());
             mvc.perform(put("/api/v1/tipo-de-documento/1").contentType("application/json")
                     .content(mapper.writeValueAsString(dto))).andExpect(status().isInternalServerError());
-            doThrow(new RuntimeException("fk")).when(repo).deleteById(1);
+
+            when(plantillaRepo.findByTipoDeDocumentoIdTipoDocumento(1)).thenReturn(List.of(new com.licensis.notaire.negocio.PlantillaTramite()));
             mvc.perform(delete("/api/v1/tipo-de-documento/1")).andExpect(status().isConflict());
         }
     }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -377,7 +377,8 @@
       "errorDelete": "Cannot delete: document type is referenced by other records.",
       "noData": "No document types registered",
       "nameRequired": "Name is required",
-      "namePlaceholder": "E.g.: ID Card, Deed"
+      "namePlaceholder": "E.g.: ID Card, Deed",
+      "searchPlaceholder": "Search by name..."
     },
     "estadosGestion": {
       "title": "Case Statuses",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -377,7 +377,8 @@
       "errorDelete": "No se puede eliminar: el tipo de documento está referenciado por otros registros.",
       "noData": "No hay tipos de documento registrados",
       "nameRequired": "El nombre es requerido",
-      "namePlaceholder": "Ej: DNI, Escritura"
+      "namePlaceholder": "Ej: DNI, Escritura",
+      "searchPlaceholder": "Buscar por nombre..."
     },
     "estadosGestion": {
       "title": "Estados de Gestión",

--- a/frontend/src/app/dashboard/administracion/documentos/page.tsx
+++ b/frontend/src/app/dashboard/administracion/documentos/page.tsx
@@ -16,6 +16,19 @@ import type { TipoDeDocumento } from "@/types";
 
 const EMPTY: Partial<TipoDeDocumento> = { nombre: "" };
 
+function extractApiError(err: unknown): string | null {
+  if (!(err instanceof Error)) return null;
+  if (!err.message.includes("[409]")) return null;
+  try {
+    const jsonStart = err.message.indexOf("{");
+    if (jsonStart !== -1) {
+      const body = JSON.parse(err.message.slice(jsonStart)) as { error?: string };
+      return body.error ?? null;
+    }
+  } catch { }
+  return null;
+}
+
 export default function DocumentosPage() {
   const t = useTranslations("administracion.documentos");
   const tc = useTranslations("common");
@@ -44,6 +57,11 @@ export default function DocumentosPage() {
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [editing, setEditing] = useState<Partial<TipoDeDocumento>>(EMPTY);
   const [isEditMode, setIsEditMode] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const filtered = search.trim()
+    ? tipos.filter((t) => t.nombre?.toLowerCase().includes(search.toLowerCase()))
+    : tipos;
 
   function openCreate() { setEditing(EMPTY); setIsEditMode(false); setModalOpen(true); }
   function openEdit(tipo: TipoDeDocumento) { setEditing(tipo); setIsEditMode(true); setModalOpen(true); }
@@ -59,8 +77,9 @@ export default function DocumentosPage() {
         toast.success("Tipo de documento creado");
       }
       setModalOpen(false);
-    } catch {
-      toast.error(t("errorSave"));
+    } catch (err) {
+      const apiError = extractApiError(err);
+      toast.error(apiError ?? t("errorSave"));
     }
   }
 
@@ -69,8 +88,9 @@ export default function DocumentosPage() {
     try {
       await deleteMutation.mutateAsync(deleteId);
       toast.success("Tipo de documento eliminado");
-    } catch {
-      toast.error(t("errorDelete"));
+    } catch (err) {
+      const apiError = extractApiError(err);
+      toast.error(apiError ?? t("errorDelete"));
     } finally {
       setDeleteId(null);
     }
@@ -106,8 +126,16 @@ export default function DocumentosPage() {
           </Button>
         }
       />
+      <div className="mb-4">
+        <Input
+          placeholder={t("searchPlaceholder")}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="max-w-sm"
+        />
+      </div>
       <DataTable
-        data={tipos}
+        data={filtered}
         columns={columns}
         isLoading={isLoading}
         keyExtractor={(tipo) => tipo.idTipoDocumento!}


### PR DESCRIPTION
## Summary
- Added proactive 409 conflict check on PUT/DELETE when tipo de documento is referenced by plantilla_tramite or documentos_presentados
- Added `GET /tipo-de-documento/search?nombre=xxx` and `GET /tipo-de-documento/{id}/in-use` endpoints
- Fixed PUT to preserve `quienEntrega` when omitted from update payload
- Added search input and 409-aware error messages in the frontend page

## Changes
### Added
- `GET /tipo-de-documento/search` — filter by name
- `GET /tipo-de-documento/{id}/in-use` — check referential usage
- `TipoDeDocumentoReferentialIntegrityTest` — 6 TDD integration tests
- `existsByFkIdTipoDocumento` in `DocumentoPresentadoRepository`
- `findByNombreContaining` in `TipoDeDocumentoRepository`
### Modified
- `TipoDeDocumentoController` — referential integrity, fix quienEntrega preservation
- `SimpleControllersTest` — updated for new 3-arg constructor
- `UsuarioDeleteControllerTest` — use `activo` field (pre-existing test bug)
- Frontend `administracion/documentos/page.tsx` — search + 409 error handling
- i18n messages (en/es) — `searchPlaceholder` added

## Testing
- [x] Unit tests added/updated
- [x] Integration tests pass (6 new TDD tests for referential integrity)
- [x] All tests pass (`mvn verify -pl backend-api`)
- [x] TypeScript: no errors

## Issue Reference
Fixes #433