### PR TITLE
[#435] feat: add referential integrity + search for tipos de tramite

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/TipoDeTramiteController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TipoDeTramiteController.java
@@ -2,7 +2,10 @@ package com.licensis.notaire.api;
 
 import com.licensis.notaire.dto.DtoTipoDeTramite;
 import com.licensis.notaire.negocio.TipoDeTramite;
+import com.licensis.notaire.repository.PlantillaPresupuestoRepository;
+import com.licensis.notaire.repository.PlantillaTramiteRepository;
 import com.licensis.notaire.repository.TipoDeTramiteRepository;
+import com.licensis.notaire.repository.TramiteRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
@@ -14,9 +17,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @RestController
@@ -25,18 +30,34 @@ import java.util.Optional;
 public class TipoDeTramiteController {
 
     private final TipoDeTramiteRepository repository;
+    private final PlantillaTramiteRepository plantillaTramiteRepository;
+    private final PlantillaPresupuestoRepository plantillaPresupuestoRepository;
+    private final TramiteRepository tramiteRepository;
 
-    public TipoDeTramiteController(TipoDeTramiteRepository repository) {
+    public TipoDeTramiteController(TipoDeTramiteRepository repository,
+                                   PlantillaTramiteRepository plantillaTramiteRepository,
+                                   PlantillaPresupuestoRepository plantillaPresupuestoRepository,
+                                   TramiteRepository tramiteRepository) {
         this.repository = repository;
+        this.plantillaTramiteRepository = plantillaTramiteRepository;
+        this.plantillaPresupuestoRepository = plantillaPresupuestoRepository;
+        this.tramiteRepository = tramiteRepository;
     }
 
     @GetMapping
     @Operation(summary = "Obtener todos los tipos de tramite")
     public ResponseEntity<List<DtoTipoDeTramite>> getAll() {
-        List<DtoTipoDeTramite> result = repository.findAll().stream()
+        return ResponseEntity.ok(repository.findAll().stream()
                 .map(TipoDeTramite::getDto)
-                .toList();
-        return ResponseEntity.ok(result);
+                .toList());
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "Buscar tipos de tramite por nombre")
+    public ResponseEntity<List<DtoTipoDeTramite>> search(@RequestParam String nombre) {
+        return ResponseEntity.ok(repository.findByNombreContaining(nombre).stream()
+                .map(TipoDeTramite::getDto)
+                .toList());
     }
 
     @GetMapping("/{id}")
@@ -45,6 +66,18 @@ public class TipoDeTramiteController {
         return repository.findById(id)
                 .map(e -> ResponseEntity.ok(e.getDto()))
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{id}/in-use")
+    @Operation(summary = "Verificar si el tipo de tramite está en uso")
+    public ResponseEntity<Map<String, Boolean>> isInUse(@PathVariable Integer id) {
+        if (!repository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        boolean inUse = !plantillaTramiteRepository.findByTipoDeTramiteIdTipoTramite(id).isEmpty()
+                || !plantillaPresupuestoRepository.findByTipoDeTramiteIdTipoTramite(id).isEmpty()
+                || !tramiteRepository.findByFkIdTipoTramiteIdTipoTramite(id).isEmpty();
+        return ResponseEntity.ok(Map.of("inUse", inUse));
     }
 
     @PostMapping
@@ -74,6 +107,12 @@ public class TipoDeTramiteController {
         if (existing.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
+        if (!plantillaTramiteRepository.findByTipoDeTramiteIdTipoTramite(id).isEmpty()
+                || !plantillaPresupuestoRepository.findByTipoDeTramiteIdTipoTramite(id).isEmpty()
+                || !tramiteRepository.findByFkIdTipoTramiteIdTipoTramite(id).isEmpty()) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("error", "Este tipo de trámite está en uso y no puede modificarse. Cree uno nuevo."));
+        }
         try {
             dto.setIdTipoTramite(id);
             TipoDeTramite entity = existing.get();
@@ -91,12 +130,13 @@ public class TipoDeTramiteController {
         if (!repository.existsById(id)) {
             return ResponseEntity.notFound().build();
         }
-        try {
-            repository.deleteById(id);
-            return ResponseEntity.noContent().build();
-        } catch (Exception e) {
+        if (!plantillaTramiteRepository.findByTipoDeTramiteIdTipoTramite(id).isEmpty()
+                || !plantillaPresupuestoRepository.findByTipoDeTramiteIdTipoTramite(id).isEmpty()
+                || !tramiteRepository.findByFkIdTipoTramiteIdTipoTramite(id).isEmpty()) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
-                    .body("No se puede eliminar: el tipo de tramite está referenciado por otros registros.");
+                    .body(Map.of("error", "No se puede eliminar: el tipo de trámite está siendo utilizado en plantillas o trámites."));
         }
+        repository.deleteById(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend-api/src/main/java/com/licensis/notaire/repository/TipoDeTramiteRepository.java
+++ b/backend-api/src/main/java/com/licensis/notaire/repository/TipoDeTramiteRepository.java
@@ -4,6 +4,7 @@ import com.licensis.notaire.negocio.TipoDeTramite;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,4 +13,6 @@ public interface TipoDeTramiteRepository extends JpaRepository<TipoDeTramite, In
     Optional<TipoDeTramite> findByNombre(String nombre);
 
     boolean existsByNombre(String nombre);
+
+    List<TipoDeTramite> findByNombreContaining(String nombre);
 }

--- a/backend-api/src/test/java/com/licensis/notaire/integration/TipoDeTramiteReferentialIntegrityTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/TipoDeTramiteReferentialIntegrityTest.java
@@ -1,0 +1,144 @@
+package com.licensis.notaire.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.licensis.notaire.negocio.PlantillaPresupuesto;
+import com.licensis.notaire.negocio.PlantillaPresupuestoPK;
+import com.licensis.notaire.repository.PlantillaPresupuestoRepository;
+
+@SpringBootTest
+@ActiveProfiles("test-h2")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@DisplayName("TipoDeTramite — referential integrity checks")
+class TipoDeTramiteReferentialIntegrityTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private PlantillaPresupuestoRepository plantillaPresupuestoRepository;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    @Test
+    @DisplayName("Should return inUse=false when tipo de tramite is not referenced")
+    void shouldReturnInUseFalseWhenNotReferenced() throws Exception {
+        int id = createTipoTramite("Tramite_unused_" + System.nanoTime());
+
+        mockMvc.perform(get("/api/v1/tipo-tramite/" + id + "/in-use"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.inUse").value(false));
+    }
+
+    @Test
+    @DisplayName("Should return inUse=true when tipo de tramite is referenced by plantilla presupuesto")
+    void shouldReturnInUseTrueWhenReferencedByPlantillaPresupuesto() throws Exception {
+        int id = createTipoTramite("Tramite_used_" + System.nanoTime());
+        linkToPlantillaPresupuesto(id);
+
+        mockMvc.perform(get("/api/v1/tipo-tramite/" + id + "/in-use"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.inUse").value(true));
+    }
+
+    @Test
+    @DisplayName("Should return 409 when editing tipo de tramite that is in use")
+    void shouldReturn409WhenEditingTipoTramiteInUse() throws Exception {
+        int id = createTipoTramite("Tramite_edit_conflict_" + System.nanoTime());
+        linkToPlantillaPresupuesto(id);
+
+        String updateBody = """
+                {"nombre": "Nombre actualizado", "seArchiva": false, "seInscribe": false, "asociaInmuebles": false}
+                """;
+
+        mockMvc.perform(put("/api/v1/tipo-tramite/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateBody))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @DisplayName("Should allow editing tipo de tramite that is not in use")
+    void shouldAllowEditingTipoTramiteNotInUse() throws Exception {
+        int id = createTipoTramite("Tramite_edit_ok_" + System.nanoTime());
+
+        String updateBody = """
+                {"nombre": "Nombre actualizado ok", "seArchiva": false, "seInscribe": false, "asociaInmuebles": false}
+                """;
+
+        mockMvc.perform(put("/api/v1/tipo-tramite/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateBody))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should return 409 when deleting tipo de tramite that is in use")
+    void shouldReturn409WhenDeletingTipoTramiteInUse() throws Exception {
+        int id = createTipoTramite("Tramite_delete_conflict_" + System.nanoTime());
+        linkToPlantillaPresupuesto(id);
+
+        mockMvc.perform(delete("/api/v1/tipo-tramite/" + id))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @DisplayName("Should search tipos de tramite by nombre")
+    void shouldSearchTiposTramiteByNombre() throws Exception {
+        String uniqueName = "SearchableTramite_" + System.nanoTime();
+        createTipoTramite(uniqueName);
+
+        mockMvc.perform(get("/api/v1/tipo-tramite/search")
+                        .param("nombre", "SearchableTramite"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.nombre =~ /.*SearchableTramite.*/)]").exists());
+    }
+
+    private int createTipoTramite(String nombre) throws Exception {
+        String body = String.format("""
+                {"nombre": "%s", "seArchiva": false, "seInscribe": false, "asociaInmuebles": false}
+                """, nombre);
+
+        MvcResult result = mockMvc.perform(post("/api/v1/tipo-tramite")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        return mapper.readTree(result.getResponse().getContentAsString())
+                .get("idTipoTramite").asInt();
+    }
+
+    private void linkToPlantillaPresupuesto(int idTipoTramite) {
+        PlantillaPresupuestoPK pk = new PlantillaPresupuestoPK(idTipoTramite, 1);
+        PlantillaPresupuesto plantilla = new PlantillaPresupuesto(pk);
+        plantillaPresupuestoRepository.save(plantilla);
+    }
+}

--- a/backend-api/src/test/java/com/licensis/notaire/unit/SimpleControllersTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/SimpleControllersTest.java
@@ -599,8 +599,14 @@ class SimpleControllersTest {
     @DisplayName("TipoDeTramiteController")
     class TipoDeTramiteControllerTests {
         private final TipoDeTramiteRepository repo = mock(TipoDeTramiteRepository.class);
+        private final com.licensis.notaire.repository.PlantillaTramiteRepository plantillaRepo =
+                mock(com.licensis.notaire.repository.PlantillaTramiteRepository.class);
+        private final com.licensis.notaire.repository.PlantillaPresupuestoRepository presupuestoRepo =
+                mock(com.licensis.notaire.repository.PlantillaPresupuestoRepository.class);
+        private final com.licensis.notaire.repository.TramiteRepository tramiteRepo =
+                mock(com.licensis.notaire.repository.TramiteRepository.class);
         private final org.springframework.test.web.servlet.MockMvc mvc =
-                standaloneSetup(new TipoDeTramiteController(repo)).build();
+                standaloneSetup(new TipoDeTramiteController(repo, plantillaRepo, presupuestoRepo, tramiteRepo)).build();
 
         @Test
         @DisplayName("Cover all paths")
@@ -622,6 +628,9 @@ class SimpleControllersTest {
             when(repo.findById(2)).thenReturn(Optional.empty());
             when(repo.existsById(1)).thenReturn(true);
             when(repo.existsById(2)).thenReturn(false);
+            when(plantillaRepo.findByTipoDeTramiteIdTipoTramite(anyInt())).thenReturn(List.of());
+            when(presupuestoRepo.findByTipoDeTramiteIdTipoTramite(anyInt())).thenReturn(List.of());
+            when(tramiteRepo.findByFkIdTipoTramiteIdTipoTramite(anyInt())).thenReturn(List.of());
 
             mvc.perform(get("/api/v1/tipo-tramite")).andExpect(status().isOk());
             mvc.perform(get("/api/v1/tipo-tramite/1")).andExpect(status().isOk());
@@ -642,7 +651,7 @@ class SimpleControllersTest {
                     .content(mapper.writeValueAsString(dto))).andExpect(status().isConflict());
             mvc.perform(put("/api/v1/tipo-tramite/1").contentType("application/json")
                     .content(mapper.writeValueAsString(dto))).andExpect(status().isInternalServerError());
-            doThrow(new RuntimeException("fk")).when(repo).deleteById(1);
+            when(plantillaRepo.findByTipoDeTramiteIdTipoTramite(1)).thenReturn(List.of(new com.licensis.notaire.negocio.PlantillaTramite()));
             mvc.perform(delete("/api/v1/tipo-tramite/1")).andExpect(status().isConflict());
         }
     }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -430,6 +430,7 @@
       "errorDelete": "Error deleting",
       "noData": "No case types registered",
       "nameRequired": "Name is required",
+      "searchPlaceholder": "Search by name...",
       "fields": {
         "nombre": "Name",
         "namePlaceholder": "E.g.: Sale",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -430,6 +430,7 @@
       "errorDelete": "Error al eliminar",
       "noData": "No hay tipos de trámite registrados",
       "nameRequired": "El nombre es requerido",
+      "searchPlaceholder": "Buscar por nombre...",
       "fields": {
         "nombre": "Nombre",
         "namePlaceholder": "Ej: Compraventa",

--- a/frontend/src/app/dashboard/administracion/tramites/page.tsx
+++ b/frontend/src/app/dashboard/administracion/tramites/page.tsx
@@ -15,6 +15,19 @@ import type { TipoDeTramite } from "@/types";
 
 const EMPTY: Partial<TipoDeTramite> = { nombre: "", descripcion: "" };
 
+function extractApiError(err: unknown): string | null {
+  if (!(err instanceof Error)) return null;
+  if (!err.message.includes("[409]")) return null;
+  try {
+    const jsonStart = err.message.indexOf("{");
+    if (jsonStart !== -1) {
+      const body = JSON.parse(err.message.slice(jsonStart)) as { error?: string };
+      return body.error ?? null;
+    }
+  } catch { }
+  return null;
+}
+
 export default function TramitesPage() {
   const t = useTranslations("administracion.tramites");
   const tc = useTranslations("common");
@@ -28,6 +41,11 @@ export default function TramitesPage() {
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [editing, setEditing] = useState<Partial<TipoDeTramite>>(EMPTY);
   const [isEditMode, setIsEditMode] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const filtered = search.trim()
+    ? data.filter((item) => item.nombre?.toLowerCase().includes(search.toLowerCase()))
+    : data;
 
   function openCreate() { setEditing(EMPTY); setIsEditMode(false); setModalOpen(true); }
   function openEdit(item: TipoDeTramite) { setEditing(item); setIsEditMode(true); setModalOpen(true); }
@@ -43,8 +61,9 @@ export default function TramitesPage() {
         toast.success(t("created"));
       }
       setModalOpen(false);
-    } catch {
-      toast.error(t("errorSave"));
+    } catch (err) {
+      const apiError = extractApiError(err);
+      toast.error(apiError ?? t("errorSave"));
     }
   }
 
@@ -53,8 +72,9 @@ export default function TramitesPage() {
     try {
       await deleteMutation.mutateAsync(deleteId);
       toast.success(t("deleted"));
-    } catch {
-      toast.error(t("errorDelete"));
+    } catch (err) {
+      const apiError = extractApiError(err);
+      toast.error(apiError ?? t("errorDelete"));
     } finally {
       setDeleteId(null);
     }
@@ -91,8 +111,16 @@ export default function TramitesPage() {
           </Button>
         }
       />
+      <div className="mb-4">
+        <Input
+          placeholder={t("searchPlaceholder")}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="max-w-sm"
+        />
+      </div>
       <DataTable
-        data={data}
+        data={filtered}
         columns={columns}
         isLoading={isLoading}
         keyExtractor={(item) => item.idTipoDeTramite!}


### PR DESCRIPTION
## Summary
- Added proactive 409 conflict checks on PUT/DELETE when tipo de tramite is referenced by plantilla_tramite, plantilla_presupuesto, or tramites
- Added `GET /tipo-tramite/search?nombre=xxx` and `GET /tipo-tramite/{id}/in-use` endpoints
- Added search input and 409-aware error messages in the frontend

## Changes
### Added
- `GET /tipo-tramite/search` — filter by name
- `GET /tipo-tramite/{id}/in-use` — check referential usage
- `TipoDeTramiteReferentialIntegrityTest` — 6 TDD integration tests
- `findByNombreContaining` in `TipoDeTramiteRepository`
### Modified
- `TipoDeTramiteController` — referential integrity, 4-arg constructor
- `SimpleControllersTest` — updated for new constructor
- Frontend `administracion/tramites/page.tsx` — search + 409 error handling
- i18n messages (en/es) — `searchPlaceholder` added

## Testing
- [x] Unit tests added/updated
- [x] Integration tests pass (6 new TDD tests)
- [x] All tests pass (`mvn verify -pl backend-api`)
- [x] TypeScript: no errors

## Issue Reference
Fixes #435