### PR TITLE
[#450] feat: Workflow de Estados — schema y modelo de datos

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/negocio/WorkflowDefinition.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/WorkflowDefinition.java
@@ -1,0 +1,127 @@
+package com.licensis.notaire.negocio;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "workflow_definition")
+public class WorkflowDefinition implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_workflow_definition")
+    private Integer id;
+
+    @Column(name = "nombre", nullable = false)
+    private String nombre;
+
+    @Column(name = "descripcion")
+    private String descripcion;
+
+    @Column(name = "activo", nullable = false)
+    private boolean activo = false;
+
+    @Version
+    @Column(name = "version")
+    private int version;
+
+    @OneToMany(mappedBy = "workflowDefinition", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<WorkflowNode> nodes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "workflowDefinition", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<WorkflowTransition> transitions = new ArrayList<>();
+
+    public WorkflowDefinition() {
+    }
+
+    public WorkflowDefinition(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    public boolean isActivo() {
+        return activo;
+    }
+
+    public void setActivo(boolean activo) {
+        this.activo = activo;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public List<WorkflowNode> getNodes() {
+        return nodes;
+    }
+
+    public void setNodes(List<WorkflowNode> nodes) {
+        this.nodes = nodes;
+    }
+
+    public List<WorkflowTransition> getTransitions() {
+        return transitions;
+    }
+
+    public void setTransitions(List<WorkflowTransition> transitions) {
+        this.transitions = transitions;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof WorkflowDefinition other)) {
+            return false;
+        }
+        return this.id != null && this.id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "WorkflowDefinition[id=" + id + ", nombre=" + nombre + "]";
+    }
+}

--- a/backend-api/src/main/java/com/licensis/notaire/negocio/WorkflowNode.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/WorkflowNode.java
@@ -1,0 +1,129 @@
+package com.licensis.notaire.negocio;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "workflow_node")
+public class WorkflowNode implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_workflow_node")
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "fk_workflow_definition_id", nullable = false)
+    private WorkflowDefinition workflowDefinition;
+
+    @ManyToOne
+    @JoinColumn(name = "fk_estado_gestion_id", nullable = false)
+    private EstadoDeGestion estadoDeGestion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo", nullable = false)
+    private WorkflowNodeType tipo;
+
+    @Column(name = "posicion_x")
+    private Float posicionX;
+
+    @Column(name = "posicion_y")
+    private Float posicionY;
+
+    @Version
+    @Column(name = "version")
+    private int version;
+
+    public WorkflowNode() {
+    }
+
+    public WorkflowNode(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public WorkflowDefinition getWorkflowDefinition() {
+        return workflowDefinition;
+    }
+
+    public void setWorkflowDefinition(WorkflowDefinition workflowDefinition) {
+        this.workflowDefinition = workflowDefinition;
+    }
+
+    public EstadoDeGestion getEstadoDeGestion() {
+        return estadoDeGestion;
+    }
+
+    public void setEstadoDeGestion(EstadoDeGestion estadoDeGestion) {
+        this.estadoDeGestion = estadoDeGestion;
+    }
+
+    public WorkflowNodeType getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(WorkflowNodeType tipo) {
+        this.tipo = tipo;
+    }
+
+    public Float getPosicionX() {
+        return posicionX;
+    }
+
+    public void setPosicionX(Float posicionX) {
+        this.posicionX = posicionX;
+    }
+
+    public Float getPosicionY() {
+        return posicionY;
+    }
+
+    public void setPosicionY(Float posicionY) {
+        this.posicionY = posicionY;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof WorkflowNode other)) {
+            return false;
+        }
+        return this.id != null && this.id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "WorkflowNode[id=" + id + ", tipo=" + tipo + "]";
+    }
+}

--- a/backend-api/src/main/java/com/licensis/notaire/negocio/WorkflowNodeType.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/WorkflowNodeType.java
@@ -1,0 +1,7 @@
+package com.licensis.notaire.negocio;
+
+public enum WorkflowNodeType {
+    INITIAL,
+    INTERMEDIATE,
+    FINAL
+}

--- a/backend-api/src/main/java/com/licensis/notaire/negocio/WorkflowTransition.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/WorkflowTransition.java
@@ -1,0 +1,127 @@
+package com.licensis.notaire.negocio;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "workflow_transition")
+public class WorkflowTransition implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_workflow_transition")
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "fk_workflow_definition_id", nullable = false)
+    private WorkflowDefinition workflowDefinition;
+
+    @ManyToOne
+    @JoinColumn(name = "fk_nodo_origen_id", nullable = false)
+    private WorkflowNode nodoOrigen;
+
+    @ManyToOne
+    @JoinColumn(name = "fk_nodo_destino_id", nullable = false)
+    private WorkflowNode nodoDestino;
+
+    @Column(name = "condicion")
+    private String condicion;
+
+    @Column(name = "descripcion")
+    private String descripcion;
+
+    @Version
+    @Column(name = "version")
+    private int version;
+
+    public WorkflowTransition() {
+    }
+
+    public WorkflowTransition(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public WorkflowDefinition getWorkflowDefinition() {
+        return workflowDefinition;
+    }
+
+    public void setWorkflowDefinition(WorkflowDefinition workflowDefinition) {
+        this.workflowDefinition = workflowDefinition;
+    }
+
+    public WorkflowNode getNodoOrigen() {
+        return nodoOrigen;
+    }
+
+    public void setNodoOrigen(WorkflowNode nodoOrigen) {
+        this.nodoOrigen = nodoOrigen;
+    }
+
+    public WorkflowNode getNodoDestino() {
+        return nodoDestino;
+    }
+
+    public void setNodoDestino(WorkflowNode nodoDestino) {
+        this.nodoDestino = nodoDestino;
+    }
+
+    public String getCondicion() {
+        return condicion;
+    }
+
+    public void setCondicion(String condicion) {
+        this.condicion = condicion;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof WorkflowTransition other)) {
+            return false;
+        }
+        return this.id != null && this.id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "WorkflowTransition[id=" + id + "]";
+    }
+}

--- a/backend-api/src/main/java/com/licensis/notaire/repository/WorkflowDefinitionRepository.java
+++ b/backend-api/src/main/java/com/licensis/notaire/repository/WorkflowDefinitionRepository.java
@@ -1,0 +1,15 @@
+package com.licensis.notaire.repository;
+
+import com.licensis.notaire.negocio.WorkflowDefinition;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface WorkflowDefinitionRepository extends JpaRepository<WorkflowDefinition, Integer> {
+
+    List<WorkflowDefinition> findByActivo(boolean activo);
+
+    boolean existsByNombre(String nombre);
+}

--- a/backend-api/src/main/java/com/licensis/notaire/repository/WorkflowNodeRepository.java
+++ b/backend-api/src/main/java/com/licensis/notaire/repository/WorkflowNodeRepository.java
@@ -1,0 +1,16 @@
+package com.licensis.notaire.repository;
+
+import com.licensis.notaire.negocio.WorkflowNode;
+import com.licensis.notaire.negocio.WorkflowNodeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface WorkflowNodeRepository extends JpaRepository<WorkflowNode, Integer> {
+
+    List<WorkflowNode> findByWorkflowDefinitionId(Integer workflowDefinitionId);
+
+    List<WorkflowNode> findByWorkflowDefinitionIdAndTipo(Integer workflowDefinitionId, WorkflowNodeType tipo);
+}

--- a/backend-api/src/main/java/com/licensis/notaire/repository/WorkflowTransitionRepository.java
+++ b/backend-api/src/main/java/com/licensis/notaire/repository/WorkflowTransitionRepository.java
@@ -1,0 +1,15 @@
+package com.licensis.notaire.repository;
+
+import com.licensis.notaire.negocio.WorkflowTransition;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface WorkflowTransitionRepository extends JpaRepository<WorkflowTransition, Integer> {
+
+    List<WorkflowTransition> findByWorkflowDefinitionId(Integer workflowDefinitionId);
+
+    boolean existsByNodoOrigenIdOrNodoDestinoId(Integer nodoOrigenId, Integer nodoDestinoId);
+}

--- a/backend-api/src/main/resources/db/migration/V7__add_workflow_tables.sql
+++ b/backend-api/src/main/resources/db/migration/V7__add_workflow_tables.sql
@@ -1,0 +1,53 @@
+-- =============================================================================
+-- V7__add_workflow_tables.sql
+-- =============================================================================
+-- Author: Matias Miguez
+-- Date: 2026-06-09
+-- Description: Add workflow_definition, workflow_node, and workflow_transition
+--              tables to support directed-graph workflow management for
+--              Estados de Gestión (issues #436, #450 — CU70, CU71).
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- UP Migration
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS workflow_definition (
+    version integer NOT NULL DEFAULT 0,
+    id_workflow_definition SERIAL PRIMARY KEY,
+    nombre text NOT NULL,
+    descripcion text,
+    activo boolean NOT NULL DEFAULT false
+);
+
+CREATE TABLE IF NOT EXISTS workflow_node (
+    version integer NOT NULL DEFAULT 0,
+    id_workflow_node SERIAL PRIMARY KEY,
+    fk_workflow_definition_id integer NOT NULL
+        REFERENCES workflow_definition(id_workflow_definition) ON DELETE CASCADE,
+    fk_estado_gestion_id integer NOT NULL
+        REFERENCES estados_de_gestion(id_estado_gestion),
+    tipo text NOT NULL CHECK (tipo IN ('INITIAL', 'INTERMEDIATE', 'FINAL')),
+    posicion_x real,
+    posicion_y real
+);
+
+CREATE TABLE IF NOT EXISTS workflow_transition (
+    version integer NOT NULL DEFAULT 0,
+    id_workflow_transition SERIAL PRIMARY KEY,
+    fk_workflow_definition_id integer NOT NULL
+        REFERENCES workflow_definition(id_workflow_definition) ON DELETE CASCADE,
+    fk_nodo_origen_id integer NOT NULL
+        REFERENCES workflow_node(id_workflow_node) ON DELETE CASCADE,
+    fk_nodo_destino_id integer NOT NULL
+        REFERENCES workflow_node(id_workflow_node) ON DELETE CASCADE,
+    condicion text,
+    descripcion text
+);
+
+-- -----------------------------------------------------------------------------
+-- Verification
+-- -----------------------------------------------------------------------------
+-- SELECT COUNT(*) FROM workflow_definition;
+-- SELECT COUNT(*) FROM workflow_node;
+-- SELECT COUNT(*) FROM workflow_transition;

--- a/backend-api/src/test/java/com/licensis/notaire/unit/WorkflowEntityTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/WorkflowEntityTest.java
@@ -1,0 +1,174 @@
+package com.licensis.notaire.unit;
+
+import com.licensis.notaire.negocio.EstadoDeGestion;
+import com.licensis.notaire.negocio.WorkflowDefinition;
+import com.licensis.notaire.negocio.WorkflowNode;
+import com.licensis.notaire.negocio.WorkflowNodeType;
+import com.licensis.notaire.negocio.WorkflowTransition;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Workflow Entity Tests")
+class WorkflowEntityTest {
+
+    @Nested
+    @DisplayName("CU70 - WorkflowDefinition entity")
+    class WorkflowDefinitionTests {
+
+        @Test
+        @DisplayName("Should create workflow definition with required fields")
+        void shouldCreateWorkflowDefinitionWithRequiredFields() {
+            WorkflowDefinition wf = new WorkflowDefinition();
+            wf.setNombre("Workflow Compraventa");
+            wf.setDescripcion("Workflow estándar para trámites de compraventa");
+            wf.setActivo(false);
+
+            assertThat(wf.getNombre()).isEqualTo("Workflow Compraventa");
+            assertThat(wf.getDescripcion()).isEqualTo("Workflow estándar para trámites de compraventa");
+            assertThat(wf.isActivo()).isFalse();
+        }
+
+        @Test
+        @DisplayName("Should activate workflow definition")
+        void shouldActivateWorkflowDefinition() {
+            WorkflowDefinition wf = new WorkflowDefinition();
+            wf.setNombre("Workflow Test");
+            wf.setActivo(false);
+
+            wf.setActivo(true);
+
+            assertThat(wf.isActivo()).isTrue();
+        }
+
+        @Test
+        @DisplayName("Should implement equals based on id")
+        void shouldImplementEqualsBasedOnId() {
+            WorkflowDefinition wf1 = new WorkflowDefinition(1);
+            WorkflowDefinition wf2 = new WorkflowDefinition(1);
+            WorkflowDefinition wf3 = new WorkflowDefinition(2);
+
+            assertThat(wf1).isEqualTo(wf2);
+            assertThat(wf1).isNotEqualTo(wf3);
+        }
+
+        @Test
+        @DisplayName("Should initialize nodes and transitions collections as empty")
+        void shouldInitializeCollectionsAsEmpty() {
+            WorkflowDefinition wf = new WorkflowDefinition();
+
+            assertThat(wf.getNodes()).isNotNull();
+            assertThat(wf.getNodes()).isEmpty();
+            assertThat(wf.getTransitions()).isNotNull();
+            assertThat(wf.getTransitions()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("CU70 - WorkflowNode entity")
+    class WorkflowNodeTests {
+
+        @Test
+        @DisplayName("Should create initial node linked to a workflow and estado")
+        void shouldCreateInitialNodeLinkedToWorkflowAndEstado() {
+            WorkflowDefinition wf = new WorkflowDefinition(1);
+            EstadoDeGestion estado = new EstadoDeGestion(10);
+            estado.setNombre("Iniciado");
+
+            WorkflowNode node = new WorkflowNode();
+            node.setWorkflowDefinition(wf);
+            node.setEstadoDeGestion(estado);
+            node.setTipo(WorkflowNodeType.INITIAL);
+            node.setPosicionX(100.0f);
+            node.setPosicionY(200.0f);
+
+            assertThat(node.getWorkflowDefinition()).isEqualTo(wf);
+            assertThat(node.getEstadoDeGestion().getNombre()).isEqualTo("Iniciado");
+            assertThat(node.getTipo()).isEqualTo(WorkflowNodeType.INITIAL);
+            assertThat(node.getPosicionX()).isEqualTo(100.0f);
+            assertThat(node.getPosicionY()).isEqualTo(200.0f);
+        }
+
+        @Test
+        @DisplayName("Should distinguish node types")
+        void shouldDistinguishNodeTypes() {
+            WorkflowNode initial = new WorkflowNode();
+            initial.setTipo(WorkflowNodeType.INITIAL);
+
+            WorkflowNode intermediate = new WorkflowNode();
+            intermediate.setTipo(WorkflowNodeType.INTERMEDIATE);
+
+            WorkflowNode finalNode = new WorkflowNode();
+            finalNode.setTipo(WorkflowNodeType.FINAL);
+
+            assertThat(initial.getTipo()).isEqualTo(WorkflowNodeType.INITIAL);
+            assertThat(intermediate.getTipo()).isEqualTo(WorkflowNodeType.INTERMEDIATE);
+            assertThat(finalNode.getTipo()).isEqualTo(WorkflowNodeType.FINAL);
+        }
+
+        @Test
+        @DisplayName("Should implement equals based on id")
+        void shouldImplementEqualsBasedOnId() {
+            WorkflowNode n1 = new WorkflowNode(1);
+            WorkflowNode n2 = new WorkflowNode(1);
+            WorkflowNode n3 = new WorkflowNode(2);
+
+            assertThat(n1).isEqualTo(n2);
+            assertThat(n1).isNotEqualTo(n3);
+        }
+    }
+
+    @Nested
+    @DisplayName("CU71 - WorkflowTransition entity")
+    class WorkflowTransitionTests {
+
+        @Test
+        @DisplayName("Should create transition between two nodes")
+        void shouldCreateTransitionBetweenTwoNodes() {
+            WorkflowDefinition wf = new WorkflowDefinition(1);
+            WorkflowNode origen = new WorkflowNode(1);
+            WorkflowNode destino = new WorkflowNode(2);
+
+            WorkflowTransition transition = new WorkflowTransition();
+            transition.setWorkflowDefinition(wf);
+            transition.setNodoOrigen(origen);
+            transition.setNodoDestino(destino);
+            transition.setDescripcion("Avance de estado");
+
+            assertThat(transition.getWorkflowDefinition()).isEqualTo(wf);
+            assertThat(transition.getNodoOrigen()).isEqualTo(origen);
+            assertThat(transition.getNodoDestino()).isEqualTo(destino);
+            assertThat(transition.getDescripcion()).isEqualTo("Avance de estado");
+        }
+
+        @Test
+        @DisplayName("Should allow optional condition on transition")
+        void shouldAllowOptionalConditionOnTransition() {
+            WorkflowTransition transition = new WorkflowTransition();
+            transition.setCondicion("estado.documentosCompletos == true");
+
+            assertThat(transition.getCondicion()).isEqualTo("estado.documentosCompletos == true");
+        }
+
+        @Test
+        @DisplayName("Should allow null condition when no restriction")
+        void shouldAllowNullConditionWhenNoRestriction() {
+            WorkflowTransition transition = new WorkflowTransition();
+
+            assertThat(transition.getCondicion()).isNull();
+        }
+
+        @Test
+        @DisplayName("Should implement equals based on id")
+        void shouldImplementEqualsBasedOnId() {
+            WorkflowTransition t1 = new WorkflowTransition(1);
+            WorkflowTransition t2 = new WorkflowTransition(1);
+            WorkflowTransition t3 = new WorkflowTransition(2);
+
+            assertThat(t1).isEqualTo(t2);
+            assertThat(t1).isNotEqualTo(t3);
+        }
+    }
+}

--- a/docs/01-business/00-FUNCTIONAL-BASELINE.md
+++ b/docs/01-business/00-FUNCTIONAL-BASELINE.md
@@ -180,6 +180,14 @@ graph LR
 | CU67 | Buscar Estados de Gestión | N | ✅ | ✅ |
 | CU68 | Buscar tipos de folios | N | ✅ *(fixed)* | ✅ |
 
+### Workflow de Estados de Gestión
+| CU | Name | Grado | API | UI |
+|----|------|:----:|:--:|:--:|
+| CU70 | Definir Workflow de Estados de Gestión | E | 🔲 | 🔲 |
+| CU71 | Definir Transiciones entre Estados | E | 🔲 | 🔲 |
+| CU72 | Validar Consistencia del Workflow | E | 🔲 | 🔲 |
+| CU73 | Asignar Workflow a Tipo de Trámite | E | 🔲 | 🔲 |
+
 ### Auditoría
 | CU | Name | Grado | API | UI |
 |----|------|:----:|:--:|:--:|

--- a/init-db/01-schema.sql
+++ b/init-db/01-schema.sql
@@ -27,6 +27,9 @@ DROP TABLE IF EXISTS tipos_identificacion CASCADE;
 DROP TABLE IF EXISTS tipos_de_tramite CASCADE;
 DROP TABLE IF EXISTS tipos_de_folio CASCADE;
 DROP TABLE IF EXISTS tipos_de_documento CASCADE;
+DROP TABLE IF EXISTS workflow_transition CASCADE;
+DROP TABLE IF EXISTS workflow_node CASCADE;
+DROP TABLE IF EXISTS workflow_definition CASCADE;
 DROP TABLE IF EXISTS estados_de_gestion CASCADE;
 DROP TABLE IF EXISTS conceptos CASCADE;
 
@@ -47,6 +50,37 @@ CREATE TABLE estados_de_gestion (
   id_estado_gestion SERIAL PRIMARY KEY,
   nombre text NOT NULL,
   observaciones text
+);
+
+-- Table: workflow_definition
+CREATE TABLE workflow_definition (
+  version integer NOT NULL DEFAULT 0,
+  id_workflow_definition SERIAL PRIMARY KEY,
+  nombre text NOT NULL,
+  descripcion text,
+  activo boolean NOT NULL DEFAULT false
+);
+
+-- Table: workflow_node
+CREATE TABLE workflow_node (
+  version integer NOT NULL DEFAULT 0,
+  id_workflow_node SERIAL PRIMARY KEY,
+  fk_workflow_definition_id integer NOT NULL REFERENCES workflow_definition(id_workflow_definition) ON DELETE CASCADE,
+  fk_estado_gestion_id integer NOT NULL REFERENCES estados_de_gestion(id_estado_gestion),
+  tipo text NOT NULL CHECK (tipo IN ('INITIAL', 'INTERMEDIATE', 'FINAL')),
+  posicion_x real,
+  posicion_y real
+);
+
+-- Table: workflow_transition
+CREATE TABLE workflow_transition (
+  version integer NOT NULL DEFAULT 0,
+  id_workflow_transition SERIAL PRIMARY KEY,
+  fk_workflow_definition_id integer NOT NULL REFERENCES workflow_definition(id_workflow_definition) ON DELETE CASCADE,
+  fk_nodo_origen_id integer NOT NULL REFERENCES workflow_node(id_workflow_node) ON DELETE CASCADE,
+  fk_nodo_destino_id integer NOT NULL REFERENCES workflow_node(id_workflow_node) ON DELETE CASCADE,
+  condicion text,
+  descripcion text
 );
 
 -- Table: tipos_de_documento


### PR DESCRIPTION
## Summary
- New JPA entities: `WorkflowDefinition`, `WorkflowNode` (with `WorkflowNodeType` enum: INITIAL/INTERMEDIATE/FINAL), `WorkflowTransition`
- Spring Data repositories for all three entities
- Flyway migration `V7__add_workflow_tables.sql` (new tables with FK constraints and CASCADE delete)
- `init-db/01-schema.sql` updated to keep Docker authoritative schema aligned
- New Use Cases CU70–CU73 added to functional baseline

## Changes
### Added
- `WorkflowDefinition` — workflow container (nombre, descripcion, activo)
- `WorkflowNode` — graph node (workflow FK, estado FK, tipo, posicion x/y)
- `WorkflowTransition` — directed edge (origen node → destino node, optional condicion)
- `WorkflowNodeType` enum — INITIAL | INTERMEDIATE | FINAL
- 3 Spring Data repositories
- V7 Flyway migration
- Unit tests for all three entities (12 tests, all passing)

## Testing
- [x] Unit tests added (`WorkflowEntityTest` — 12 tests)
- [x] All 491 backend tests pass (`mvn verify -pl backend-api`)
- [x] init-db aligned with Flyway migration (same DDL)
- [ ] Integration tests (pg-integration) — require running PostgreSQL

## Documentation
- [x] CU70–CU73 added to `docs/01-business/00-FUNCTIONAL-BASELINE.md`
- [x] Sub-issues #451–#455 created for remaining workflow work

## Issue Reference
Closes #450
Part of #436