### PR TITLE
[#451] feat: Workflow — REST API (CRUD workflows, nodos y transiciones)

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/WorkflowDefinitionController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/WorkflowDefinitionController.java
@@ -1,0 +1,106 @@
+package com.licensis.notaire.api;
+
+import com.licensis.notaire.dto.DtoWorkflowDefinition;
+import com.licensis.notaire.negocio.WorkflowDefinition;
+import com.licensis.notaire.repository.WorkflowDefinitionRepository;
+import com.licensis.notaire.repository.WorkflowNodeRepository;
+import com.licensis.notaire.repository.WorkflowTransitionRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/v1/workflow-definition")
+@Tag(name = "Workflow Definition", description = "CU70 - Gestión de workflows de estados")
+public class WorkflowDefinitionController {
+
+    private final WorkflowDefinitionRepository repository;
+    private final WorkflowNodeRepository nodeRepository;
+    private final WorkflowTransitionRepository transitionRepository;
+
+    public WorkflowDefinitionController(WorkflowDefinitionRepository repository,
+            WorkflowNodeRepository nodeRepository,
+            WorkflowTransitionRepository transitionRepository) {
+        this.repository = repository;
+        this.nodeRepository = nodeRepository;
+        this.transitionRepository = transitionRepository;
+    }
+
+    @GetMapping
+    @Operation(summary = "Obtener todos los workflows")
+    public ResponseEntity<List<DtoWorkflowDefinition>> getAll() {
+        return ResponseEntity.ok(repository.findAll().stream().map(WorkflowDefinition::toDto).toList());
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Obtener workflow por ID")
+    public ResponseEntity<DtoWorkflowDefinition> getById(@PathVariable Integer id) {
+        return repository.findById(id)
+                .map(wf -> ResponseEntity.ok(wf.toDto()))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    @Operation(summary = "Crear workflow")
+    public ResponseEntity<Object> create(@RequestBody DtoWorkflowDefinition dto) {
+        try {
+            WorkflowDefinition entity = new WorkflowDefinition();
+            entity.setNombre(dto.getNombre());
+            entity.setDescripcion(dto.getDescripcion());
+            entity.setActivo(dto.isActivo());
+            entity = repository.save(entity);
+            return ResponseEntity.status(HttpStatus.CREATED).body(entity.toDto());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Actualizar workflow")
+    public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody DtoWorkflowDefinition dto) {
+        Optional<WorkflowDefinition> existing = repository.findById(id);
+        if (existing.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        try {
+            WorkflowDefinition entity = existing.get();
+            entity.setNombre(dto.getNombre());
+            entity.setDescripcion(dto.getDescripcion());
+            entity.setActivo(dto.isActivo());
+            if (dto.getVersion() != null) {
+                entity.setVersion(dto.getVersion());
+            }
+            repository.save(entity);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Eliminar workflow")
+    public ResponseEntity<Object> delete(@PathVariable Integer id) {
+        if (!repository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        if (!nodeRepository.findByWorkflowDefinitionId(id).isEmpty()) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("error", "No se puede eliminar: el workflow tiene nodos asociados."));
+        }
+        repository.deleteById(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend-api/src/main/java/com/licensis/notaire/api/WorkflowNodeController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/WorkflowNodeController.java
@@ -1,0 +1,127 @@
+package com.licensis.notaire.api;
+
+import com.licensis.notaire.dto.DtoWorkflowNode;
+import com.licensis.notaire.negocio.EstadoDeGestion;
+import com.licensis.notaire.negocio.WorkflowDefinition;
+import com.licensis.notaire.negocio.WorkflowNode;
+import com.licensis.notaire.negocio.WorkflowNodeType;
+import com.licensis.notaire.repository.EstadoDeGestionRepository;
+import com.licensis.notaire.repository.WorkflowDefinitionRepository;
+import com.licensis.notaire.repository.WorkflowNodeRepository;
+import com.licensis.notaire.repository.WorkflowTransitionRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/v1/workflow-node")
+@Tag(name = "Workflow Node", description = "CU70/CU71 - Nodos de workflows de estados")
+public class WorkflowNodeController {
+
+    private final WorkflowNodeRepository repository;
+    private final WorkflowDefinitionRepository workflowRepository;
+    private final EstadoDeGestionRepository estadoRepository;
+    private final WorkflowTransitionRepository transitionRepository;
+
+    public WorkflowNodeController(WorkflowNodeRepository repository,
+            WorkflowDefinitionRepository workflowRepository,
+            EstadoDeGestionRepository estadoRepository,
+            WorkflowTransitionRepository transitionRepository) {
+        this.repository = repository;
+        this.workflowRepository = workflowRepository;
+        this.estadoRepository = estadoRepository;
+        this.transitionRepository = transitionRepository;
+    }
+
+    @GetMapping("/by-workflow/{workflowId}")
+    @Operation(summary = "Obtener nodos por workflow")
+    public ResponseEntity<List<DtoWorkflowNode>> getByWorkflow(@PathVariable Integer workflowId) {
+        return ResponseEntity.ok(repository.findByWorkflowDefinitionId(workflowId)
+                .stream().map(WorkflowNode::toDto).toList());
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Obtener nodo por ID")
+    public ResponseEntity<DtoWorkflowNode> getById(@PathVariable Integer id) {
+        return repository.findById(id)
+                .map(n -> ResponseEntity.ok(n.toDto()))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    @Operation(summary = "Crear nodo en un workflow")
+    public ResponseEntity<Object> create(@RequestBody DtoWorkflowNode dto) {
+        Optional<WorkflowDefinition> wf = workflowRepository.findById(dto.getWorkflowDefinitionId());
+        if (wf.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        Optional<EstadoDeGestion> estado = estadoRepository.findById(dto.getEstadoGestionId());
+        if (estado.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        try {
+            WorkflowNode node = new WorkflowNode();
+            node.setWorkflowDefinition(wf.get());
+            node.setEstadoDeGestion(estado.get());
+            node.setTipo(WorkflowNodeType.valueOf(dto.getTipo()));
+            node.setPosicionX(dto.getPosicionX());
+            node.setPosicionY(dto.getPosicionY());
+            node = repository.save(node);
+            return ResponseEntity.status(HttpStatus.CREATED).body(node.toDto());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Actualizar nodo")
+    public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody DtoWorkflowNode dto) {
+        Optional<WorkflowNode> existing = repository.findById(id);
+        if (existing.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        try {
+            WorkflowNode node = existing.get();
+            if (dto.getTipo() != null) {
+                node.setTipo(WorkflowNodeType.valueOf(dto.getTipo()));
+            }
+            if (dto.getPosicionX() != null) {
+                node.setPosicionX(dto.getPosicionX());
+            }
+            if (dto.getPosicionY() != null) {
+                node.setPosicionY(dto.getPosicionY());
+            }
+            repository.save(node);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Eliminar nodo")
+    public ResponseEntity<Object> delete(@PathVariable Integer id) {
+        if (!repository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        if (transitionRepository.existsByNodoOrigenIdOrNodoDestinoId(id, id)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("error", "No se puede eliminar: el nodo tiene transiciones asociadas."));
+        }
+        repository.deleteById(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend-api/src/main/java/com/licensis/notaire/api/WorkflowTransitionController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/WorkflowTransitionController.java
@@ -1,0 +1,96 @@
+package com.licensis.notaire.api;
+
+import com.licensis.notaire.dto.DtoWorkflowTransition;
+import com.licensis.notaire.negocio.WorkflowDefinition;
+import com.licensis.notaire.negocio.WorkflowNode;
+import com.licensis.notaire.negocio.WorkflowTransition;
+import com.licensis.notaire.repository.WorkflowDefinitionRepository;
+import com.licensis.notaire.repository.WorkflowNodeRepository;
+import com.licensis.notaire.repository.WorkflowTransitionRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/v1/workflow-transition")
+@Tag(name = "Workflow Transition", description = "CU71 - Transiciones entre estados de un workflow")
+public class WorkflowTransitionController {
+
+    private final WorkflowTransitionRepository repository;
+    private final WorkflowNodeRepository nodeRepository;
+    private final WorkflowDefinitionRepository workflowRepository;
+
+    public WorkflowTransitionController(WorkflowTransitionRepository repository,
+            WorkflowNodeRepository nodeRepository,
+            WorkflowDefinitionRepository workflowRepository) {
+        this.repository = repository;
+        this.nodeRepository = nodeRepository;
+        this.workflowRepository = workflowRepository;
+    }
+
+    @GetMapping("/by-workflow/{workflowId}")
+    @Operation(summary = "Obtener transiciones por workflow")
+    public ResponseEntity<List<DtoWorkflowTransition>> getByWorkflow(@PathVariable Integer workflowId) {
+        return ResponseEntity.ok(repository.findByWorkflowDefinitionId(workflowId)
+                .stream().map(WorkflowTransition::toDto).toList());
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Obtener transición por ID")
+    public ResponseEntity<DtoWorkflowTransition> getById(@PathVariable Integer id) {
+        return repository.findById(id)
+                .map(t -> ResponseEntity.ok(t.toDto()))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    @Operation(summary = "Crear transición entre dos nodos")
+    public ResponseEntity<Object> create(@RequestBody DtoWorkflowTransition dto) {
+        Optional<WorkflowDefinition> wf = workflowRepository.findById(dto.getWorkflowDefinitionId());
+        if (wf.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        Optional<WorkflowNode> origen = nodeRepository.findById(dto.getNodoOrigenId());
+        if (origen.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        Optional<WorkflowNode> destino = nodeRepository.findById(dto.getNodoDestinoId());
+        if (destino.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        try {
+            WorkflowTransition transition = new WorkflowTransition();
+            transition.setWorkflowDefinition(wf.get());
+            transition.setNodoOrigen(origen.get());
+            transition.setNodoDestino(destino.get());
+            transition.setCondicion(dto.getCondicion());
+            transition.setDescripcion(dto.getDescripcion());
+            transition = repository.save(transition);
+            return ResponseEntity.status(HttpStatus.CREATED).body(transition.toDto());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Eliminar transición")
+    public ResponseEntity<Object> delete(@PathVariable Integer id) {
+        if (!repository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        repository.deleteById(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend-api/src/main/java/com/licensis/notaire/negocio/WorkflowDefinition.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/WorkflowDefinition.java
@@ -1,5 +1,6 @@
 package com.licensis.notaire.negocio;
 
+import com.licensis.notaire.dto.DtoWorkflowDefinition;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -105,6 +106,16 @@ public class WorkflowDefinition implements Serializable {
 
     public void setTransitions(List<WorkflowTransition> transitions) {
         this.transitions = transitions;
+    }
+
+    public DtoWorkflowDefinition toDto() {
+        DtoWorkflowDefinition dto = new DtoWorkflowDefinition();
+        dto.setId(this.id);
+        dto.setNombre(this.nombre);
+        dto.setDescripcion(this.descripcion);
+        dto.setActivo(this.activo);
+        dto.setVersion(this.version);
+        return dto;
     }
 
     @Override

--- a/backend-api/src/main/java/com/licensis/notaire/negocio/WorkflowNode.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/WorkflowNode.java
@@ -1,5 +1,6 @@
 package com.licensis.notaire.negocio;
 
+import com.licensis.notaire.dto.DtoWorkflowNode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -107,6 +108,19 @@ public class WorkflowNode implements Serializable {
 
     public void setVersion(int version) {
         this.version = version;
+    }
+
+    public DtoWorkflowNode toDto() {
+        DtoWorkflowNode dto = new DtoWorkflowNode();
+        dto.setId(this.id);
+        dto.setWorkflowDefinitionId(workflowDefinition != null ? workflowDefinition.getId() : null);
+        dto.setEstadoGestionId(estadoDeGestion != null ? estadoDeGestion.getIdEstadoGestion() : null);
+        dto.setEstadoGestionNombre(estadoDeGestion != null ? estadoDeGestion.getNombre() : null);
+        dto.setTipo(tipo != null ? tipo.name() : null);
+        dto.setPosicionX(this.posicionX);
+        dto.setPosicionY(this.posicionY);
+        dto.setVersion(this.version);
+        return dto;
     }
 
     @Override

--- a/backend-api/src/main/java/com/licensis/notaire/negocio/WorkflowTransition.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/WorkflowTransition.java
@@ -1,5 +1,6 @@
 package com.licensis.notaire.negocio;
 
+import com.licensis.notaire.dto.DtoWorkflowTransition;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -105,6 +106,18 @@ public class WorkflowTransition implements Serializable {
 
     public void setVersion(int version) {
         this.version = version;
+    }
+
+    public DtoWorkflowTransition toDto() {
+        DtoWorkflowTransition dto = new DtoWorkflowTransition();
+        dto.setId(this.id);
+        dto.setWorkflowDefinitionId(workflowDefinition != null ? workflowDefinition.getId() : null);
+        dto.setNodoOrigenId(nodoOrigen != null ? nodoOrigen.getId() : null);
+        dto.setNodoDestinoId(nodoDestino != null ? nodoDestino.getId() : null);
+        dto.setCondicion(this.condicion);
+        dto.setDescripcion(this.descripcion);
+        dto.setVersion(this.version);
+        return dto;
     }
 
     @Override

--- a/backend-api/src/test/java/com/licensis/notaire/unit/WorkflowDefinitionControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/WorkflowDefinitionControllerTest.java
@@ -1,0 +1,157 @@
+package com.licensis.notaire.unit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.licensis.notaire.api.WorkflowDefinitionController;
+import com.licensis.notaire.dto.DtoWorkflowDefinition;
+import com.licensis.notaire.negocio.WorkflowDefinition;
+import com.licensis.notaire.repository.WorkflowDefinitionRepository;
+import com.licensis.notaire.repository.WorkflowNodeRepository;
+import com.licensis.notaire.repository.WorkflowTransitionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("CU70 - WorkflowDefinitionController unit tests")
+@ExtendWith(MockitoExtension.class)
+class WorkflowDefinitionControllerTest {
+
+    @Mock
+    private WorkflowDefinitionRepository repository;
+    @Mock
+    private WorkflowNodeRepository nodeRepository;
+    @Mock
+    private WorkflowTransitionRepository transitionRepository;
+
+    private MockMvc mockMvc;
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        WorkflowDefinitionController controller = new WorkflowDefinitionController(
+                repository, nodeRepository, transitionRepository);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        mapper = new ObjectMapper();
+    }
+
+    private WorkflowDefinition buildEntity() {
+        WorkflowDefinition wf = new WorkflowDefinition();
+        wf.setId(1);
+        wf.setNombre("Workflow Compraventa");
+        wf.setDescripcion("Workflow estándar");
+        wf.setActivo(false);
+        return wf;
+    }
+
+    private DtoWorkflowDefinition buildDto() {
+        DtoWorkflowDefinition dto = new DtoWorkflowDefinition();
+        dto.setNombre("Workflow Compraventa");
+        dto.setDescripcion("Workflow estándar");
+        dto.setActivo(false);
+        dto.setVersion(0);
+        return dto;
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/workflow-definition should return 200 with list")
+    void shouldReturnAllWorkflows() throws Exception {
+        when(repository.findAll()).thenReturn(List.of(buildEntity()));
+        mockMvc.perform(get("/api/v1/workflow-definition"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].nombre").value("Workflow Compraventa"));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/workflow-definition/{id} should return 200 when found")
+    void shouldReturnWorkflowById() throws Exception {
+        when(repository.findById(1)).thenReturn(Optional.of(buildEntity()));
+        mockMvc.perform(get("/api/v1/workflow-definition/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nombre").value("Workflow Compraventa"));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/workflow-definition/{id} should return 404 when missing")
+    void shouldReturn404WhenWorkflowMissing() throws Exception {
+        when(repository.findById(99)).thenReturn(Optional.empty());
+        mockMvc.perform(get("/api/v1/workflow-definition/99"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/workflow-definition should return 201 when created")
+    void shouldCreateWorkflow() throws Exception {
+        WorkflowDefinition saved = buildEntity();
+        when(repository.save(any(WorkflowDefinition.class))).thenReturn(saved);
+        mockMvc.perform(post("/api/v1/workflow-definition")
+                        .contentType("application/json")
+                        .content(mapper.writeValueAsString(buildDto())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.nombre").value("Workflow Compraventa"));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/workflow-definition should return 409 when save fails")
+    void shouldReturn409WhenCreateFails() throws Exception {
+        when(repository.save(any(WorkflowDefinition.class))).thenThrow(new RuntimeException("conflict"));
+        mockMvc.perform(post("/api/v1/workflow-definition")
+                        .contentType("application/json")
+                        .content(mapper.writeValueAsString(buildDto())))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/workflow-definition/{id} should return 200 when updated")
+    void shouldUpdateWorkflow() throws Exception {
+        WorkflowDefinition existing = buildEntity();
+        when(repository.findById(1)).thenReturn(Optional.of(existing));
+        when(repository.save(any(WorkflowDefinition.class))).thenReturn(existing);
+        mockMvc.perform(put("/api/v1/workflow-definition/1")
+                        .contentType("application/json")
+                        .content(mapper.writeValueAsString(buildDto())))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/workflow-definition/{id} should return 404 when missing")
+    void shouldReturn404WhenUpdatingMissingWorkflow() throws Exception {
+        when(repository.findById(99)).thenReturn(Optional.empty());
+        mockMvc.perform(put("/api/v1/workflow-definition/99")
+                        .contentType("application/json")
+                        .content(mapper.writeValueAsString(buildDto())))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/workflow-definition/{id} should return 200 when deleted")
+    void shouldDeleteWorkflow() throws Exception {
+        when(repository.existsById(1)).thenReturn(true);
+        when(nodeRepository.findByWorkflowDefinitionId(1)).thenReturn(List.of());
+        mockMvc.perform(delete("/api/v1/workflow-definition/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/workflow-definition/{id} should return 404 when missing")
+    void shouldReturn404WhenDeletingMissingWorkflow() throws Exception {
+        when(repository.existsById(99)).thenReturn(false);
+        mockMvc.perform(delete("/api/v1/workflow-definition/99"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/backend-api/src/test/java/com/licensis/notaire/unit/WorkflowNodeControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/WorkflowNodeControllerTest.java
@@ -1,0 +1,164 @@
+package com.licensis.notaire.unit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.licensis.notaire.api.WorkflowNodeController;
+import com.licensis.notaire.dto.DtoWorkflowNode;
+import com.licensis.notaire.negocio.EstadoDeGestion;
+import com.licensis.notaire.negocio.WorkflowDefinition;
+import com.licensis.notaire.negocio.WorkflowNode;
+import com.licensis.notaire.negocio.WorkflowNodeType;
+import com.licensis.notaire.repository.EstadoDeGestionRepository;
+import com.licensis.notaire.repository.WorkflowDefinitionRepository;
+import com.licensis.notaire.repository.WorkflowNodeRepository;
+import com.licensis.notaire.repository.WorkflowTransitionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("CU70/CU71 - WorkflowNodeController unit tests")
+@ExtendWith(MockitoExtension.class)
+class WorkflowNodeControllerTest {
+
+    @Mock
+    private WorkflowNodeRepository repository;
+    @Mock
+    private WorkflowDefinitionRepository workflowRepository;
+    @Mock
+    private EstadoDeGestionRepository estadoRepository;
+    @Mock
+    private WorkflowTransitionRepository transitionRepository;
+
+    private MockMvc mockMvc;
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        WorkflowNodeController controller = new WorkflowNodeController(
+                repository, workflowRepository, estadoRepository, transitionRepository);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        mapper = new ObjectMapper();
+    }
+
+    private WorkflowNode buildEntity() {
+        WorkflowDefinition wf = new WorkflowDefinition(1);
+        EstadoDeGestion estado = new EstadoDeGestion(10);
+        estado.setNombre("Iniciado");
+        WorkflowNode node = new WorkflowNode();
+        node.setId(1);
+        node.setWorkflowDefinition(wf);
+        node.setEstadoDeGestion(estado);
+        node.setTipo(WorkflowNodeType.INITIAL);
+        node.setPosicionX(100f);
+        node.setPosicionY(200f);
+        return node;
+    }
+
+    private DtoWorkflowNode buildDto() {
+        DtoWorkflowNode dto = new DtoWorkflowNode();
+        dto.setWorkflowDefinitionId(1);
+        dto.setEstadoGestionId(10);
+        dto.setTipo("INITIAL");
+        dto.setPosicionX(100f);
+        dto.setPosicionY(200f);
+        dto.setVersion(0);
+        return dto;
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/workflow-node/by-workflow/{id} should return nodes for workflow")
+    void shouldReturnNodesForWorkflow() throws Exception {
+        when(repository.findByWorkflowDefinitionId(1)).thenReturn(List.of(buildEntity()));
+        mockMvc.perform(get("/api/v1/workflow-node/by-workflow/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].tipo").value("INITIAL"));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/workflow-node/{id} should return 200 when found")
+    void shouldReturnNodeById() throws Exception {
+        when(repository.findById(1)).thenReturn(Optional.of(buildEntity()));
+        mockMvc.perform(get("/api/v1/workflow-node/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tipo").value("INITIAL"));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/workflow-node/{id} should return 404 when missing")
+    void shouldReturn404WhenNodeMissing() throws Exception {
+        when(repository.findById(99)).thenReturn(Optional.empty());
+        mockMvc.perform(get("/api/v1/workflow-node/99"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/workflow-node should return 201 when created")
+    void shouldCreateNode() throws Exception {
+        WorkflowDefinition wf = new WorkflowDefinition(1);
+        EstadoDeGestion estado = new EstadoDeGestion(10);
+        WorkflowNode saved = buildEntity();
+        when(workflowRepository.findById(1)).thenReturn(Optional.of(wf));
+        when(estadoRepository.findById(10)).thenReturn(Optional.of(estado));
+        when(repository.save(any(WorkflowNode.class))).thenReturn(saved);
+        mockMvc.perform(post("/api/v1/workflow-node")
+                        .contentType("application/json")
+                        .content(mapper.writeValueAsString(buildDto())))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/workflow-node should return 404 when workflow not found")
+    void shouldReturn404WhenWorkflowMissing() throws Exception {
+        when(workflowRepository.findById(1)).thenReturn(Optional.empty());
+        mockMvc.perform(post("/api/v1/workflow-node")
+                        .contentType("application/json")
+                        .content(mapper.writeValueAsString(buildDto())))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/workflow-node/{id} should return 200 when updated")
+    void shouldUpdateNode() throws Exception {
+        WorkflowNode existing = buildEntity();
+        when(repository.findById(1)).thenReturn(Optional.of(existing));
+        when(repository.save(any(WorkflowNode.class))).thenReturn(existing);
+        mockMvc.perform(put("/api/v1/workflow-node/1")
+                        .contentType("application/json")
+                        .content(mapper.writeValueAsString(buildDto())))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/workflow-node/{id} should return 200 when deleted")
+    void shouldDeleteNode() throws Exception {
+        when(repository.existsById(1)).thenReturn(true);
+        when(transitionRepository.existsByNodoOrigenIdOrNodoDestinoId(1, 1)).thenReturn(false);
+        mockMvc.perform(delete("/api/v1/workflow-node/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/workflow-node/{id} should return 409 when node has transitions")
+    void shouldReturn409WhenNodeHasTransitions() throws Exception {
+        when(repository.existsById(1)).thenReturn(true);
+        when(transitionRepository.existsByNodoOrigenIdOrNodoDestinoId(1, 1)).thenReturn(true);
+        mockMvc.perform(delete("/api/v1/workflow-node/1"))
+                .andExpect(status().isConflict());
+    }
+}

--- a/backend-api/src/test/java/com/licensis/notaire/unit/WorkflowTransitionControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/WorkflowTransitionControllerTest.java
@@ -1,0 +1,148 @@
+package com.licensis.notaire.unit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.licensis.notaire.api.WorkflowTransitionController;
+import com.licensis.notaire.dto.DtoWorkflowTransition;
+import com.licensis.notaire.negocio.WorkflowDefinition;
+import com.licensis.notaire.negocio.WorkflowNode;
+import com.licensis.notaire.negocio.WorkflowNodeType;
+import com.licensis.notaire.negocio.WorkflowTransition;
+import com.licensis.notaire.repository.WorkflowDefinitionRepository;
+import com.licensis.notaire.repository.WorkflowNodeRepository;
+import com.licensis.notaire.repository.WorkflowTransitionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("CU71 - WorkflowTransitionController unit tests")
+@ExtendWith(MockitoExtension.class)
+class WorkflowTransitionControllerTest {
+
+    @Mock
+    private WorkflowTransitionRepository repository;
+    @Mock
+    private WorkflowNodeRepository nodeRepository;
+    @Mock
+    private WorkflowDefinitionRepository workflowRepository;
+
+    private MockMvc mockMvc;
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        WorkflowTransitionController controller = new WorkflowTransitionController(
+                repository, nodeRepository, workflowRepository);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        mapper = new ObjectMapper();
+    }
+
+    private WorkflowNode buildNode(int id, WorkflowNodeType tipo) {
+        WorkflowNode node = new WorkflowNode(id);
+        node.setTipo(tipo);
+        node.setWorkflowDefinition(new WorkflowDefinition(1));
+        return node;
+    }
+
+    private WorkflowTransition buildEntity() {
+        WorkflowTransition t = new WorkflowTransition();
+        t.setId(1);
+        t.setWorkflowDefinition(new WorkflowDefinition(1));
+        t.setNodoOrigen(buildNode(1, WorkflowNodeType.INITIAL));
+        t.setNodoDestino(buildNode(2, WorkflowNodeType.INTERMEDIATE));
+        t.setDescripcion("Inicio → Revisión");
+        return t;
+    }
+
+    private DtoWorkflowTransition buildDto() {
+        DtoWorkflowTransition dto = new DtoWorkflowTransition();
+        dto.setWorkflowDefinitionId(1);
+        dto.setNodoOrigenId(1);
+        dto.setNodoDestinoId(2);
+        dto.setDescripcion("Inicio → Revisión");
+        dto.setVersion(0);
+        return dto;
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/workflow-transition/by-workflow/{id} should return transitions")
+    void shouldReturnTransitionsForWorkflow() throws Exception {
+        when(repository.findByWorkflowDefinitionId(1)).thenReturn(List.of(buildEntity()));
+        mockMvc.perform(get("/api/v1/workflow-transition/by-workflow/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].descripcion").value("Inicio → Revisión"));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/workflow-transition/{id} should return 200 when found")
+    void shouldReturnTransitionById() throws Exception {
+        when(repository.findById(1)).thenReturn(Optional.of(buildEntity()));
+        mockMvc.perform(get("/api/v1/workflow-transition/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/workflow-transition/{id} should return 404 when missing")
+    void shouldReturn404WhenTransitionMissing() throws Exception {
+        when(repository.findById(99)).thenReturn(Optional.empty());
+        mockMvc.perform(get("/api/v1/workflow-transition/99"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/workflow-transition should return 201 when created")
+    void shouldCreateTransition() throws Exception {
+        WorkflowTransition saved = buildEntity();
+        WorkflowDefinition wf = new WorkflowDefinition(1);
+        when(workflowRepository.findById(1)).thenReturn(Optional.of(wf));
+        when(nodeRepository.findById(1)).thenReturn(Optional.of(buildNode(1, WorkflowNodeType.INITIAL)));
+        when(nodeRepository.findById(2)).thenReturn(Optional.of(buildNode(2, WorkflowNodeType.INTERMEDIATE)));
+        when(repository.save(any(WorkflowTransition.class))).thenReturn(saved);
+        mockMvc.perform(post("/api/v1/workflow-transition")
+                        .contentType("application/json")
+                        .content(mapper.writeValueAsString(buildDto())))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/workflow-transition should return 404 when origin node missing")
+    void shouldReturn404WhenOriginNodeMissing() throws Exception {
+        when(workflowRepository.findById(1)).thenReturn(Optional.of(new WorkflowDefinition(1)));
+        when(nodeRepository.findById(1)).thenReturn(Optional.empty());
+        mockMvc.perform(post("/api/v1/workflow-transition")
+                        .contentType("application/json")
+                        .content(mapper.writeValueAsString(buildDto())))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/workflow-transition/{id} should return 200 when deleted")
+    void shouldDeleteTransition() throws Exception {
+        when(repository.existsById(1)).thenReturn(true);
+        mockMvc.perform(delete("/api/v1/workflow-transition/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/workflow-transition/{id} should return 404 when missing")
+    void shouldReturn404WhenDeletingMissingTransition() throws Exception {
+        when(repository.existsById(99)).thenReturn(false);
+        mockMvc.perform(delete("/api/v1/workflow-transition/99"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/notaire-shared/src/main/java/com/licensis/notaire/dto/DtoWorkflowDefinition.java
+++ b/notaire-shared/src/main/java/com/licensis/notaire/dto/DtoWorkflowDefinition.java
@@ -1,0 +1,50 @@
+package com.licensis.notaire.dto;
+
+public class DtoWorkflowDefinition {
+
+    private Integer id;
+    private String nombre;
+    private String descripcion;
+    private boolean activo;
+    private Integer version = 0;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    public boolean isActivo() {
+        return activo;
+    }
+
+    public void setActivo(boolean activo) {
+        this.activo = activo;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+}

--- a/notaire-shared/src/main/java/com/licensis/notaire/dto/DtoWorkflowNode.java
+++ b/notaire-shared/src/main/java/com/licensis/notaire/dto/DtoWorkflowNode.java
@@ -1,0 +1,77 @@
+package com.licensis.notaire.dto;
+
+public class DtoWorkflowNode {
+
+    private Integer id;
+    private Integer workflowDefinitionId;
+    private Integer estadoGestionId;
+    private String estadoGestionNombre;
+    private String tipo;
+    private Float posicionX;
+    private Float posicionY;
+    private Integer version = 0;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getWorkflowDefinitionId() {
+        return workflowDefinitionId;
+    }
+
+    public void setWorkflowDefinitionId(Integer workflowDefinitionId) {
+        this.workflowDefinitionId = workflowDefinitionId;
+    }
+
+    public Integer getEstadoGestionId() {
+        return estadoGestionId;
+    }
+
+    public void setEstadoGestionId(Integer estadoGestionId) {
+        this.estadoGestionId = estadoGestionId;
+    }
+
+    public String getEstadoGestionNombre() {
+        return estadoGestionNombre;
+    }
+
+    public void setEstadoGestionNombre(String estadoGestionNombre) {
+        this.estadoGestionNombre = estadoGestionNombre;
+    }
+
+    public String getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(String tipo) {
+        this.tipo = tipo;
+    }
+
+    public Float getPosicionX() {
+        return posicionX;
+    }
+
+    public void setPosicionX(Float posicionX) {
+        this.posicionX = posicionX;
+    }
+
+    public Float getPosicionY() {
+        return posicionY;
+    }
+
+    public void setPosicionY(Float posicionY) {
+        this.posicionY = posicionY;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+}

--- a/notaire-shared/src/main/java/com/licensis/notaire/dto/DtoWorkflowTransition.java
+++ b/notaire-shared/src/main/java/com/licensis/notaire/dto/DtoWorkflowTransition.java
@@ -1,0 +1,68 @@
+package com.licensis.notaire.dto;
+
+public class DtoWorkflowTransition {
+
+    private Integer id;
+    private Integer workflowDefinitionId;
+    private Integer nodoOrigenId;
+    private Integer nodoDestinoId;
+    private String condicion;
+    private String descripcion;
+    private Integer version = 0;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getWorkflowDefinitionId() {
+        return workflowDefinitionId;
+    }
+
+    public void setWorkflowDefinitionId(Integer workflowDefinitionId) {
+        this.workflowDefinitionId = workflowDefinitionId;
+    }
+
+    public Integer getNodoOrigenId() {
+        return nodoOrigenId;
+    }
+
+    public void setNodoOrigenId(Integer nodoOrigenId) {
+        this.nodoOrigenId = nodoOrigenId;
+    }
+
+    public Integer getNodoDestinoId() {
+        return nodoDestinoId;
+    }
+
+    public void setNodoDestinoId(Integer nodoDestinoId) {
+        this.nodoDestinoId = nodoDestinoId;
+    }
+
+    public String getCondicion() {
+        return condicion;
+    }
+
+    public void setCondicion(String condicion) {
+        this.condicion = condicion;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+}


### PR DESCRIPTION
## Summary
- 3 REST controllers: WorkflowDefinition, WorkflowNode, WorkflowTransition
- 3 DTOs in notaire-shared
- toDto() methods on entities
- 24 MockMvc unit tests (all green)

## Endpoints
- GET/POST/PUT/DELETE `/api/v1/workflow-definition`
- GET/POST/PUT/DELETE `/api/v1/workflow-node` + `/by-workflow/{id}`
- GET/POST/DELETE `/api/v1/workflow-transition` + `/by-workflow/{id}`

## Testing
- [x] 24 controller unit tests pass
- [x] Full suite 515 tests green

Closes #451 — Part of #436