### PR TITLE
[#454] feat: Workflow — validación de consistencia

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/WorkflowValidationController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/WorkflowValidationController.java
@@ -1,0 +1,52 @@
+package com.licensis.notaire.api;
+
+import com.licensis.notaire.repository.WorkflowDefinitionRepository;
+import com.licensis.notaire.repository.WorkflowNodeRepository;
+import com.licensis.notaire.repository.WorkflowTransitionRepository;
+import com.licensis.notaire.service.WorkflowValidationService;
+import com.licensis.notaire.service.WorkflowValidationService.ValidationResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/workflow-definition")
+@Tag(name = "Workflow Validation", description = "CU72 - Validación de consistencia del workflow")
+public class WorkflowValidationController {
+
+    private final WorkflowDefinitionRepository workflowRepository;
+    private final WorkflowNodeRepository nodeRepository;
+    private final WorkflowTransitionRepository transitionRepository;
+    private final WorkflowValidationService validationService;
+
+    public WorkflowValidationController(WorkflowDefinitionRepository workflowRepository,
+            WorkflowNodeRepository nodeRepository,
+            WorkflowTransitionRepository transitionRepository,
+            WorkflowValidationService validationService) {
+        this.workflowRepository = workflowRepository;
+        this.nodeRepository = nodeRepository;
+        this.transitionRepository = transitionRepository;
+        this.validationService = validationService;
+    }
+
+    @PostMapping("/{id}/validate")
+    @Operation(summary = "Validar consistencia de un workflow")
+    public ResponseEntity<Map<String, Object>> validate(@PathVariable Integer id) {
+        if (!workflowRepository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        ValidationResult result = validationService.validate(
+                nodeRepository.findByWorkflowDefinitionId(id),
+                transitionRepository.findByWorkflowDefinitionId(id));
+        return ResponseEntity.ok(Map.of(
+                "valid", result.isValid(),
+                "errors", result.getErrors()));
+    }
+}

--- a/backend-api/src/main/java/com/licensis/notaire/service/WorkflowValidationService.java
+++ b/backend-api/src/main/java/com/licensis/notaire/service/WorkflowValidationService.java
@@ -1,0 +1,108 @@
+package com.licensis.notaire.service;
+
+import com.licensis.notaire.negocio.WorkflowNode;
+import com.licensis.notaire.negocio.WorkflowNodeType;
+import com.licensis.notaire.negocio.WorkflowTransition;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class WorkflowValidationService {
+
+    public ValidationResult validate(List<WorkflowNode> nodes, List<WorkflowTransition> transitions) {
+        List<String> errors = new ArrayList<>();
+
+        if (nodes.isEmpty()) {
+            errors.add("El workflow no tiene nodos.");
+            return ValidationResult.invalid(errors);
+        }
+
+        long initialCount = nodes.stream().filter(n -> n.getTipo() == WorkflowNodeType.INITIAL).count();
+        if (initialCount == 0) {
+            errors.add("El workflow debe tener exactamente un nodo inicial.");
+        } else if (initialCount > 1) {
+            errors.add("El workflow tiene más de un nodo inicial (" + initialCount + ").");
+        }
+
+        long finalCount = nodes.stream().filter(n -> n.getTipo() == WorkflowNodeType.FINAL).count();
+        if (finalCount == 0) {
+            errors.add("El workflow debe tener al menos un nodo final.");
+        }
+
+        if (!errors.isEmpty()) {
+            return ValidationResult.invalid(errors);
+        }
+
+        Set<Integer> reachable = reachableFrom(
+                nodes.stream().filter(n -> n.getTipo() == WorkflowNodeType.INITIAL)
+                        .findFirst().map(WorkflowNode::getId).orElse(-1),
+                transitions);
+
+        Set<Integer> allIds = nodes.stream().map(WorkflowNode::getId).collect(Collectors.toSet());
+        Set<Integer> unreachable = new HashSet<>(allIds);
+        unreachable.removeAll(reachable);
+
+        if (!unreachable.isEmpty()) {
+            String names = nodes.stream()
+                    .filter(n -> unreachable.contains(n.getId()))
+                    .map(n -> n.getEstadoDeGestion() != null ? n.getEstadoDeGestion().getNombre() : String.valueOf(n.getId()))
+                    .collect(Collectors.joining(", "));
+            errors.add("Nodos no alcanzables desde el nodo inicial (aislados): " + names + ".");
+        }
+
+        return errors.isEmpty() ? ValidationResult.valid() : ValidationResult.invalid(errors);
+    }
+
+    private Set<Integer> reachableFrom(Integer startId, List<WorkflowTransition> transitions) {
+        Map<Integer, List<Integer>> adjacency = transitions.stream()
+                .collect(Collectors.groupingBy(
+                        t -> t.getNodoOrigen().getId(),
+                        Collectors.mapping(t -> t.getNodoDestino().getId(), Collectors.toList())));
+
+        Set<Integer> visited = new HashSet<>();
+        dfs(startId, adjacency, visited);
+        return visited;
+    }
+
+    private void dfs(Integer node, Map<Integer, List<Integer>> adjacency, Set<Integer> visited) {
+        if (visited.contains(node)) {
+            return;
+        }
+        visited.add(node);
+        for (Integer neighbour : adjacency.getOrDefault(node, List.of())) {
+            dfs(neighbour, adjacency, visited);
+        }
+    }
+
+    public static final class ValidationResult {
+        private final boolean valid;
+        private final List<String> errors;
+
+        private ValidationResult(boolean valid, List<String> errors) {
+            this.valid = valid;
+            this.errors = errors;
+        }
+
+        public static ValidationResult valid() {
+            return new ValidationResult(true, List.of());
+        }
+
+        public static ValidationResult invalid(List<String> errors) {
+            return new ValidationResult(false, errors);
+        }
+
+        public boolean isValid() {
+            return valid;
+        }
+
+        public List<String> getErrors() {
+            return errors;
+        }
+    }
+}

--- a/backend-api/src/test/java/com/licensis/notaire/unit/WorkflowValidationControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/WorkflowValidationControllerTest.java
@@ -1,0 +1,85 @@
+package com.licensis.notaire.unit;
+
+import com.licensis.notaire.api.WorkflowValidationController;
+import com.licensis.notaire.negocio.WorkflowDefinition;
+import com.licensis.notaire.repository.WorkflowDefinitionRepository;
+import com.licensis.notaire.repository.WorkflowNodeRepository;
+import com.licensis.notaire.repository.WorkflowTransitionRepository;
+import com.licensis.notaire.service.WorkflowValidationService;
+import com.licensis.notaire.service.WorkflowValidationService.ValidationResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("CU72 - WorkflowValidationController unit tests")
+@ExtendWith(MockitoExtension.class)
+class WorkflowValidationControllerTest {
+
+    @Mock
+    private WorkflowDefinitionRepository workflowRepository;
+    @Mock
+    private WorkflowNodeRepository nodeRepository;
+    @Mock
+    private WorkflowTransitionRepository transitionRepository;
+    @Mock
+    private WorkflowValidationService validationService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        WorkflowValidationController controller = new WorkflowValidationController(
+                workflowRepository, nodeRepository, transitionRepository, validationService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/workflow-definition/{id}/validate should return 200 when valid")
+    void shouldReturnValidWhenWorkflowIsConsistent() throws Exception {
+        when(workflowRepository.existsById(1)).thenReturn(true);
+        when(nodeRepository.findByWorkflowDefinitionId(1)).thenReturn(List.of());
+        when(transitionRepository.findByWorkflowDefinitionId(1)).thenReturn(List.of());
+        when(validationService.validate(any(), any())).thenReturn(ValidationResult.valid());
+
+        mockMvc.perform(post("/api/v1/workflow-definition/1/validate"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valid").value(true))
+                .andExpect(jsonPath("$.errors").isEmpty());
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/workflow-definition/{id}/validate should return 200 with errors when invalid")
+    void shouldReturnErrorsWhenWorkflowIsInconsistent() throws Exception {
+        when(workflowRepository.existsById(1)).thenReturn(true);
+        when(nodeRepository.findByWorkflowDefinitionId(1)).thenReturn(List.of());
+        when(transitionRepository.findByWorkflowDefinitionId(1)).thenReturn(List.of());
+        when(validationService.validate(any(), any())).thenReturn(
+                ValidationResult.invalid(List.of("Falta nodo inicial", "Falta nodo final")));
+
+        mockMvc.perform(post("/api/v1/workflow-definition/1/validate"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valid").value(false))
+                .andExpect(jsonPath("$.errors[0]").value("Falta nodo inicial"));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/workflow-definition/{id}/validate should return 404 when workflow missing")
+    void shouldReturn404WhenWorkflowMissing() throws Exception {
+        when(workflowRepository.existsById(99)).thenReturn(false);
+        mockMvc.perform(post("/api/v1/workflow-definition/99/validate"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/backend-api/src/test/java/com/licensis/notaire/unit/WorkflowValidationServiceTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/WorkflowValidationServiceTest.java
@@ -1,0 +1,144 @@
+package com.licensis.notaire.unit;
+
+import com.licensis.notaire.negocio.EstadoDeGestion;
+import com.licensis.notaire.negocio.WorkflowDefinition;
+import com.licensis.notaire.negocio.WorkflowNode;
+import com.licensis.notaire.negocio.WorkflowNodeType;
+import com.licensis.notaire.negocio.WorkflowTransition;
+import com.licensis.notaire.service.WorkflowValidationService;
+import com.licensis.notaire.service.WorkflowValidationService.ValidationResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CU72 - WorkflowValidationService unit tests")
+class WorkflowValidationServiceTest {
+
+    private WorkflowValidationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WorkflowValidationService();
+    }
+
+    private WorkflowNode makeNode(int id, WorkflowNodeType tipo) {
+        WorkflowNode n = new WorkflowNode(id);
+        n.setTipo(tipo);
+        EstadoDeGestion e = new EstadoDeGestion(id);
+        e.setNombre("Estado " + id);
+        n.setEstadoDeGestion(e);
+        return n;
+    }
+
+    private WorkflowTransition makeTransition(int id, WorkflowNode origen, WorkflowNode destino) {
+        WorkflowTransition t = new WorkflowTransition(id);
+        t.setNodoOrigen(origen);
+        t.setNodoDestino(destino);
+        return t;
+    }
+
+    @Nested
+    @DisplayName("Valid workflow scenarios")
+    class ValidScenarios {
+
+        @Test
+        @DisplayName("Should pass for minimal valid workflow: INITIAL → FINAL")
+        void shouldPassForMinimalValidWorkflow() {
+            WorkflowNode initial = makeNode(1, WorkflowNodeType.INITIAL);
+            WorkflowNode finalNode = makeNode(2, WorkflowNodeType.FINAL);
+            WorkflowTransition t = makeTransition(1, initial, finalNode);
+
+            ValidationResult result = service.validate(List.of(initial, finalNode), List.of(t));
+
+            assertThat(result.isValid()).isTrue();
+            assertThat(result.getErrors()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Should pass for INITIAL → INTERMEDIATE → FINAL")
+        void shouldPassForLinearWorkflow() {
+            WorkflowNode initial = makeNode(1, WorkflowNodeType.INITIAL);
+            WorkflowNode mid = makeNode(2, WorkflowNodeType.INTERMEDIATE);
+            WorkflowNode finalNode = makeNode(3, WorkflowNodeType.FINAL);
+            WorkflowTransition t1 = makeTransition(1, initial, mid);
+            WorkflowTransition t2 = makeTransition(2, mid, finalNode);
+
+            ValidationResult result = service.validate(List.of(initial, mid, finalNode), List.of(t1, t2));
+
+            assertThat(result.isValid()).isTrue();
+            assertThat(result.getErrors()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Invalid workflow scenarios")
+    class InvalidScenarios {
+
+        @Test
+        @DisplayName("Should fail when no nodes")
+        void shouldFailWhenNoNodes() {
+            ValidationResult result = service.validate(List.of(), List.of());
+
+            assertThat(result.isValid()).isFalse();
+            assertThat(result.getErrors()).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("Should fail when no INITIAL node")
+        void shouldFailWhenNoInitialNode() {
+            WorkflowNode mid = makeNode(1, WorkflowNodeType.INTERMEDIATE);
+            WorkflowNode finalNode = makeNode(2, WorkflowNodeType.FINAL);
+            WorkflowTransition t = makeTransition(1, mid, finalNode);
+
+            ValidationResult result = service.validate(List.of(mid, finalNode), List.of(t));
+
+            assertThat(result.isValid()).isFalse();
+            assertThat(result.getErrors()).anyMatch(e -> e.contains("inicial"));
+        }
+
+        @Test
+        @DisplayName("Should fail when more than one INITIAL node")
+        void shouldFailWhenMultipleInitialNodes() {
+            WorkflowNode i1 = makeNode(1, WorkflowNodeType.INITIAL);
+            WorkflowNode i2 = makeNode(2, WorkflowNodeType.INITIAL);
+            WorkflowNode finalNode = makeNode(3, WorkflowNodeType.FINAL);
+
+            ValidationResult result = service.validate(List.of(i1, i2, finalNode), List.of());
+
+            assertThat(result.isValid()).isFalse();
+            assertThat(result.getErrors()).anyMatch(e -> e.contains("inicial"));
+        }
+
+        @Test
+        @DisplayName("Should fail when no FINAL node")
+        void shouldFailWhenNoFinalNode() {
+            WorkflowNode initial = makeNode(1, WorkflowNodeType.INITIAL);
+            WorkflowNode mid = makeNode(2, WorkflowNodeType.INTERMEDIATE);
+            WorkflowTransition t = makeTransition(1, initial, mid);
+
+            ValidationResult result = service.validate(List.of(initial, mid), List.of(t));
+
+            assertThat(result.isValid()).isFalse();
+            assertThat(result.getErrors()).anyMatch(e -> e.contains("final"));
+        }
+
+        @Test
+        @DisplayName("Should fail when orphan node unreachable from INITIAL")
+        void shouldFailWhenOrphanNodeExists() {
+            WorkflowNode initial = makeNode(1, WorkflowNodeType.INITIAL);
+            WorkflowNode finalNode = makeNode(2, WorkflowNodeType.FINAL);
+            WorkflowNode orphan = makeNode(3, WorkflowNodeType.INTERMEDIATE);
+            WorkflowTransition t = makeTransition(1, initial, finalNode);
+
+            ValidationResult result = service.validate(List.of(initial, finalNode, orphan), List.of(t));
+
+            assertThat(result.isValid()).isFalse();
+            assertThat(result.getErrors()).anyMatch(e -> e.contains("alcanzable") || e.contains("aislado"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `WorkflowValidationService`: DFS-based reachability + structural rules
- `POST /api/v1/workflow-definition/{id}/validate` endpoint
- Rules: exactly 1 INITIAL, ≥1 FINAL, all nodes reachable from INITIAL
- 9 unit tests (service + controller), all passing

Closes #454 — Part of #436