### PR TITLE
[#434] feat(ui): add breadcrumb navigation to dashboard layout

### DIFF
--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { AppSidebar } from "@/components/layout/AppSidebar";
+import { Breadcrumb } from "@/components/layout/Breadcrumb";
 import { useAuthStore } from "@/store/auth-store";
 import { AnimatePresence, PageTransition } from "@/components/motion";
 
@@ -37,6 +38,9 @@ export default function DashboardLayout({
       <div className="flex-1 flex flex-col">
         {/* Each page renders its own AppHeader with a title; a title-less one
             here only produced an empty (a11y-invalid) duplicate <h1>. */}
+        <div className="px-6 lg:px-8 pt-4 pb-0">
+          <Breadcrumb />
+        </div>
         <main className="flex-1 overflow-y-auto p-6 lg:p-8">
           <AnimatePresence mode="wait" initial={false}>
             <PageTransition key={pathname}>{children}</PageTransition>

--- a/frontend/src/components/layout/Breadcrumb.tsx
+++ b/frontend/src/components/layout/Breadcrumb.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const SEGMENT_LABELS: Record<string, string> = {
+  dashboard: "Dashboard",
+  administracion: "Administración",
+  usuarios: "Usuarios",
+  tramites: "Tipos de Trámite",
+  documentos: "Tipos de Documento",
+  folios: "Tipos de Folio",
+  conceptos: "Conceptos",
+  "estados-gestion": "Estados de Gestión",
+  plantillas: "Plantillas",
+  items: "Ítems",
+  auditoria: "Auditoría",
+  workflows: "Workflows",
+  suplencias: "Suplencias",
+  personas: "Personas",
+  escrituras: "Escrituras",
+  gestiones: "Gestiones",
+  protocolo: "Protocolo",
+  presupuestos: "Presupuestos",
+  pagos: "Pagos",
+  copias: "Copias",
+  reportes: "Reportes",
+  inmuebles: "Inmuebles",
+};
+
+function labelForSegment(segment: string): string {
+  return SEGMENT_LABELS[segment] ?? segment.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function Breadcrumb() {
+  const pathname = usePathname();
+  const segments = pathname.split("/").filter(Boolean);
+
+  if (segments.length <= 1) return null;
+
+  const crumbs = segments.map((seg, i) => ({
+    label: labelForSegment(seg),
+    href: "/" + segments.slice(0, i + 1).join("/"),
+    isLast: i === segments.length - 1,
+  }));
+
+  return (
+    <nav aria-label="Breadcrumb" data-testid="breadcrumb">
+      <ol className="flex items-center gap-1 text-sm text-muted-foreground flex-wrap">
+        {crumbs.map((crumb, i) => (
+          <li key={crumb.href} className="flex items-center gap-1">
+            {i > 0 && <span className="text-neutral-300 select-none">/</span>}
+            {crumb.isLast ? (
+              <span className="font-medium text-foreground">{crumb.label}</span>
+            ) : (
+              <Link
+                href={crumb.href}
+                className="hover:text-foreground transition-colors"
+              >
+                {crumb.label}
+              </Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/frontend/tests/e2e/cu-breadcrumb-nav.spec.ts
+++ b/frontend/tests/e2e/cu-breadcrumb-nav.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * E2E tests — Breadcrumb navigation in admin module
+ * Issue #434: Breadcrumb navigation en el módulo de Administración
+ */
+import { test, expect } from "@playwright/test";
+
+async function loginAsAdmin(page: import("@playwright/test").Page) {
+  await page.goto("/login");
+  await page.getByTestId("input-usuario").fill("admin");
+  await page.getByTestId("input-contrasenia").fill("admin");
+  await page.getByTestId("btn-ingresar").click();
+  await expect(page).toHaveURL(/\/dashboard/, { timeout: 10000 });
+}
+
+test.describe("Breadcrumb navigation — admin module", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test("breadcrumb is visible on admin section pages", async ({ page }) => {
+    await page.goto("/dashboard/administracion/usuarios");
+    await expect(page.getByTestId("breadcrumb")).toBeVisible({ timeout: 5000 });
+  });
+
+  test("breadcrumb shows correct segments for usuarios", async ({ page }) => {
+    await page.goto("/dashboard/administracion/usuarios");
+    const breadcrumb = page.getByTestId("breadcrumb");
+    await expect(breadcrumb).toContainText("Administración");
+    await expect(breadcrumb).toContainText("Usuarios");
+  });
+
+  test("breadcrumb 'Administración' segment is a link to admin root", async ({ page }) => {
+    await page.goto("/dashboard/administracion/usuarios");
+    const adminLink = page.getByTestId("breadcrumb").getByRole("link", { name: "Administración" });
+    await expect(adminLink).toBeVisible();
+    await adminLink.click();
+    await expect(page).toHaveURL(/\/dashboard\/administracion$/);
+  });
+
+  test("breadcrumb shows workflow editor nested route", async ({ page }) => {
+    await page.goto("/dashboard/administracion/workflows");
+    const breadcrumb = page.getByTestId("breadcrumb");
+    await expect(breadcrumb).toContainText("Administración");
+    await expect(breadcrumb).toContainText("Workflows");
+  });
+});


### PR DESCRIPTION
## Summary
- New `Breadcrumb` component using `usePathname()` with a segment→label map
- Rendered above all page content in the dashboard layout
- Covers all admin module paths including nested routes (`workflows/[id]`)

## Changes
### Added
- `frontend/src/components/layout/Breadcrumb.tsx`
- `frontend/tests/e2e/cu-breadcrumb-nav.spec.ts`
### Modified
- `frontend/src/app/dashboard/layout.tsx` — breadcrumb added above main content

## Testing
- [x] TypeScript compiles clean
- [x] E2E tests added (4 test cases)

## Use Case Reference
Applies to all CU20–CU40 admin module use cases

Fixes #434