### PR TITLE
[#339] test(bruno): add missing mutation and query tests

### DIFF
--- a/backend-api/api-test/escrituras/01-buscar.yml
+++ b/backend-api/api-test/escrituras/01-buscar.yml
@@ -1,0 +1,17 @@
+info:
+  name: Buscar Escrituras por Numero
+  type: http
+  seq: 1
+  description: "## CU62 — GET /api/v1/escrituras/buscar?numero=<n>"
+http:
+  method: GET
+  url: "{{base_url}}/api/v1/escrituras/buscar"
+  params:
+    - name: numero
+      value: "1"
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+          test("Status 200 OK", function () { expect(res.getStatus()).to.equal(200); });
+          test("Returns array", function () { expect(res.getBody()).to.be.an('array'); });

--- a/backend-api/api-test/escrituras/folder.yml
+++ b/backend-api/api-test/escrituras/folder.yml
@@ -1,0 +1,3 @@
+info:
+  name: Escrituras
+  type: folder

--- a/backend-api/api-test/plantilla-presupuesto/01-create.yml
+++ b/backend-api/api-test/plantilla-presupuesto/01-create.yml
@@ -1,0 +1,22 @@
+info:
+  name: Create Plantilla Presupuesto
+  type: http
+  seq: 1
+http:
+  method: POST
+  url: "{{base_url}}/api/v1/plantilla-presupuestos"
+  body:
+    type: json
+    data: |-
+        {"plantillaPresupuestoPK":{"fkIdTipoTramite":1,"fkIdConcepto":1},"observaciones":"Test plantilla E2E"}
+  headers:
+    Content-Type: application/json
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+          test("Status 201 or 200", function () { expect([200,201]).to.include(res.getStatus()); });
+          test("Saves tipo-tramite and concepto IDs", function () {
+            bru.setVar('_pp_tipo_tramite', 1);
+            bru.setVar('_pp_concepto', 1);
+          });

--- a/backend-api/api-test/plantilla-presupuesto/02-list.yml
+++ b/backend-api/api-test/plantilla-presupuesto/02-list.yml
@@ -1,0 +1,13 @@
+info:
+  name: List Plantillas Presupuesto
+  type: http
+  seq: 2
+http:
+  method: GET
+  url: "{{base_url}}/api/v1/plantilla-presupuestos"
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+          test("Status 200 OK", function () { expect(res.getStatus()).to.equal(200); });
+          test("Returns array", function () { expect(res.getBody()).to.be.an('array'); });

--- a/backend-api/api-test/plantilla-presupuesto/03-get-by-tipo-tramite.yml
+++ b/backend-api/api-test/plantilla-presupuesto/03-get-by-tipo-tramite.yml
@@ -1,0 +1,13 @@
+info:
+  name: Get Plantillas by Tipo Tramite
+  type: http
+  seq: 3
+http:
+  method: GET
+  url: "{{base_url}}/api/v1/plantilla-presupuestos/tipo-tramite/{{_pp_tipo_tramite}}"
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+          test("Status 200 OK", function () { expect(res.getStatus()).to.equal(200); });
+          test("Returns array", function () { expect(res.getBody()).to.be.an('array'); });

--- a/backend-api/api-test/plantilla-presupuesto/04-update.yml
+++ b/backend-api/api-test/plantilla-presupuesto/04-update.yml
@@ -1,0 +1,18 @@
+info:
+  name: Update Plantilla Presupuesto
+  type: http
+  seq: 4
+http:
+  method: PUT
+  url: "{{base_url}}/api/v1/plantilla-presupuestos/tipo-tramite/{{_pp_tipo_tramite}}/concepto/{{_pp_concepto}}"
+  body:
+    type: json
+    data: |-
+        {"observaciones":"Updated E2E"}
+  headers:
+    Content-Type: application/json
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+          test("Status 200 or 204", function () { expect([200,204]).to.include(res.getStatus()); });

--- a/backend-api/api-test/plantilla-presupuesto/05-delete.yml
+++ b/backend-api/api-test/plantilla-presupuesto/05-delete.yml
@@ -1,0 +1,12 @@
+info:
+  name: Delete Plantilla Presupuesto
+  type: http
+  seq: 5
+http:
+  method: DELETE
+  url: "{{base_url}}/api/v1/plantilla-presupuestos/tipo-tramite/{{_pp_tipo_tramite}}/concepto/{{_pp_concepto}}"
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+          test("Status 200 or 204", function () { expect([200,204]).to.include(res.getStatus()); });

--- a/backend-api/api-test/plantilla-presupuesto/folder.yml
+++ b/backend-api/api-test/plantilla-presupuesto/folder.yml
@@ -1,0 +1,1 @@
+name: Plantilla Presupuesto

--- a/backend-api/api-test/plantilla-tramite/01-list.yml
+++ b/backend-api/api-test/plantilla-tramite/01-list.yml
@@ -1,0 +1,13 @@
+info:
+  name: List Plantillas Tramite
+  type: http
+  seq: 1
+http:
+  method: GET
+  url: "{{base_url}}/api/v1/plantilla-tramites"
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+          test("Status 200 OK", function () { expect(res.getStatus()).to.equal(200); });
+          test("Returns array", function () { expect(res.getBody()).to.be.an('array'); });

--- a/backend-api/api-test/plantilla-tramite/02-get-by-tipo-tramite.yml
+++ b/backend-api/api-test/plantilla-tramite/02-get-by-tipo-tramite.yml
@@ -1,0 +1,13 @@
+info:
+  name: Get Plantillas by Tipo Tramite
+  type: http
+  seq: 2
+http:
+  method: GET
+  url: "{{base_url}}/api/v1/plantilla-tramites/tipo-tramite/1"
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+          test("Status 200 OK", function () { expect(res.getStatus()).to.equal(200); });
+          test("Returns array", function () { expect(res.getBody()).to.be.an('array'); });

--- a/backend-api/api-test/plantilla-tramite/folder.yml
+++ b/backend-api/api-test/plantilla-tramite/folder.yml
@@ -1,0 +1,3 @@
+info:
+  name: Plantilla Tramite
+  type: folder

--- a/backend-api/api-test/suplencias/01-create.yml
+++ b/backend-api/api-test/suplencias/01-create.yml
@@ -1,0 +1,23 @@
+info:
+  name: Create Suplencia
+  type: http
+  seq: 1
+http:
+  method: POST
+  url: "{{base_url}}/api/v1/suplencia"
+  body:
+    type: json
+    data: |-
+        {"fechaInicio":"2026-01-01","fechaFin":"2026-01-31","fkIdSuplente":{"idPersona":1},"fkIdSuplantado":{"idPersona":2}}
+  headers:
+    Content-Type: application/json
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+          test("Status 201 Created", function () { expect(res.getStatus()).to.equal(201); });
+          test("Returns idSuplencia", function () {
+            const b = res.getBody();
+            expect(b).to.have.property('idSuplencia');
+            bru.setVar('_suplencia_id', b.idSuplencia);
+          });

--- a/backend-api/api-test/suplencias/02-list.yml
+++ b/backend-api/api-test/suplencias/02-list.yml
@@ -1,0 +1,13 @@
+info:
+  name: List Suplencias
+  type: http
+  seq: 2
+http:
+  method: GET
+  url: "{{base_url}}/api/v1/suplencia"
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+          test("Status 200 OK", function () { expect(res.getStatus()).to.equal(200); });
+          test("Returns array", function () { expect(res.getBody()).to.be.an('array'); });

--- a/backend-api/api-test/suplencias/03-get-by-id.yml
+++ b/backend-api/api-test/suplencias/03-get-by-id.yml
@@ -1,0 +1,13 @@
+info:
+  name: Get Suplencia by ID
+  type: http
+  seq: 3
+http:
+  method: GET
+  url: "{{base_url}}/api/v1/suplencia/{{_suplencia_id}}"
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+          test("Status 200 OK", function () { expect(res.getStatus()).to.equal(200); });
+          test("Returns idSuplencia", function () { expect(res.getBody()).to.have.property('idSuplencia'); });

--- a/backend-api/api-test/suplencias/04-update.yml
+++ b/backend-api/api-test/suplencias/04-update.yml
@@ -1,0 +1,18 @@
+info:
+  name: Update Suplencia
+  type: http
+  seq: 4
+http:
+  method: PUT
+  url: "{{base_url}}/api/v1/suplencia/{{_suplencia_id}}"
+  body:
+    type: json
+    data: |-
+        {"fechaInicio":"2026-02-01","fechaFin":"2026-02-28","fkIdSuplente":{"idPersona":1},"fkIdSuplantado":{"idPersona":2}}
+  headers:
+    Content-Type: application/json
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+          test("Status 200 or 204", function () { expect([200,204]).to.include(res.getStatus()); });

--- a/backend-api/api-test/suplencias/05-delete.yml
+++ b/backend-api/api-test/suplencias/05-delete.yml
@@ -1,0 +1,12 @@
+info:
+  name: Delete Suplencia
+  type: http
+  seq: 5
+http:
+  method: DELETE
+  url: "{{base_url}}/api/v1/suplencia/{{_suplencia_id}}"
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+          test("Status 200 or 204", function () { expect([200,204]).to.include(res.getStatus()); });

--- a/backend-api/api-test/suplencias/06-verify-delete.yml
+++ b/backend-api/api-test/suplencias/06-verify-delete.yml
@@ -1,0 +1,12 @@
+info:
+  name: Verify Suplencia Deleted
+  type: http
+  seq: 6
+http:
+  method: GET
+  url: "{{base_url}}/api/v1/suplencia/{{_suplencia_id}}"
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+          test("Status 404 Not Found", function () { expect(res.getStatus()).to.equal(404); });

--- a/backend-api/api-test/suplencias/folder.yml
+++ b/backend-api/api-test/suplencias/folder.yml
@@ -1,0 +1,1 @@
+name: Suplencias


### PR DESCRIPTION
## Summary
- Added Bruno API test suites for Suplencias (full CRUD + verify-delete)
- Added Bruno API test suites for PlantillaPresupuesto (full CRUD with composite key)
- Added Bruno API test suites for PlantillaTramite (read: list + get-by-tipo-tramite)
- Added Bruno API test suite for Escrituras buscar endpoint (CU62)

## Changes
### Added
- `api-test/suplencias/` — 7 test files covering full lifecycle
- `api-test/plantilla-presupuesto/` — 6 test files covering full CRUD with composite PK path
- `api-test/plantilla-tramite/` — 3 files (folder + 2 GET tests)
- `api-test/escrituras/` — 2 files (folder + buscar GET test)

## Testing
- [x] All tests are Bruno collection YAML (runnable via `bash scripts/test.sh`)
- [x] No unit/integration code changes — documentation/test only

## Issue Reference
Fixes #339