### PR TITLE
[#431] feat(roles): add role and permission management for users

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/RolController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/RolController.java
@@ -1,0 +1,130 @@
+package com.licensis.notaire.api;
+
+import com.licensis.notaire.negocio.Rol;
+import com.licensis.notaire.negocio.Usuario;
+import com.licensis.notaire.repository.RolRepository;
+import com.licensis.notaire.repository.UsuarioRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/v1/roles")
+@Tag(name = "Roles", description = "API para gestionar roles y permisos de usuario")
+public class RolController {
+
+    private final RolRepository rolRepository;
+    private final UsuarioRepository usuarioRepository;
+
+    public RolController(RolRepository rolRepository, UsuarioRepository usuarioRepository) {
+        this.rolRepository = rolRepository;
+        this.usuarioRepository = usuarioRepository;
+    }
+
+    record RolResponse(Integer idRol, String nombre, String descripcion, boolean activo, List<String> modulos) {}
+
+    record RolRequest(String nombre, String descripcion, boolean activo, List<String> modulos) {}
+
+    private RolResponse toResponse(Rol rol) {
+        return new RolResponse(rol.getIdRol(), rol.getNombre(), rol.getDescripcion(),
+                rol.isActivo(), rol.getModulos());
+    }
+
+    @GetMapping
+    @Operation(summary = "Obtener todos los roles")
+    public ResponseEntity<List<RolResponse>> getAllRoles() {
+        return ResponseEntity.ok(rolRepository.findAll().stream().map(this::toResponse).toList());
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Obtener rol por ID")
+    public ResponseEntity<RolResponse> getRolById(@PathVariable Integer id) {
+        return rolRepository.findById(id)
+                .map(this::toResponse)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    @Operation(summary = "Crear nuevo rol")
+    public ResponseEntity<Object> createRol(@RequestBody RolRequest request) {
+        if (rolRepository.findByNombre(request.nombre()).isPresent()) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("error", "Ya existe un rol con el nombre: " + request.nombre()));
+        }
+        Rol rol = new Rol();
+        rol.setNombre(request.nombre());
+        rol.setDescripcion(request.descripcion());
+        rol.setActivo(request.activo());
+        rol.setModulos(request.modulos() != null ? request.modulos() : List.of());
+        Rol saved = rolRepository.save(rol);
+        return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(saved));
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Actualizar rol")
+    public ResponseEntity<RolResponse> updateRol(@PathVariable Integer id, @RequestBody RolRequest request) {
+        Optional<Rol> existing = rolRepository.findById(id);
+        if (existing.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        Rol rol = existing.get();
+        rol.setNombre(request.nombre());
+        rol.setDescripcion(request.descripcion());
+        rol.setActivo(request.activo());
+        rol.setModulos(request.modulos() != null ? request.modulos() : List.of());
+        return ResponseEntity.ok(toResponse(rolRepository.save(rol)));
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Eliminar rol")
+    public ResponseEntity<Void> deleteRol(@PathVariable Integer id) {
+        if (!rolRepository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        rolRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{idRol}/usuarios/{idUsuario}")
+    @Operation(summary = "Asignar rol a usuario")
+    public ResponseEntity<Object> assignRolToUsuario(@PathVariable Integer idRol,
+                                                      @PathVariable Integer idUsuario) {
+        Optional<Rol> rol = rolRepository.findById(idRol);
+        if (rol.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        Optional<Usuario> usuario = usuarioRepository.findById(idUsuario);
+        if (usuario.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        usuario.get().setRol(rol.get());
+        usuarioRepository.save(usuario.get());
+        return ResponseEntity.ok(Map.of("idUsuario", idUsuario, "idRol", idRol));
+    }
+
+    @DeleteMapping("/usuarios/{idUsuario}")
+    @Operation(summary = "Desasignar rol de usuario")
+    public ResponseEntity<Void> unassignRolFromUsuario(@PathVariable Integer idUsuario) {
+        Optional<Usuario> usuario = usuarioRepository.findById(idUsuario);
+        if (usuario.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        usuario.get().setRol(null);
+        usuarioRepository.save(usuario.get());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
@@ -35,7 +35,10 @@ public class UsuarioController {
 
     record PersonaInfo(Integer idPersona, String nombre, String apellido) {}
 
-    record UsuarioResponse(Integer idUsuario, String nombre, String tipo, boolean activo, PersonaInfo persona) {}
+    record RolInfo(Integer idRol, String nombre) {}
+
+    record UsuarioResponse(Integer idUsuario, String nombre, String tipo, boolean activo,
+                            PersonaInfo persona, RolInfo rol) {}
 
     record UsuarioRequest(String nombre, String contrasenia, String tipo, boolean activo) {}
 
@@ -45,7 +48,11 @@ public class UsuarioController {
             var p = u.getFkIdPersona();
             persona = new PersonaInfo(p.getIdPersona(), p.getNombre(), p.getApellido());
         }
-        return new UsuarioResponse(u.getIdUsuario(), u.getNombre(), u.getTipo(), u.getEstado(), persona);
+        RolInfo rolInfo = null;
+        if (u.getRol() != null) {
+            rolInfo = new RolInfo(u.getRol().getIdRol(), u.getRol().getNombre());
+        }
+        return new UsuarioResponse(u.getIdUsuario(), u.getNombre(), u.getTipo(), u.getEstado(), persona, rolInfo);
     }
 
     @GetMapping

--- a/backend-api/src/main/java/com/licensis/notaire/negocio/Rol.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/Rol.java
@@ -1,0 +1,95 @@
+package com.licensis.notaire.negocio;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "roles")
+public class Rol implements Serializable {
+
+    @Version
+    @Column(name = "version")
+    private int version;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_rol")
+    private Integer idRol;
+
+    @Column(name = "nombre", unique = true, nullable = false)
+    private String nombre;
+
+    @Column(name = "descripcion")
+    private String descripcion;
+
+    @Column(name = "activo", nullable = false)
+    private boolean activo;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "roles_permisos", joinColumns = @JoinColumn(name = "fk_id_rol"))
+    @Column(name = "modulo")
+    private List<String> modulos = new ArrayList<>();
+
+    public Rol() {
+    }
+
+    public Integer getIdRol() {
+        return idRol;
+    }
+
+    public void setIdRol(Integer idRol) {
+        this.idRol = idRol;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    public boolean isActivo() {
+        return activo;
+    }
+
+    public void setActivo(boolean activo) {
+        this.activo = activo;
+    }
+
+    public List<String> getModulos() {
+        return modulos;
+    }
+
+    public void setModulos(List<String> modulos) {
+        this.modulos = modulos != null ? modulos : new ArrayList<>();
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+}

--- a/backend-api/src/main/java/com/licensis/notaire/negocio/Usuario.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/Usuario.java
@@ -73,6 +73,11 @@ public class Usuario implements Serializable {
     @ManyToOne(optional = true, fetch = FetchType.EAGER)
     private Persona fkIdPersona;
 
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+    @JoinColumn(name = "fk_id_rol", referencedColumnName = "id_rol")
+    @ManyToOne(optional = true, fetch = FetchType.EAGER)
+    private Rol rol;
+
     public Usuario() {
     }
 
@@ -145,6 +150,14 @@ public class Usuario implements Serializable {
         this.fkIdPersona = fkIdPersona;
     }
 
+    public Rol getRol() {
+        return rol;
+    }
+
+    public void setRol(Rol rol) {
+        this.rol = rol;
+    }
+
     @Override
     public int hashCode() {
         int hash = 0;
@@ -211,6 +224,11 @@ public class Usuario implements Serializable {
 
             miDto.setPersonas(miDtoPersona);
             miDto.setTipo(tipo);
+
+            if (rol != null) {
+                miDto.setRolId(rol.getIdRol());
+                miDto.setRolNombre(rol.getNombre());
+            }
 
             // Controlo la version del objeto
             miDto.setVersion(version);

--- a/backend-api/src/main/java/com/licensis/notaire/repository/RolRepository.java
+++ b/backend-api/src/main/java/com/licensis/notaire/repository/RolRepository.java
@@ -1,0 +1,11 @@
+package com.licensis.notaire.repository;
+
+import com.licensis.notaire.negocio.Rol;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+@Repository
+public interface RolRepository extends JpaRepository<Rol, Integer> {
+    Optional<Rol> findByNombre(String nombre);
+}

--- a/backend-api/src/main/resources/db/migration/V9__add_roles_permisos.sql
+++ b/backend-api/src/main/resources/db/migration/V9__add_roles_permisos.sql
@@ -1,0 +1,35 @@
+-- =============================================================================
+-- V9__add_roles_permisos.sql
+-- =============================================================================
+-- Author: Matias Miguez
+-- Date: 2026-06-10
+-- Description: Adds roles and role_permissions tables; links users to roles (CU431)
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- UP Migration
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS roles (
+    version integer NOT NULL DEFAULT 0,
+    id_rol SERIAL PRIMARY KEY,
+    nombre text NOT NULL,
+    descripcion text,
+    activo boolean NOT NULL DEFAULT true,
+    CONSTRAINT roles_nombre_unique UNIQUE (nombre)
+);
+
+CREATE TABLE IF NOT EXISTS roles_permisos (
+    fk_id_rol integer NOT NULL REFERENCES roles(id_rol) ON DELETE CASCADE,
+    modulo text NOT NULL,
+    PRIMARY KEY (fk_id_rol, modulo)
+);
+
+ALTER TABLE usuarios
+    ADD COLUMN IF NOT EXISTS fk_id_rol integer REFERENCES roles(id_rol);
+
+-- -----------------------------------------------------------------------------
+-- Verification
+-- -----------------------------------------------------------------------------
+-- SELECT COUNT(*) FROM roles;
+-- SELECT COUNT(*) FROM roles_permisos;

--- a/backend-api/src/test/java/com/licensis/notaire/unit/RolControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/RolControllerTest.java
@@ -1,0 +1,171 @@
+package com.licensis.notaire.unit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.licensis.notaire.api.RolController;
+import com.licensis.notaire.negocio.Rol;
+import com.licensis.notaire.repository.RolRepository;
+import com.licensis.notaire.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class RolControllerTest {
+
+    @Mock
+    private RolRepository rolRepository;
+
+    @Mock
+    private UsuarioRepository usuarioRepository;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new RolController(rolRepository, usuarioRepository)).build();
+    }
+
+    private Rol buildRol(Integer id, String nombre) {
+        Rol rol = new Rol();
+        rol.setIdRol(id);
+        rol.setNombre(nombre);
+        rol.setDescripcion("Descripción de " + nombre);
+        rol.setActivo(true);
+        rol.setModulos(List.of("administracion", "usuarios"));
+        return rol;
+    }
+
+    @Test
+    @DisplayName("Should return all roles")
+    void shouldReturnAllRoles() throws Exception {
+        when(rolRepository.findAll()).thenReturn(List.of(buildRol(1, "ADMIN"), buildRol(2, "OPERADOR")));
+
+        mockMvc.perform(get("/api/v1/roles"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2));
+    }
+
+    @Test
+    @DisplayName("Should return role by ID")
+    void shouldReturnRoleById() throws Exception {
+        when(rolRepository.findById(1)).thenReturn(Optional.of(buildRol(1, "ADMIN")));
+
+        mockMvc.perform(get("/api/v1/roles/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nombre").value("ADMIN"));
+    }
+
+    @Test
+    @DisplayName("Should return 404 when role not found")
+    void shouldReturn404WhenRoleNotFound() throws Exception {
+        when(rolRepository.findById(99)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/v1/roles/99"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Should create role and return 201")
+    void shouldCreateRole() throws Exception {
+        Rol saved = buildRol(1, "ADMIN");
+        when(rolRepository.findByNombre("ADMIN")).thenReturn(Optional.empty());
+        when(rolRepository.save(any())).thenReturn(saved);
+
+        Map<String, Object> body = Map.of(
+                "nombre", "ADMIN",
+                "descripcion", "Administrador",
+                "activo", true,
+                "modulos", List.of("administracion")
+        );
+
+        mockMvc.perform(post("/api/v1/roles")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(body)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.nombre").value("ADMIN"));
+    }
+
+    @Test
+    @DisplayName("Should return 409 when role name already exists")
+    void shouldReturn409WhenRoleNameExists() throws Exception {
+        when(rolRepository.findByNombre("ADMIN")).thenReturn(Optional.of(buildRol(1, "ADMIN")));
+
+        Map<String, Object> body = Map.of("nombre", "ADMIN", "activo", true, "modulos", List.of());
+
+        mockMvc.perform(post("/api/v1/roles")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(body)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("Should update role and return 200")
+    void shouldUpdateRole() throws Exception {
+        Rol existing = buildRol(1, "ADMIN");
+        when(rolRepository.findById(1)).thenReturn(Optional.of(existing));
+        when(rolRepository.save(any())).thenReturn(existing);
+
+        Map<String, Object> body = Map.of(
+                "nombre", "ADMIN_UPDATED",
+                "descripcion", "Updated",
+                "activo", true,
+                "modulos", List.of("administracion", "usuarios")
+        );
+
+        mockMvc.perform(put("/api/v1/roles/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(body)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should return 404 when updating non-existent role")
+    void shouldReturn404WhenUpdatingNonExistentRole() throws Exception {
+        when(rolRepository.findById(99)).thenReturn(Optional.empty());
+
+        Map<String, Object> body = Map.of("nombre", "X", "activo", true, "modulos", List.of());
+
+        mockMvc.perform(put("/api/v1/roles/99")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(body)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Should delete role and return 204")
+    void shouldDeleteRole() throws Exception {
+        when(rolRepository.existsById(1)).thenReturn(true);
+
+        mockMvc.perform(delete("/api/v1/roles/1"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("Should return 404 when deleting non-existent role")
+    void shouldReturn404WhenDeletingNonExistentRole() throws Exception {
+        when(rolRepository.existsById(99)).thenReturn(false);
+
+        mockMvc.perform(delete("/api/v1/roles/99"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -327,6 +327,10 @@
       "plantillas": {
         "label": "Quote Templates",
         "description": "Reusable quote templates"
+      },
+      "roles": {
+        "label": "Roles & Permissions",
+        "description": "User role management and module access control"
       }
     },
     "usuarios": {

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -327,6 +327,10 @@
       "plantillas": {
         "label": "Plantillas Presupuesto",
         "description": "Plantillas reutilizables para presupuestos"
+      },
+      "roles": {
+        "label": "Roles y Permisos",
+        "description": "Gestión de roles de usuario y accesos a módulos"
       }
     },
     "usuarios": {

--- a/frontend/src/app/dashboard/administracion/page.tsx
+++ b/frontend/src/app/dashboard/administracion/page.tsx
@@ -17,6 +17,7 @@ export default function AdministracionPage() {
     { key: "tramites" as const, href: "/dashboard/administracion/tramites", pngIcon: "/icons/admin/tramites.png" },
     { key: "estadosGestion" as const, href: "/dashboard/administracion/estados-gestion", pngIcon: "/icons/admin/estadosGestion.png" },
     { key: "plantillas" as const, href: "/dashboard/administracion/plantillas", pngIcon: "/icons/admin/plantillaPresupuesto.png" },
+    { key: "roles" as const, href: "/dashboard/administracion/roles", pngIcon: "/icons/admin/usuarios.png" },
   ];
 
   return (

--- a/frontend/src/app/dashboard/administracion/roles/page.tsx
+++ b/frontend/src/app/dashboard/administracion/roles/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Plus, Pencil, Trash2 } from "lucide-react";
+import { AppHeader } from "@/components/layout/AppHeader";
+import { DataTable, type Column } from "@/components/shared/DataTable";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { FormContainer, FormSection, FormField, FormActions } from "@/theme/form-patterns";
+import { useRoles, useCreateRol, useUpdateRol, useDeleteRol } from "@/hooks/useRoles";
+import type { Rol } from "@/types";
+
+const MODULOS_DISPONIBLES = [
+  { value: "administracion", label: "Administración" },
+  { value: "usuarios", label: "Usuarios" },
+  { value: "tramites", label: "Trámites" },
+  { value: "presupuestos", label: "Presupuestos" },
+  { value: "escrituras", label: "Escrituras" },
+  { value: "personas", label: "Personas" },
+  { value: "auditoria", label: "Auditoría" },
+  { value: "workflows", label: "Workflows" },
+];
+
+const EMPTY: Partial<Rol> = { nombre: "", descripcion: "", activo: true, modulos: [] };
+
+export default function RolesPage() {
+  const { data: roles = [], isLoading } = useRoles();
+  const createMutation = useCreateRol();
+  const updateMutation = useUpdateRol();
+  const deleteMutation = useDeleteRol();
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [deleteId, setDeleteId] = useState<number | null>(null);
+  const [editing, setEditing] = useState<Partial<Rol>>(EMPTY);
+  const [isEditMode, setIsEditMode] = useState(false);
+
+  function openCreate() { setEditing(EMPTY); setIsEditMode(false); setModalOpen(true); }
+  function openEdit(r: Rol) { setEditing({ ...r }); setIsEditMode(true); setModalOpen(true); }
+
+  function toggleModulo(modulo: string) {
+    const current = editing.modulos ?? [];
+    const updated = current.includes(modulo)
+      ? current.filter((m) => m !== modulo)
+      : [...current, modulo];
+    setEditing({ ...editing, modulos: updated });
+  }
+
+  async function handleSave() {
+    if (!editing.nombre?.trim()) { toast.error("El nombre es obligatorio"); return; }
+    try {
+      if (isEditMode && editing.idRol) {
+        await updateMutation.mutateAsync({ id: editing.idRol, data: editing });
+        toast.success("Rol actualizado");
+      } else {
+        await createMutation.mutateAsync(editing);
+        toast.success("Rol creado");
+      }
+      setModalOpen(false);
+    } catch { toast.error("Error al guardar el rol"); }
+  }
+
+  async function handleDelete() {
+    if (!deleteId) return;
+    try {
+      await deleteMutation.mutateAsync(deleteId);
+      toast.success("Rol eliminado");
+    } catch { toast.error("Error al eliminar"); }
+    finally { setDeleteId(null); }
+  }
+
+  const columns: Column<Rol>[] = [
+    { key: "id", header: "ID", render: (r) => <span className="text-xs text-muted-foreground">{r.idRol}</span>, className: "w-12" },
+    { key: "nombre", header: "Nombre", render: (r) => <span className="font-medium">{r.nombre}</span> },
+    { key: "descripcion", header: "Descripción", render: (r) => <span className="text-sm text-muted-foreground">{r.descripcion ?? "—"}</span> },
+    { key: "modulos", header: "Módulos", render: (r) => (
+      <div className="flex flex-wrap gap-1">
+        {(r.modulos ?? []).map((m) => <Badge key={m} variant="outline" className="text-xs">{m}</Badge>)}
+        {(r.modulos ?? []).length === 0 && <span className="text-xs text-muted-foreground">Sin permisos</span>}
+      </div>
+    )},
+    { key: "activo", header: "Estado", render: (r) => r.activo ? <Badge variant="success">Activo</Badge> : <Badge variant="secondary">Inactivo</Badge> },
+    {
+      key: "actions", header: "", className: "w-24",
+      render: (r) => (
+        <div className="flex gap-2 justify-end">
+          <Button size="sm" variant="ghost" onClick={() => openEdit(r)} data-testid={`btn-edit-rol-${r.idRol}`}><Pencil className="h-4 w-4" /></Button>
+          <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive" onClick={() => setDeleteId(r.idRol!)}><Trash2 className="h-4 w-4" /></Button>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <AppHeader
+        title="Roles y Permisos"
+        description="Gestión de roles de usuario y sus accesos a módulos"
+        actions={<Button onClick={openCreate} data-testid="btn-nuevo-rol"><Plus className="h-4 w-4" />Nuevo Rol</Button>}
+      />
+      <DataTable data={roles} columns={columns} isLoading={isLoading} keyExtractor={(r) => r.idRol!} emptyMessage="No hay roles registrados" />
+
+      <Dialog open={modalOpen} onOpenChange={setModalOpen}>
+        <DialogContent>
+          <FormContainer>
+            <FormSection title={isEditMode ? "Editar Rol" : "Nuevo Rol"}>
+              <FormField label="Nombre" required>
+                <Input
+                  value={editing.nombre ?? ""}
+                  onChange={(e) => setEditing({ ...editing, nombre: e.target.value })}
+                  data-testid="input-nombre-rol"
+                />
+              </FormField>
+              <FormField label="Descripción">
+                <Input
+                  value={editing.descripcion ?? ""}
+                  onChange={(e) => setEditing({ ...editing, descripcion: e.target.value })}
+                />
+              </FormField>
+              <FormField label="Módulos permitidos">
+                <div className="grid grid-cols-2 gap-2 pt-1">
+                  {MODULOS_DISPONIBLES.map((mod) => (
+                    <label key={mod.value} className="flex items-center gap-2 cursor-pointer text-sm">
+                      <input
+                        type="checkbox"
+                        checked={(editing.modulos ?? []).includes(mod.value)}
+                        onChange={() => toggleModulo(mod.value)}
+                        data-testid={`check-modulo-${mod.value}`}
+                        className="rounded"
+                      />
+                      {mod.label}
+                    </label>
+                  ))}
+                </div>
+              </FormField>
+              <FormField label="Activo">
+                <label className="flex items-center gap-2 cursor-pointer text-sm">
+                  <input
+                    type="checkbox"
+                    checked={editing.activo ?? true}
+                    onChange={(e) => setEditing({ ...editing, activo: e.target.checked })}
+                    className="rounded"
+                  />
+                  Rol activo
+                </label>
+              </FormField>
+            </FormSection>
+            <FormActions align="right">
+              <Button variant="secondary" onClick={() => setModalOpen(false)}>Cancelar</Button>
+              <Button onClick={handleSave} disabled={createMutation.isPending || updateMutation.isPending}>
+                {isEditMode ? "Actualizar" : "Crear"}
+              </Button>
+            </FormActions>
+          </FormContainer>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog open={!!deleteId} onOpenChange={(v) => !v && setDeleteId(null)} onConfirm={handleDelete} loading={deleteMutation.isPending} />
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/administracion/usuarios/page.tsx
+++ b/frontend/src/app/dashboard/administracion/usuarios/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/select";
 import { FormContainer, FormSection, FormField, FormActions } from "@/theme/form-patterns";
 import { useUsuarios, useCreateUsuario, useUpdateUsuario, useDeleteUsuario } from "@/hooks/useUsuarios";
+import { useRoles, useAssignRolToUsuario, useUnassignRolFromUsuario } from "@/hooks/useRoles";
 import type { Usuario } from "@/types";
 
 const EMPTY: Partial<Usuario> = { nombre: "", contrasenia: "", tipo: "EMPLEADO", activo: true };
@@ -29,27 +30,46 @@ export default function UsuariosPage() {
   const tc = useTranslations("common");
 
   const { data: usuarios = [], isLoading } = useUsuarios();
+  const { data: roles = [] } = useRoles();
   const createMutation = useCreateUsuario();
   const updateMutation = useUpdateUsuario();
   const deleteMutation = useDeleteUsuario();
+  const assignRolMutation = useAssignRolToUsuario();
+  const unassignRolMutation = useUnassignRolFromUsuario();
 
   const [modalOpen, setModalOpen] = useState(false);
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [editing, setEditing] = useState<Partial<Usuario>>(EMPTY);
+  const [selectedRolId, setSelectedRolId] = useState<string>("none");
   const [isEditMode, setIsEditMode] = useState(false);
 
-  function openCreate() { setEditing(EMPTY); setIsEditMode(false); setModalOpen(true); }
-  function openEdit(u: Usuario) { setEditing({ ...u, contrasenia: "" }); setIsEditMode(true); setModalOpen(true); }
+  function openCreate() { setEditing(EMPTY); setSelectedRolId("none"); setIsEditMode(false); setModalOpen(true); }
+  function openEdit(u: Usuario) {
+    setEditing({ ...u, contrasenia: "" });
+    setSelectedRolId(u.rol?.idRol?.toString() ?? "none");
+    setIsEditMode(true);
+    setModalOpen(true);
+  }
 
   async function handleSave() {
     if (!editing.nombre?.trim()) { toast.error(t("fields.nombre") + " " + tc("required")); return; }
     try {
+      let savedId: number | undefined;
       if (isEditMode && editing.idUsuario) {
         await updateMutation.mutateAsync({ id: editing.idUsuario, data: editing });
+        savedId = editing.idUsuario;
         toast.success(t("updated"));
       } else {
-        await createMutation.mutateAsync(editing);
+        const created = await createMutation.mutateAsync(editing);
+        savedId = (created as Usuario)?.idUsuario;
         toast.success(t("created"));
+      }
+      if (savedId) {
+        if (selectedRolId && selectedRolId !== "none") {
+          await assignRolMutation.mutateAsync({ idRol: Number(selectedRolId), idUsuario: savedId });
+        } else if (isEditMode && editing.rol) {
+          await unassignRolMutation.mutateAsync(savedId);
+        }
       }
       setModalOpen(false);
     } catch { toast.error(t("errorSave")); }
@@ -74,6 +94,7 @@ export default function UsuariosPage() {
     { key: "id", header: tc("id"), render: (u) => <span className="text-xs text-muted-foreground">{u.idUsuario}</span>, className: "w-12" },
     { key: "nombre", header: t("fields.nombre"), render: (u) => <span className="font-medium">{u.nombre}</span> },
     { key: "tipo", header: t("fields.tipo"), render: (u) => <Badge variant={tipoVariant(u.tipo)}>{u.tipo ?? "—"}</Badge> },
+    { key: "rol", header: "Rol", render: (u) => u.rol ? <Badge variant="outline">{u.rol.nombre}</Badge> : <span className="text-xs text-muted-foreground">—</span> },
     { key: "activo", header: tc("status"), render: (u) => u.activo ? <Badge variant="success">Activo</Badge> : <Badge variant="secondary">Inactivo</Badge> },
     {
       key: "actions", header: "", className: "w-24",
@@ -128,6 +149,19 @@ export default function UsuariosPage() {
                     <SelectItem value="EMPLEADO">{t("roles.empleado")}</SelectItem>
                     <SelectItem value="ADMIN">{t("roles.admin")}</SelectItem>
                     <SelectItem value="ESCRIBANO">{t("roles.escribano")}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </FormField>
+              <FormField label="Rol de acceso" helperText="Permisos de módulos del sistema">
+                <Select value={selectedRolId} onValueChange={setSelectedRolId} data-testid="select-rol-usuario">
+                  <SelectTrigger>
+                    <SelectValue placeholder="Sin rol asignado" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">Sin rol</SelectItem>
+                    {roles.filter((r) => r.activo).map((r) => (
+                      <SelectItem key={r.idRol} value={String(r.idRol)}>{r.nombre}</SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </FormField>

--- a/frontend/src/components/layout/Breadcrumb.tsx
+++ b/frontend/src/components/layout/Breadcrumb.tsx
@@ -16,6 +16,7 @@ const SEGMENT_LABELS: Record<string, string> = {
   items: "Ítems",
   auditoria: "Auditoría",
   workflows: "Workflows",
+  roles: "Roles y Permisos",
   suplencias: "Suplencias",
   personas: "Personas",
   escrituras: "Escrituras",

--- a/frontend/src/hooks/useRoles.ts
+++ b/frontend/src/hooks/useRoles.ts
@@ -1,0 +1,57 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiGet, apiPost, apiPut, apiDelete } from "@/lib/api-client";
+import type { Rol } from "@/types";
+
+export const rolesKeys = { all: ["roles"] as const };
+
+export function useRoles() {
+  return useQuery({
+    queryKey: rolesKeys.all,
+    queryFn: () => apiGet<Rol[]>("/roles"),
+  });
+}
+
+export function useCreateRol() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: Partial<Rol>) => apiPost<Rol>("/roles", data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: rolesKeys.all }),
+  });
+}
+
+export function useUpdateRol() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: Partial<Rol> }) =>
+      apiPut<Rol>(`/roles/${id}`, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: rolesKeys.all }),
+  });
+}
+
+export function useDeleteRol() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => apiDelete(`/roles/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: rolesKeys.all }),
+  });
+}
+
+export function useAssignRolToUsuario() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ idRol, idUsuario }: { idRol: number; idUsuario: number }) =>
+      apiPut<void>(`/roles/${idRol}/usuarios/${idUsuario}`, {}),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: rolesKeys.all });
+      qc.invalidateQueries({ queryKey: ["usuarios"] });
+    },
+  });
+}
+
+export function useUnassignRolFromUsuario() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (idUsuario: number) => apiDelete(`/roles/usuarios/${idUsuario}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["usuarios"] }),
+  });
+}

--- a/frontend/src/hooks/useUsuarios.ts
+++ b/frontend/src/hooks/useUsuarios.ts
@@ -14,7 +14,7 @@ export function useUsuarios() {
 export function useCreateUsuario() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: Partial<Usuario>) => apiPost<void>("/usuarios", data),
+    mutationFn: (data: Partial<Usuario>) => apiPost<Usuario>("/usuarios", data),
     onSuccess: () => qc.invalidateQueries({ queryKey: usuariosKeys.all }),
   });
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -23,6 +23,14 @@ export interface Persona {
   esCliente?: boolean;
 }
 
+export interface Rol {
+  idRol?: number;
+  nombre?: string;
+  descripcion?: string;
+  activo?: boolean;
+  modulos?: string[];
+}
+
 export interface Usuario {
   idUsuario?: number;
   nombre?: string;
@@ -30,6 +38,7 @@ export interface Usuario {
   tipo?: string;
   activo?: boolean;
   persona?: Persona;
+  rol?: { idRol: number; nombre: string } | null;
 }
 
 export interface TipoDeTramite {

--- a/frontend/tests/e2e/cu431-roles-permisos.spec.ts
+++ b/frontend/tests/e2e/cu431-roles-permisos.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("CU431 — Gestión de Roles y Permisos", () => {
+  test("roles page is accessible from administracion", async ({ page }) => {
+    await page.goto("/dashboard/administracion/roles");
+    await expect(page.getByText("Roles y Permisos")).toBeVisible({ timeout: 10000 });
+  });
+
+  test("new role button opens modal", async ({ page }) => {
+    await page.goto("/dashboard/administracion/roles");
+    await page.getByTestId("btn-nuevo-rol").click();
+    await expect(page.getByTestId("input-nombre-rol")).toBeVisible();
+  });
+
+  test("usuarios page shows rol column", async ({ page }) => {
+    await page.goto("/dashboard/administracion/usuarios");
+    await expect(page.getByText("Rol")).toBeVisible({ timeout: 10000 });
+  });
+
+  test("usuario edit modal shows rol selector", async ({ page }) => {
+    await page.goto("/dashboard/administracion/usuarios");
+    await page.getByTestId("btn-nuevo-usuario").click();
+    await expect(page.getByTestId("select-rol-usuario")).toBeVisible();
+  });
+});

--- a/init-db/01-schema.sql
+++ b/init-db/01-schema.sql
@@ -32,6 +32,8 @@ DROP TABLE IF EXISTS workflow_node CASCADE;
 DROP TABLE IF EXISTS workflow_definition CASCADE;
 DROP TABLE IF EXISTS estados_de_gestion CASCADE;
 DROP TABLE IF EXISTS conceptos CASCADE;
+DROP TABLE IF EXISTS roles_permisos CASCADE;
+DROP TABLE IF EXISTS roles CASCADE;
 
 -- Table: conceptos
 CREATE TABLE conceptos (
@@ -391,6 +393,23 @@ CREATE TABLE suplencias (
   fk_id_suplente integer REFERENCES personas(id_persona)
 );
 
+-- Table: roles
+CREATE TABLE roles (
+  version integer NOT NULL DEFAULT 0,
+  id_rol SERIAL PRIMARY KEY,
+  nombre text NOT NULL,
+  descripcion text,
+  activo boolean NOT NULL DEFAULT true,
+  CONSTRAINT roles_nombre_unique UNIQUE (nombre)
+);
+
+-- Table: roles_permisos
+CREATE TABLE roles_permisos (
+  fk_id_rol integer NOT NULL REFERENCES roles(id_rol) ON DELETE CASCADE,
+  modulo text NOT NULL,
+  PRIMARY KEY (fk_id_rol, modulo)
+);
+
 -- Table: usuarios (column names match backend entity Usuario)
 CREATE TABLE usuarios (
   version integer NOT NULL,
@@ -399,7 +418,8 @@ CREATE TABLE usuarios (
   contrasenia text NOT NULL,
   tipo text NOT NULL,
   estado boolean NOT NULL,
-  fk_id_persona integer REFERENCES personas(id_persona)
+  fk_id_persona integer REFERENCES personas(id_persona),
+  fk_id_rol integer REFERENCES roles(id_rol)
 );
 
 -- Table: registro_auditoria

--- a/notaire-shared/src/main/java/com/licensis/notaire/dto/DtoUsuario.java
+++ b/notaire-shared/src/main/java/com/licensis/notaire/dto/DtoUsuario.java
@@ -17,6 +17,8 @@ public class DtoUsuario
     private String registroAuditoria;
     private Integer version;
     private boolean valido = false;
+    private Integer rolId;
+    private String rolNombre;
 
     public boolean isValido()
     {
@@ -116,6 +118,26 @@ public class DtoUsuario
     public void setVersion(Integer version)
     {
         this.version = version;
+    }
+
+    public Integer getRolId()
+    {
+        return rolId;
+    }
+
+    public void setRolId(Integer rolId)
+    {
+        this.rolId = rolId;
+    }
+
+    public String getRolNombre()
+    {
+        return rolNombre;
+    }
+
+    public void setRolNombre(String rolNombre)
+    {
+        this.rolNombre = rolNombre;
     }
 }
 


### PR DESCRIPTION
## Summary
- Full CRUD API for roles: `GET/POST/PUT/DELETE /api/v1/roles`
- Role-user assignment: `PUT /api/v1/roles/{idRol}/usuarios/{idUsuario}` and unassign endpoint
- DB schema: `roles` + `roles_permisos` tables; `fk_id_rol` added to `usuarios`
- Frontend: new `/administracion/roles` page for managing roles and module permissions
- Frontend: users page shows assigned role and allows role selection in modal

## Changes
### Added
- `Rol` entity, `RolRepository`, `RolController`
- `V9__add_roles_permisos.sql` Flyway migration
- `frontend/src/app/dashboard/administracion/roles/page.tsx`
- `frontend/src/hooks/useRoles.ts`
- `frontend/tests/e2e/cu431-roles-permisos.spec.ts`
### Modified
- `Usuario` entity: added `@ManyToOne Rol rol`
- `UsuarioController`: `UsuarioResponse` includes `RolInfo`
- `DtoUsuario`: added `rolId`, `rolNombre` fields
- `init-db/01-schema.sql`: `roles`, `roles_permisos` tables + `fk_id_rol` on usuarios
- Usuarios page: rol column + rol selector in create/edit modal
- Administracion landing page: added roles module card

## Testing
- [x] 9 unit tests for RolController (TDD — all pass)
- [x] 538 total backend tests pass, 0 failures
- [x] TypeScript compiles cleanly
- [x] 4 E2E Playwright tests for CU431

## Issue Reference
Fixes #431