### PR TITLE
[#257] feat(docs): complete Swagger/OpenAPI documentation for all endpoints

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/ConceptoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/ConceptoController.java
@@ -5,6 +5,8 @@ import com.licensis.notaire.negocio.Concepto;
 import com.licensis.notaire.repository.ConceptoRepository;
 import com.licensis.notaire.repository.PlantillaPresupuestoRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -64,6 +66,10 @@ public class ConceptoController {
         return ResponseEntity.ok(Map.of("inUse", inUse));
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener concepto por ID")
     public ResponseEntity<DtoConcepto> getConceptoById(@PathVariable Integer id) {
@@ -72,6 +78,11 @@ public class ConceptoController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo concepto")
     public ResponseEntity<Object> createConcepto(@RequestBody DtoConcepto dto) {
@@ -86,6 +97,10 @@ public class ConceptoController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar concepto")
     public ResponseEntity<Object> updateConcepto(@PathVariable Integer id, @RequestBody DtoConcepto dto) {
@@ -111,6 +126,10 @@ public class ConceptoController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar concepto")
     public ResponseEntity<Object> deleteConcepto(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/CopiaController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/CopiaController.java
@@ -3,6 +3,8 @@ package com.licensis.notaire.api;
 import com.licensis.notaire.negocio.Copia;
 import com.licensis.notaire.repository.CopiaRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +33,10 @@ public class CopiaController {
         return ResponseEntity.ok(repository.findAll());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener copia por ID")
     public ResponseEntity<Copia> getById(@PathVariable Integer id) {
@@ -39,6 +45,11 @@ public class CopiaController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nueva copia")
     public ResponseEntity<Object> create(@RequestBody Copia entity) {
@@ -51,6 +62,10 @@ public class CopiaController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar copia")
     public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody Copia entity) {
@@ -67,6 +82,10 @@ public class CopiaController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar copia")
     public ResponseEntity<Void> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/DocumentoPresentadoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/DocumentoPresentadoController.java
@@ -4,6 +4,8 @@ import com.licensis.notaire.negocio.DocumentoPresentado;
 import com.licensis.notaire.repository.DocumentoPresentadoRepository;
 import com.licensis.notaire.repository.TipoDeDocumentoRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,6 +81,10 @@ public class DocumentoPresentadoController {
         return ResponseEntity.ok(repository.findAll().stream().map(this::toResponse).toList());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener documento presentado por ID")
     public ResponseEntity<DocumentoPresentadoResponse> getById(@PathVariable Integer id) {
@@ -88,6 +94,11 @@ public class DocumentoPresentadoController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo documento presentado")
     public ResponseEntity<Object> create(@RequestBody DocumentoPresentadoRequest request) {
@@ -101,6 +112,10 @@ public class DocumentoPresentadoController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar documento presentado")
     public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody DocumentoPresentadoRequest request) {
@@ -118,6 +133,10 @@ public class DocumentoPresentadoController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar documento presentado")
     public ResponseEntity<Void> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/EscrituraController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/EscrituraController.java
@@ -4,6 +4,8 @@ import com.licensis.notaire.negocio.Escritura;
 import com.licensis.notaire.negocio.Persona;
 import com.licensis.notaire.service.EscrituraService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +36,10 @@ public class EscrituraController {
         return ResponseEntity.ok(escrituraService.findAll());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener escritura por ID")
     @Transactional(readOnly = true)
@@ -43,6 +49,11 @@ public class EscrituraController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nueva escritura")
     public ResponseEntity<Escritura> create(@RequestBody Escritura entity) {
@@ -55,6 +66,10 @@ public class EscrituraController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar escritura")
     public ResponseEntity<Escritura> update(@PathVariable Integer id, @RequestBody Escritura entity) {
@@ -68,6 +83,10 @@ public class EscrituraController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar escritura")
     public ResponseEntity<Void> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/EstadoDeGestionController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/EstadoDeGestionController.java
@@ -5,6 +5,8 @@ import com.licensis.notaire.negocio.EstadoDeGestion;
 import com.licensis.notaire.repository.EstadoDeGestionRepository;
 import com.licensis.notaire.repository.GestionDeEscrituraRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -45,6 +47,10 @@ public class EstadoDeGestionController {
         return ResponseEntity.ok(result);
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener estado de gestion por ID")
     public ResponseEntity<DtoEstadoDeGestion> getById(@PathVariable Integer id) {
@@ -72,6 +78,11 @@ public class EstadoDeGestionController {
         return ResponseEntity.ok(Map.of("inUse", inUse));
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear estado de gestion")
     public ResponseEntity<Object> create(@RequestBody DtoEstadoDeGestion dto) {
@@ -88,6 +99,10 @@ public class EstadoDeGestionController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar estado de gestion")
     public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody DtoEstadoDeGestion dto) {
@@ -114,6 +129,10 @@ public class EstadoDeGestionController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar estado de gestion")
     public ResponseEntity<Object> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/FolioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/FolioController.java
@@ -8,6 +8,8 @@ import com.licensis.notaire.repository.FolioRepository;
 import com.licensis.notaire.repository.PersonaRepository;
 import com.licensis.notaire.repository.TipoDeFolioRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +62,10 @@ public class FolioController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener folio por ID")
     public ResponseEntity<DtoFolio> getById(@PathVariable Integer id) {
@@ -68,6 +74,11 @@ public class FolioController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo folio")
     public ResponseEntity<DtoFolio> create(@RequestBody FolioRequest request) {
@@ -95,6 +106,10 @@ public class FolioController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar folio")
     public ResponseEntity<DtoFolio> update(@PathVariable Integer id, @RequestBody FolioRequest request) {
@@ -122,6 +137,10 @@ public class FolioController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar folio")
     @Transactional

--- a/backend-api/src/main/java/com/licensis/notaire/api/GestionController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/GestionController.java
@@ -5,6 +5,8 @@ import com.licensis.notaire.negocio.Historial;
 import com.licensis.notaire.repository.GestionDeEscrituraRepository;
 import com.licensis.notaire.repository.HistorialRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +38,10 @@ public class GestionController {
         return ResponseEntity.ok(repository.findAll());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener gestion por ID")
     public ResponseEntity<GestionDeEscritura> getById(@PathVariable Integer id) {
@@ -71,6 +77,11 @@ public class GestionController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nueva gestion")
     public ResponseEntity<Object> create(@RequestBody GestionDeEscritura entity) {
@@ -83,6 +94,10 @@ public class GestionController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar gestion")
     public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody GestionDeEscritura entity) {
@@ -99,6 +114,10 @@ public class GestionController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar gestion")
     public ResponseEntity<Void> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/HistorialController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/HistorialController.java
@@ -3,6 +3,8 @@ package com.licensis.notaire.api;
 import com.licensis.notaire.negocio.Historial;
 import com.licensis.notaire.repository.HistorialRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +33,10 @@ public class HistorialController {
         return ResponseEntity.ok(repository.findAll());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener historial por ID")
     public ResponseEntity<Historial> getById(@PathVariable Integer id) {
@@ -45,6 +51,11 @@ public class HistorialController {
         return ResponseEntity.ok(repository.findByFkIdGestionIdGestion(idGestion));
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo registro de historial")
     public ResponseEntity<Object> create(@RequestBody Historial entity) {
@@ -57,6 +68,10 @@ public class HistorialController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar historial")
     public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody Historial entity) {
@@ -73,6 +88,10 @@ public class HistorialController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar historial")
     public ResponseEntity<Void> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/InmuebleController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/InmuebleController.java
@@ -4,6 +4,8 @@ import com.licensis.notaire.jpa.InmuebleJpaController;
 import com.licensis.notaire.config.JpaControllerProvider;
 import com.licensis.notaire.negocio.Inmueble;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +32,10 @@ public class InmuebleController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener inmueble por ID")
     public ResponseEntity<Inmueble> getById(@PathVariable Integer id) {
@@ -40,6 +46,11 @@ public class InmuebleController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo inmueble")
     public ResponseEntity<Object> create(@RequestBody Inmueble entity) {
@@ -51,6 +62,10 @@ public class InmuebleController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar inmueble")
     public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody Inmueble entity) {
@@ -63,6 +78,10 @@ public class InmuebleController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar inmueble")
     public ResponseEntity<Void> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/ItemController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/ItemController.java
@@ -3,6 +3,8 @@ package com.licensis.notaire.api;
 import com.licensis.notaire.negocio.Item;
 import com.licensis.notaire.repository.ItemRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +33,10 @@ public class ItemController {
         return ResponseEntity.ok(repository.findAll());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener ítem por ID")
     public ResponseEntity<Item> getById(@PathVariable Integer id) {
@@ -45,6 +51,11 @@ public class ItemController {
         return ResponseEntity.ok(repository.findByFkIdPresupuestoIdPresupuesto(idPresupuesto));
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo ítem")
     public ResponseEntity<Object> create(@RequestBody Item entity) {
@@ -57,6 +68,10 @@ public class ItemController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar ítem")
     public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody Item entity) {
@@ -73,6 +88,10 @@ public class ItemController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar ítem")
     public ResponseEntity<Void> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/MovimientoTestimonioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/MovimientoTestimonioController.java
@@ -4,6 +4,8 @@ import com.licensis.notaire.dto.DtoMovimientoTestimonio;
 import com.licensis.notaire.negocio.MovimientoTestimonio;
 import com.licensis.notaire.repository.MovimientoTestimonioRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +34,10 @@ public class MovimientoTestimonioController {
         return ResponseEntity.ok(result);
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener movimiento-testimonio por ID")
     public ResponseEntity<DtoMovimientoTestimonio> getById(@PathVariable Integer id) {
@@ -40,6 +46,11 @@ public class MovimientoTestimonioController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo movimiento-testimonio")
     public ResponseEntity<Object> create(@RequestBody DtoMovimientoTestimonio dto) {
@@ -53,6 +64,10 @@ public class MovimientoTestimonioController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar movimiento-testimonio")
     public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody DtoMovimientoTestimonio dto) {
@@ -71,6 +86,10 @@ public class MovimientoTestimonioController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar movimiento-testimonio")
     public ResponseEntity<Object> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/PagoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/PagoController.java
@@ -3,6 +3,8 @@ package com.licensis.notaire.api;
 import com.licensis.notaire.negocio.Pago;
 import com.licensis.notaire.service.PagoService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
@@ -39,6 +41,10 @@ public class PagoController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "CU47 - Consultar pago por ID")
     public ResponseEntity<Pago> getById(@PathVariable Integer id) {
@@ -92,6 +98,11 @@ public class PagoController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "CU15 - Procesar pago (JSON body)")
     public ResponseEntity<Pago> procesarPago(@RequestBody PagoRequest request) {
@@ -132,6 +143,10 @@ public class PagoController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Editar pago")
     public ResponseEntity<Pago> update(@PathVariable Integer id, @RequestBody Pago entity) {
@@ -146,6 +161,10 @@ public class PagoController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar pago")
     public ResponseEntity<Void> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/PersonaController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/PersonaController.java
@@ -5,6 +5,8 @@ import com.licensis.notaire.negocio.TipoIdentificacion;
 import com.licensis.notaire.repository.TipoIdentificacionRepository;
 import com.licensis.notaire.service.PersonaService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,6 +36,10 @@ public class PersonaController {
         return ResponseEntity.ok(personas);
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener persona por ID")
     @Transactional(readOnly = true)
@@ -43,6 +49,11 @@ public class PersonaController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nueva persona")
     public ResponseEntity<Object> createPersona(@RequestBody Persona persona) {
@@ -63,6 +74,10 @@ public class PersonaController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar persona")
     public ResponseEntity<Persona> updatePersona(@PathVariable Integer id, @RequestBody Persona persona) {
@@ -79,6 +94,10 @@ public class PersonaController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar persona")
     public ResponseEntity<Object> deletePersona(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/PlantillaPresupuestoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/PlantillaPresupuestoController.java
@@ -7,6 +7,8 @@ import com.licensis.notaire.jpa.exceptions.PreexistingEntityException;
 import com.licensis.notaire.negocio.PlantillaPresupuesto;
 import com.licensis.notaire.negocio.PlantillaPresupuestoPK;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.persistence.OptimisticLockException;
 import org.springframework.http.HttpStatus;
@@ -61,6 +63,11 @@ public class PlantillaPresupuestoController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nueva plantilla de presupuesto")
     public ResponseEntity<?> create(@RequestBody PlantillaPresupuesto entity) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/PlantillaTramiteController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/PlantillaTramiteController.java
@@ -3,6 +3,8 @@ package com.licensis.notaire.api;
 import com.licensis.notaire.negocio.PlantillaTramite;
 import com.licensis.notaire.repository.PlantillaTramiteRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/backend-api/src/main/java/com/licensis/notaire/api/PresupuestoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/PresupuestoController.java
@@ -4,6 +4,8 @@ import com.licensis.notaire.exception.ResourceNotFoundException;
 import com.licensis.notaire.negocio.Presupuesto;
 import com.licensis.notaire.service.PresupuestoService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
@@ -41,6 +43,10 @@ public class PresupuestoController {
         return ResponseEntity.ok(presupuestoService.findAll());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener presupuesto por ID")
     public ResponseEntity<Presupuesto> getById(@PathVariable Integer id) {
@@ -62,6 +68,11 @@ public class PresupuestoController {
         return ResponseEntity.ok(presupuestoService.findByEstado(estado));
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo presupuesto")
     public ResponseEntity<Presupuesto> create(@RequestBody Presupuesto entity) {
@@ -69,6 +80,10 @@ public class PresupuestoController {
         return ResponseEntity.status(HttpStatus.CREATED).body(saved);
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar presupuesto")
     public ResponseEntity<Presupuesto> update(@PathVariable Integer id, @RequestBody Presupuesto entity) {
@@ -80,6 +95,10 @@ public class PresupuestoController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar presupuesto")
     public ResponseEntity<Void> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/RegistroAuditoriaController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/RegistroAuditoriaController.java
@@ -4,6 +4,8 @@ import com.licensis.notaire.dto.DtoRegistroAuditoria;
 import com.licensis.notaire.negocio.RegistroAuditoria;
 import com.licensis.notaire.service.RegistroAuditoriaService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -67,6 +69,10 @@ public class RegistroAuditoriaController {
         return ResponseEntity.ok(toPageResponse(result));
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener registro de auditoria por ID")
     public ResponseEntity<DtoRegistroAuditoria> getById(@PathVariable Integer id) {
@@ -81,6 +87,11 @@ public class RegistroAuditoriaController {
         return ResponseEntity.ok(service.findByUsuarioIdAsDto(idUsuario));
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo registro de auditoria")
     public ResponseEntity<RegistroAuditoria> create(@RequestBody RegistroAuditoria entity) {
@@ -88,6 +99,10 @@ public class RegistroAuditoriaController {
         return ResponseEntity.ok(saved);
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar registro de auditoria")
     public ResponseEntity<Void> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/ReporteController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/ReporteController.java
@@ -2,6 +2,8 @@ package com.licensis.notaire.api;
 
 import com.licensis.notaire.servicios.ReporteService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpHeaders;

--- a/backend-api/src/main/java/com/licensis/notaire/api/RolController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/RolController.java
@@ -5,6 +5,8 @@ import com.licensis.notaire.negocio.Usuario;
 import com.licensis.notaire.repository.RolRepository;
 import com.licensis.notaire.repository.UsuarioRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -49,6 +51,10 @@ public class RolController {
         return ResponseEntity.ok(rolRepository.findAll().stream().map(this::toResponse).toList());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener rol por ID")
     public ResponseEntity<RolResponse> getRolById(@PathVariable Integer id) {
@@ -58,6 +64,11 @@ public class RolController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo rol")
     public ResponseEntity<Object> createRol(@RequestBody RolRequest request) {
@@ -74,6 +85,10 @@ public class RolController {
         return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(saved));
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar rol")
     public ResponseEntity<RolResponse> updateRol(@PathVariable Integer id, @RequestBody RolRequest request) {
@@ -89,6 +104,10 @@ public class RolController {
         return ResponseEntity.ok(toResponse(rolRepository.save(rol)));
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar rol")
     public ResponseEntity<Void> deleteRol(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/SuplenciaController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/SuplenciaController.java
@@ -4,6 +4,8 @@ import com.licensis.notaire.jpa.SuplenciaJpaController;
 import com.licensis.notaire.config.JpaControllerProvider;
 import com.licensis.notaire.negocio.Suplencia;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +32,10 @@ public class SuplenciaController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener suplencia por ID")
     public ResponseEntity<Suplencia> getById(@PathVariable Integer id) {
@@ -40,6 +46,11 @@ public class SuplenciaController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo suplencia")
     public ResponseEntity<Object> create(@RequestBody Suplencia entity) {
@@ -51,6 +62,10 @@ public class SuplenciaController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar suplencia")
     public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody Suplencia entity) {
@@ -63,6 +78,10 @@ public class SuplenciaController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar suplencia")
     public ResponseEntity<Void> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/TestimonioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TestimonioController.java
@@ -4,6 +4,8 @@ import com.licensis.notaire.dto.DtoTestimonio;
 import com.licensis.notaire.negocio.Testimonio;
 import com.licensis.notaire.repository.TestimonioRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +34,10 @@ public class TestimonioController {
         return ResponseEntity.ok(result);
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener testimonio por ID")
     public ResponseEntity<DtoTestimonio> getById(@PathVariable Integer id) {
@@ -40,6 +46,11 @@ public class TestimonioController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo testimonio")
     public ResponseEntity<Object> create(@RequestBody DtoTestimonio dto) {
@@ -53,6 +64,10 @@ public class TestimonioController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar testimonio")
     public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody DtoTestimonio dto) {
@@ -71,6 +86,10 @@ public class TestimonioController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar testimonio")
     public ResponseEntity<Object> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/TipoDeDocumentoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TipoDeDocumentoController.java
@@ -6,6 +6,8 @@ import com.licensis.notaire.repository.DocumentoPresentadoRepository;
 import com.licensis.notaire.repository.PlantillaTramiteRepository;
 import com.licensis.notaire.repository.TipoDeDocumentoRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -48,6 +50,10 @@ public class TipoDeDocumentoController {
                 .toList());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener tipo-de-documento por ID")
     public ResponseEntity<DtoTipoDeDocumento> getById(@PathVariable Integer id) {
@@ -67,6 +73,11 @@ public class TipoDeDocumentoController {
         return ResponseEntity.ok(Map.of("inUse", inUse));
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo tipo-de-documento")
     public ResponseEntity<Object> create(@RequestBody DtoTipoDeDocumento dto) {
@@ -84,6 +95,10 @@ public class TipoDeDocumentoController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar tipo-de-documento")
     public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody DtoTipoDeDocumento dto) {
@@ -110,6 +125,10 @@ public class TipoDeDocumentoController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar tipo-de-documento")
     public ResponseEntity<Object> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/TipoDeFolioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TipoDeFolioController.java
@@ -4,6 +4,8 @@ import com.licensis.notaire.dto.DtoTipoDeFolio;
 import com.licensis.notaire.negocio.TipoDeFolio;
 import com.licensis.notaire.repository.TipoDeFolioRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +34,10 @@ public class TipoDeFolioController {
         return ResponseEntity.ok(result);
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener tipo de folio por ID")
     public ResponseEntity<DtoTipoDeFolio> getById(@PathVariable Integer id) {
@@ -40,6 +46,11 @@ public class TipoDeFolioController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear tipo de folio")
     public ResponseEntity<Object> create(@RequestBody DtoTipoDeFolio dto) {
@@ -53,6 +64,10 @@ public class TipoDeFolioController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar tipo de folio")
     public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody DtoTipoDeFolio dto) {
@@ -71,6 +86,10 @@ public class TipoDeFolioController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar tipo de folio")
     public ResponseEntity<Object> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/TipoDeTramiteController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TipoDeTramiteController.java
@@ -9,6 +9,8 @@ import com.licensis.notaire.repository.TramiteRepository;
 import com.licensis.notaire.repository.WorkflowDefinitionRepository;
 import com.licensis.notaire.negocio.WorkflowDefinition;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -65,6 +67,10 @@ public class TipoDeTramiteController {
                 .toList());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener tipo de tramite por ID")
     public ResponseEntity<DtoTipoDeTramite> getById(@PathVariable Integer id) {
@@ -85,6 +91,11 @@ public class TipoDeTramiteController {
         return ResponseEntity.ok(Map.of("inUse", inUse));
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear tipo de tramite")
     public ResponseEntity<Object> create(@RequestBody DtoTipoDeTramite dto) {
@@ -105,6 +116,10 @@ public class TipoDeTramiteController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar tipo de tramite")
     public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody DtoTipoDeTramite dto) {
@@ -129,6 +144,10 @@ public class TipoDeTramiteController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar tipo de tramite")
     public ResponseEntity<Object> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/TipoIdentificacionController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TipoIdentificacionController.java
@@ -3,6 +3,8 @@ package com.licensis.notaire.api;
 import com.licensis.notaire.negocio.TipoIdentificacion;
 import com.licensis.notaire.repository.TipoIdentificacionRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +33,10 @@ public class TipoIdentificacionController {
         return ResponseEntity.ok(repository.findAll());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener tipo de identificacion por ID")
     public ResponseEntity<TipoIdentificacion> getById(@PathVariable Integer id) {
@@ -39,6 +45,11 @@ public class TipoIdentificacionController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo tipo de identificacion")
     public ResponseEntity<Object> create(@RequestBody TipoIdentificacion entity) {
@@ -51,6 +62,10 @@ public class TipoIdentificacionController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar tipo de identificacion")
     public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody TipoIdentificacion entity) {
@@ -67,6 +82,10 @@ public class TipoIdentificacionController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar tipo de identificacion")
     public ResponseEntity<Void> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/TramiteController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TramiteController.java
@@ -3,6 +3,8 @@ package com.licensis.notaire.api;
 import com.licensis.notaire.negocio.Tramite;
 import com.licensis.notaire.repository.TramiteRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +33,10 @@ public class TramiteController {
         return ResponseEntity.ok(repository.findAll());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener trámite por ID")
     public ResponseEntity<Tramite> getById(@PathVariable Integer id) {
@@ -39,6 +45,11 @@ public class TramiteController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo trámite")
     public ResponseEntity<Object> create(@RequestBody Tramite entity) {
@@ -51,6 +62,10 @@ public class TramiteController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar trámite")
     public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody Tramite entity) {
@@ -67,6 +82,10 @@ public class TramiteController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar trámite")
     public ResponseEntity<Void> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
@@ -5,6 +5,8 @@ import com.licensis.notaire.dto.DtoUsuario;
 import com.licensis.notaire.negocio.Usuario;
 import com.licensis.notaire.repository.UsuarioRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -70,6 +72,10 @@ public class UsuarioController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener usuario por ID")
     public ResponseEntity<UsuarioResponse> getUsuarioById(@PathVariable Integer id) {
@@ -79,6 +85,11 @@ public class UsuarioController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nuevo usuario")
     public ResponseEntity<Object> createUsuario(@RequestBody UsuarioRequest request) {
@@ -97,6 +108,10 @@ public class UsuarioController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar usuario")
     public ResponseEntity<Void> updateUsuario(@PathVariable Integer id, @RequestBody UsuarioRequest request) {
@@ -121,6 +136,10 @@ public class UsuarioController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar usuario")
     public ResponseEntity<Void> deleteUsuario(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/WorkflowDefinitionController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/WorkflowDefinitionController.java
@@ -6,6 +6,8 @@ import com.licensis.notaire.repository.WorkflowDefinitionRepository;
 import com.licensis.notaire.repository.WorkflowNodeRepository;
 import com.licensis.notaire.repository.WorkflowTransitionRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -45,6 +47,10 @@ public class WorkflowDefinitionController {
         return ResponseEntity.ok(repository.findAll().stream().map(WorkflowDefinition::toDto).toList());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener workflow por ID")
     public ResponseEntity<DtoWorkflowDefinition> getById(@PathVariable Integer id) {
@@ -53,6 +59,11 @@ public class WorkflowDefinitionController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear workflow")
     public ResponseEntity<Object> create(@RequestBody DtoWorkflowDefinition dto) {
@@ -68,6 +79,10 @@ public class WorkflowDefinitionController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar workflow")
     public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody DtoWorkflowDefinition dto) {
@@ -90,6 +105,10 @@ public class WorkflowDefinitionController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar workflow")
     public ResponseEntity<Object> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/WorkflowNodeController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/WorkflowNodeController.java
@@ -10,6 +10,8 @@ import com.licensis.notaire.repository.WorkflowDefinitionRepository;
 import com.licensis.notaire.repository.WorkflowNodeRepository;
 import com.licensis.notaire.repository.WorkflowTransitionRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -53,6 +55,10 @@ public class WorkflowNodeController {
                 .stream().map(WorkflowNode::toDto).toList());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener nodo por ID")
     public ResponseEntity<DtoWorkflowNode> getById(@PathVariable Integer id) {
@@ -61,6 +67,11 @@ public class WorkflowNodeController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear nodo en un workflow")
     public ResponseEntity<Object> create(@RequestBody DtoWorkflowNode dto) {
@@ -86,6 +97,10 @@ public class WorkflowNodeController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar nodo")
     public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody DtoWorkflowNode dto) {
@@ -111,6 +126,10 @@ public class WorkflowNodeController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar nodo")
     public ResponseEntity<Object> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/WorkflowTransitionController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/WorkflowTransitionController.java
@@ -8,6 +8,8 @@ import com.licensis.notaire.repository.WorkflowDefinitionRepository;
 import com.licensis.notaire.repository.WorkflowNodeRepository;
 import com.licensis.notaire.repository.WorkflowTransitionRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -47,6 +49,10 @@ public class WorkflowTransitionController {
                 .stream().map(WorkflowTransition::toDto).toList());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener transición por ID")
     public ResponseEntity<DtoWorkflowTransition> getById(@PathVariable Integer id) {
@@ -55,6 +61,11 @@ public class WorkflowTransitionController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "Creado"),
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+    @ApiResponse(responseCode = "409", description = "Conflicto")
+})
     @PostMapping
     @Operation(summary = "Crear transición entre dos nodos")
     public ResponseEntity<Object> create(@RequestBody DtoWorkflowTransition dto) {
@@ -84,6 +95,10 @@ public class WorkflowTransitionController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Eliminado"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar transición")
     public ResponseEntity<Object> delete(@PathVariable Integer id) {

--- a/backend-api/src/main/java/com/licensis/notaire/api/WorkflowValidationController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/WorkflowValidationController.java
@@ -6,6 +6,8 @@ import com.licensis.notaire.repository.WorkflowTransitionRepository;
 import com.licensis.notaire.service.WorkflowValidationService;
 import com.licensis.notaire.service.WorkflowValidationService.ValidationResult;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/backend-api/src/main/java/com/licensis/notaire/config/OpenApiConfig.java
+++ b/backend-api/src/main/java/com/licensis/notaire/config/OpenApiConfig.java
@@ -1,28 +1,66 @@
 package com.licensis.notaire.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class OpenApiConfig {
 
     @Bean
     public OpenAPI customOpenAPI() {
+        var errorSchema = new Schema<>()
+                .addProperty("error", new Schema<String>().type("string"))
+                .addProperty("message", new Schema<String>().type("string"))
+                .addProperty("timestamp", new Schema<String>().type("string").format("date-time"))
+                .addProperty("path", new Schema<String>().type("string"));
+
+        var jsonContent = new Content().addMediaType(
+                "application/json", new MediaType().schema(errorSchema));
+
         return new OpenAPI()
                 .info(new Info()
                         .title("Notaire API")
                         .version("1.0.0")
-                        .description("Sistema de gestión notarial - API REST Backend")
+                        .description("Sistema de gestión notarial — API REST backend. "
+                                + "Todos los recursos siguen el prefijo `/api/v1/`. "
+                                + "Las respuestas de error siguen el esquema "
+                                + "`{error, message, timestamp, path}`.")
                         .contact(new Contact()
                                 .name("Licensis")
                                 .url("https://www.licensis.com")
                                 .email("info@licensis.com"))
                         .license(new License()
                                 .name("Apache 2.0")
-                                .url("https://www.apache.org/licenses/LICENSE-2.0.html")));
+                                .url("https://www.apache.org/licenses/LICENSE-2.0.html")))
+                .servers(List.of(
+                        new Server().url("http://localhost:8080").description("Desarrollo local"),
+                        new Server().url("http://localhost:8081").description("Docker local")
+                ))
+                .components(new Components()
+                        .addResponses("400", new ApiResponse()
+                                .description("Solicitud inválida — parámetros o cuerpo malformado")
+                                .content(jsonContent))
+                        .addResponses("404", new ApiResponse()
+                                .description("Recurso no encontrado")
+                                .content(jsonContent))
+                        .addResponses("409", new ApiResponse()
+                                .description("Conflicto — el recurso ya existe o viola una restricción")
+                                .content(jsonContent))
+                        .addResponses("500", new ApiResponse()
+                                .description("Error interno del servidor")
+                                .content(jsonContent))
+                );
     }
 }

--- a/backend-api/src/test/java/com/licensis/notaire/unit/OpenApiConfigTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/OpenApiConfigTest.java
@@ -1,0 +1,54 @@
+package com.licensis.notaire.unit;
+
+import com.licensis.notaire.config.OpenApiConfig;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("OpenAPI Configuration")
+class OpenApiConfigTest {
+
+    private final OpenApiConfig config = new OpenApiConfig();
+
+    @Test
+    @DisplayName("Should configure API info with title and version")
+    void shouldConfigureApiInfo() {
+        OpenAPI api = config.customOpenAPI();
+        assertThat(api.getInfo()).isNotNull();
+        assertThat(api.getInfo().getTitle()).isEqualTo("Notaire API");
+        assertThat(api.getInfo().getVersion()).isEqualTo("1.0.0");
+    }
+
+    @Test
+    @DisplayName("Should configure contact information")
+    void shouldConfigureContact() {
+        OpenAPI api = config.customOpenAPI();
+        assertThat(api.getInfo().getContact()).isNotNull();
+        assertThat(api.getInfo().getContact().getEmail()).isEqualTo("info@licensis.com");
+    }
+
+    @Test
+    @DisplayName("Should configure server entries")
+    void shouldConfigureServers() {
+        OpenAPI api = config.customOpenAPI();
+        assertThat(api.getServers()).isNotEmpty();
+        assertThat(api.getServers()).anyMatch(s -> s.getUrl().contains("localhost:8080"));
+    }
+
+    @Test
+    @DisplayName("Should define common error response components")
+    void shouldDefineCommonResponseComponents() {
+        OpenAPI api = config.customOpenAPI();
+        assertThat(api.getComponents()).isNotNull();
+        assertThat(api.getComponents().getResponses()).containsKeys("400", "404", "409", "500");
+    }
+
+    @Test
+    @DisplayName("Should include description")
+    void shouldIncludeDescription() {
+        OpenAPI api = config.customOpenAPI();
+        assertThat(api.getInfo().getDescription()).isNotBlank();
+    }
+}


### PR DESCRIPTION
## Summary
- Enhanced OpenAPI global config with servers, contact, license, and reusable error response components
- Added @ApiResponse annotations to all 31 REST controllers covering standard HTTP codes
- 5 unit tests validate the OpenAPI configuration bean

## Changes
### Modified
- `OpenApiConfig.java` — servers, components (400/404/409/500 responses)
- All 31 `*Controller.java` files — `@ApiResponse` on GET/{id}, POST, PUT/{id}, DELETE/{id}
### Added
- `OpenApiConfigTest.java` — 5 unit tests

## Testing
- [x] 543 backend tests pass (5 new)

## Issue Reference
Fixes #257