### PR TITLE
[#246] feat: complete CRUD for PlantillaTramite and WorkflowTransition

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/PlantillaTramiteController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/PlantillaTramiteController.java
@@ -1,13 +1,22 @@
 package com.licensis.notaire.api;
 
 import com.licensis.notaire.negocio.PlantillaTramite;
+import com.licensis.notaire.negocio.PlantillaTramitePK;
 import com.licensis.notaire.repository.PlantillaTramiteRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -32,5 +41,63 @@ public class PlantillaTramiteController {
     @Operation(summary = "Obtener plantillas de tramite por tipo de tramite")
     public ResponseEntity<List<PlantillaTramite>> getByTipoTramite(@PathVariable Integer idTipoTramite) {
         return ResponseEntity.ok(repository.findByTipoDeTramiteIdTipoTramite(idTipoTramite));
+    }
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "404", description = "No encontrado")
+    })
+    @GetMapping("/{idTipoTramite}/{idTipoDocumento}")
+    @Operation(summary = "Obtener plantilla por clave compuesta (CU55)")
+    public ResponseEntity<PlantillaTramite> getById(@PathVariable Integer idTipoTramite,
+            @PathVariable Integer idTipoDocumento) {
+        return repository.findById(new PlantillaTramitePK(idTipoTramite, idTipoDocumento))
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "Creado"),
+        @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+        @ApiResponse(responseCode = "409", description = "Conflicto")
+    })
+    @PostMapping
+    @Operation(summary = "Crear plantilla de tramite (CU55)")
+    public ResponseEntity<PlantillaTramite> create(@RequestBody PlantillaTramite entity) {
+        PlantillaTramite saved = repository.save(entity);
+        return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+    }
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "404", description = "No encontrado")
+    })
+    @PutMapping("/{idTipoTramite}/{idTipoDocumento}")
+    @Operation(summary = "Actualizar plantilla de tramite (CU55)")
+    public ResponseEntity<PlantillaTramite> update(@PathVariable Integer idTipoTramite,
+            @PathVariable Integer idTipoDocumento,
+            @RequestBody PlantillaTramite entity) {
+        PlantillaTramitePK pk = new PlantillaTramitePK(idTipoTramite, idTipoDocumento);
+        if (!repository.existsById(pk)) {
+            return ResponseEntity.notFound().build();
+        }
+        entity.setPlantillaTramitePK(pk);
+        return ResponseEntity.ok(repository.save(entity));
+    }
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "Eliminado"),
+        @ApiResponse(responseCode = "404", description = "No encontrado")
+    })
+    @DeleteMapping("/{idTipoTramite}/{idTipoDocumento}")
+    @Operation(summary = "Eliminar plantilla de tramite (CU55)")
+    public ResponseEntity<Void> delete(@PathVariable Integer idTipoTramite,
+            @PathVariable Integer idTipoDocumento) {
+        PlantillaTramitePK pk = new PlantillaTramitePK(idTipoTramite, idTipoDocumento);
+        if (!repository.existsById(pk)) {
+            return ResponseEntity.notFound().build();
+        }
+        repository.deleteById(pk);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend-api/src/main/java/com/licensis/notaire/api/WorkflowTransitionController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/WorkflowTransitionController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -90,6 +91,36 @@ public class WorkflowTransitionController {
             transition.setDescripcion(dto.getDescripcion());
             transition = repository.save(transition);
             return ResponseEntity.status(HttpStatus.CREATED).body(transition.toDto());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK"),
+    @ApiResponse(responseCode = "404", description = "No encontrado")
+})
+    @PutMapping("/{id}")
+    @Operation(summary = "Actualizar transición")
+    public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody DtoWorkflowTransition dto) {
+        if (!repository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        Optional<WorkflowNode> origen = nodeRepository.findById(dto.getNodoOrigenId());
+        if (origen.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        Optional<WorkflowNode> destino = nodeRepository.findById(dto.getNodoDestinoId());
+        if (destino.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        try {
+            WorkflowTransition transition = repository.findById(id).get();
+            transition.setNodoOrigen(origen.get());
+            transition.setNodoDestino(destino.get());
+            transition.setCondicion(dto.getCondicion());
+            transition.setDescripcion(dto.getDescripcion());
+            return ResponseEntity.ok(repository.save(transition).toDto());
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
         }

--- a/backend-api/src/main/java/com/licensis/notaire/repository/PlantillaTramiteRepository.java
+++ b/backend-api/src/main/java/com/licensis/notaire/repository/PlantillaTramiteRepository.java
@@ -1,6 +1,7 @@
 package com.licensis.notaire.repository;
 
 import com.licensis.notaire.negocio.PlantillaTramite;
+import com.licensis.notaire.negocio.PlantillaTramitePK;
 import com.licensis.notaire.negocio.TipoDeTramite;
 import com.licensis.notaire.negocio.TipoDeDocumento;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,7 +10,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface PlantillaTramiteRepository extends JpaRepository<PlantillaTramite, Integer> {
+public interface PlantillaTramiteRepository extends JpaRepository<PlantillaTramite, PlantillaTramitePK> {
 
     List<PlantillaTramite> findByTipoDeTramite(TipoDeTramite tipoDeTramite);
 

--- a/backend-api/src/test/java/com/licensis/notaire/unit/PlantillaTramiteControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/PlantillaTramiteControllerTest.java
@@ -1,0 +1,142 @@
+package com.licensis.notaire.unit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.licensis.notaire.api.PlantillaTramiteController;
+import com.licensis.notaire.negocio.PlantillaTramite;
+import com.licensis.notaire.negocio.PlantillaTramitePK;
+import com.licensis.notaire.repository.PlantillaTramiteRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PlantillaTramiteController unit tests")
+class PlantillaTramiteControllerTest {
+
+    @Mock
+    private PlantillaTramiteRepository repository;
+
+    private MockMvc mockMvc;
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new PlantillaTramiteController(repository)).build();
+        mapper = new ObjectMapper();
+    }
+
+    private PlantillaTramite buildPlantilla(int idTipoTramite, int idTipoDocumento) {
+        PlantillaTramite pt = new PlantillaTramite(new PlantillaTramitePK(idTipoTramite, idTipoDocumento));
+        pt.setObservaciones("Obs test");
+        return pt;
+    }
+
+    @Test
+    @DisplayName("GET /plantilla-tramite returns list")
+    void shouldReturnAll() throws Exception {
+        when(repository.findAll()).thenReturn(List.of(buildPlantilla(1, 2)));
+        mockMvc.perform(get("/api/v1/plantilla-tramite"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    @DisplayName("GET /plantilla-tramite/tipo-tramite/{id} returns list")
+    void shouldReturnByTipoTramite() throws Exception {
+        when(repository.findByTipoDeTramiteIdTipoTramite(1)).thenReturn(List.of(buildPlantilla(1, 2)));
+        mockMvc.perform(get("/api/v1/plantilla-tramite/tipo-tramite/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    @DisplayName("GET /plantilla-tramite/{idTipoTramite}/{idTipoDocumento} returns 200 when found")
+    void shouldReturnByCompositeId() throws Exception {
+        PlantillaTramitePK pk = new PlantillaTramitePK(1, 2);
+        when(repository.findById(pk)).thenReturn(Optional.of(buildPlantilla(1, 2)));
+        mockMvc.perform(get("/api/v1/plantilla-tramite/1/2"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("GET /plantilla-tramite/{idTipoTramite}/{idTipoDocumento} returns 404 when not found")
+    void shouldReturn404WhenNotFound() throws Exception {
+        PlantillaTramitePK pk = new PlantillaTramitePK(9, 9);
+        when(repository.findById(pk)).thenReturn(Optional.empty());
+        mockMvc.perform(get("/api/v1/plantilla-tramite/9/9"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("POST /plantilla-tramite creates new entry and returns 201")
+    void shouldCreatePlantilla() throws Exception {
+        PlantillaTramite pt = buildPlantilla(1, 2);
+        when(repository.save(any(PlantillaTramite.class))).thenReturn(pt);
+        mockMvc.perform(post("/api/v1/plantilla-tramite")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(pt)))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("PUT /plantilla-tramite/{idTipoTramite}/{idTipoDocumento} returns 200 when exists")
+    void shouldUpdatePlantilla() throws Exception {
+        PlantillaTramitePK pk = new PlantillaTramitePK(1, 2);
+        PlantillaTramite pt = buildPlantilla(1, 2);
+        when(repository.existsById(pk)).thenReturn(true);
+        when(repository.save(any(PlantillaTramite.class))).thenReturn(pt);
+        mockMvc.perform(put("/api/v1/plantilla-tramite/1/2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(pt)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("PUT /plantilla-tramite/{idTipoTramite}/{idTipoDocumento} returns 404 when not exists")
+    void shouldReturn404OnUpdate() throws Exception {
+        PlantillaTramitePK pk = new PlantillaTramitePK(9, 9);
+        when(repository.existsById(pk)).thenReturn(false);
+        mockMvc.perform(put("/api/v1/plantilla-tramite/9/9")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(buildPlantilla(9, 9))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("DELETE /plantilla-tramite/{idTipoTramite}/{idTipoDocumento} returns 204 when exists")
+    void shouldDeletePlantilla() throws Exception {
+        PlantillaTramitePK pk = new PlantillaTramitePK(1, 2);
+        when(repository.existsById(pk)).thenReturn(true);
+        doNothing().when(repository).deleteById(pk);
+        mockMvc.perform(delete("/api/v1/plantilla-tramite/1/2"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("DELETE /plantilla-tramite/{idTipoTramite}/{idTipoDocumento} returns 404 when not exists")
+    void shouldReturn404OnDelete() throws Exception {
+        PlantillaTramitePK pk = new PlantillaTramitePK(9, 9);
+        when(repository.existsById(pk)).thenReturn(false);
+        mockMvc.perform(delete("/api/v1/plantilla-tramite/9/9"))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## Summary
- Added POST/PUT/DELETE to `PlantillaTramiteController` (was read-only)
- Fixed `PlantillaTramiteRepository` generic type from `Integer` to `PlantillaTramitePK` (composite key)
- Added PUT to `WorkflowTransitionController`

## Changes
### Added
- `GET /{idTipoTramite}/{idTipoDocumento}` — get by composite key
- `POST /plantilla-tramite` — create with 201 response
- `PUT /{idTipoTramite}/{idTipoDocumento}` — update by composite key
- `DELETE /{idTipoTramite}/{idTipoDocumento}` — delete by composite key
- `PUT /{id}` on WorkflowTransitionController

### Fixed
- `PlantillaTramiteRepository` now extends `JpaRepository<PlantillaTramite, PlantillaTramitePK>`

## Testing
- [x] 9 unit tests added in `PlantillaTramiteControllerTest`
- [x] 362 unit tests passing

## Issue Reference
Fixes #246