### PR TITLE
[#245] feat(auth): implement JWT token generation and login endpoint

### DIFF
--- a/backend-api/pom.xml
+++ b/backend-api/pom.xml
@@ -65,6 +65,24 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <!-- JWT token generation and validation -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
         <!-- Observability: Micrometer with Prometheus -->
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
@@ -1,5 +1,6 @@
 package com.licensis.notaire.api;
 
+import com.licensis.notaire.config.JwtTokenService;
 import com.licensis.notaire.dto.DtoPersona;
 import com.licensis.notaire.dto.DtoUsuario;
 import com.licensis.notaire.negocio.Usuario;
@@ -30,9 +31,11 @@ public class UsuarioController {
     private static final Logger log = LoggerFactory.getLogger(UsuarioController.class);
 
     private final UsuarioRepository usuarioRepository;
+    private final JwtTokenService jwtTokenService;
 
-    public UsuarioController(UsuarioRepository usuarioRepository) {
+    public UsuarioController(UsuarioRepository usuarioRepository, JwtTokenService jwtTokenService) {
         this.usuarioRepository = usuarioRepository;
+        this.jwtTokenService = jwtTokenService;
     }
 
     record PersonaInfo(Integer idPersona, String nombre, String apellido) {}
@@ -197,6 +200,7 @@ public class UsuarioController {
                             // Create a map response to ensure 'valido' field is included
                             Map<String, Object> response = new HashMap<>();
                             response.put("valido", true);
+                            response.put("token", jwtTokenService.generateToken(usuario.getNombre()));
                             response.put("idUsuario", dtoUsuario.getIdUsuario());
                             response.put("nombre", dtoUsuario.getNombre());
                             response.put("estado", dtoUsuario.isEstado());

--- a/backend-api/src/main/java/com/licensis/notaire/config/JwtAuthenticationFilter.java
+++ b/backend-api/src/main/java/com/licensis/notaire/config/JwtAuthenticationFilter.java
@@ -1,0 +1,39 @@
+package com.licensis.notaire.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenService jwtTokenService;
+
+    public JwtAuthenticationFilter(JwtTokenService jwtTokenService) {
+        this.jwtTokenService = jwtTokenService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            if (jwtTokenService.isValid(token)) {
+                String username = jwtTokenService.extractUsername(token);
+                var auth = new UsernamePasswordAuthenticationToken(username, null, List.of());
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend-api/src/main/java/com/licensis/notaire/config/JwtTokenService.java
+++ b/backend-api/src/main/java/com/licensis/notaire/config/JwtTokenService.java
@@ -1,0 +1,61 @@
+package com.licensis.notaire.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtTokenService {
+
+    @Value("${jwt.secret:notaire-default-secret-key-change-in-production-!!}")
+    private String secretKey;
+
+    @Value("${jwt.expiration-ms:86400000}")
+    private long expirationMs;
+
+    public String generateToken(String username) {
+        SecretKey key = signingKey();
+        return Jwts.builder()
+                .subject(username)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expirationMs))
+                .signWith(key)
+                .compact();
+    }
+
+    public String extractUsername(String token) {
+        return claims(token).getSubject();
+    }
+
+    public boolean isValid(String token) {
+        if (token == null || token.isBlank()) {
+            return false;
+        }
+        try {
+            Claims c = claims(token);
+            return c.getExpiration().after(new Date());
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private Claims claims(String token) {
+        return Jwts.parser()
+                .verifyWith(signingKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    private SecretKey signingKey() {
+        byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+}

--- a/backend-api/src/main/java/com/licensis/notaire/config/SecurityAndCorsConfig.java
+++ b/backend-api/src/main/java/com/licensis/notaire/config/SecurityAndCorsConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,6 +27,12 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @Configuration
 @EnableWebSecurity
 public class SecurityAndCorsConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    public SecurityAndCorsConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
 
     @Value("${cors.allowed-origins:http://localhost:3000,http://localhost:8080}")
     private String[] allowedOrigins;
@@ -84,7 +91,8 @@ public class SecurityAndCorsConfig {
 
     /**
      * Security filter chain for API endpoints.
-     * Permits all for now - authentication will be added in future phases.
+     * JWT filter authenticates requests that carry a valid Bearer token.
+     * Endpoints remain accessible without auth for backward compatibility.
      */
     @Bean
     @Order(2)
@@ -94,7 +102,7 @@ public class SecurityAndCorsConfig {
             .authorizeHttpRequests(auth -> auth
                 .anyRequest().permitAll()
             )
-            .httpBasic(withDefaults())
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .csrf(csrf -> csrf.disable())
             .cors(withDefaults());

--- a/backend-api/src/test/java/com/licensis/notaire/integration/JwtAuthIntegrationTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/JwtAuthIntegrationTest.java
@@ -1,0 +1,89 @@
+package com.licensis.notaire.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test-h2")
+@DisplayName("JWT authentication integration tests")
+class JwtAuthIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    @Test
+    @DisplayName("Login with valid credentials returns JWT token")
+    void shouldLoginAndReturnJwtToken() throws Exception {
+        mockMvc.perform(post("/api/v1/usuarios/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"nombre": "admin", "contrasenia": "admin"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valido").value(true))
+                .andExpect(jsonPath("$.token").isString())
+                .andExpect(jsonPath("$.token").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("Login with wrong password returns valido=false and no token")
+    void shouldRejectLoginWithWrongPassword() throws Exception {
+        mockMvc.perform(post("/api/v1/usuarios/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"nombre": "admin", "contrasenia": "wrongpassword"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valido").value(false));
+    }
+
+    @Test
+    @DisplayName("Login with unknown user returns valido=false")
+    void shouldRejectLoginWithUnknownUser() throws Exception {
+        mockMvc.perform(post("/api/v1/usuarios/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"nombre": "nosuchuser", "contrasenia": "any"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valido").value(false));
+    }
+
+    @Test
+    @DisplayName("Valid Bearer token is accepted in API requests")
+    void shouldAcceptValidBearerTokenInApiRequest() throws Exception {
+        String loginResponse = mockMvc.perform(post("/api/v1/usuarios/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"nombre": "admin", "contrasenia": "admin"}
+                                """))
+                .andReturn().getResponse().getContentAsString();
+
+        String token = com.fasterxml.jackson.databind.json.JsonMapper.builder().build()
+                .readTree(loginResponse).get("token").asText();
+
+        mockMvc.perform(get("/api/v1/usuarios")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+    }
+}

--- a/backend-api/src/test/java/com/licensis/notaire/unit/AdditionalControllersTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/AdditionalControllersTest.java
@@ -186,7 +186,9 @@ class AdditionalControllersTest {
         @DisplayName("All endpoints")
         void all() throws Exception {
             UsuarioRepository repo = mock(UsuarioRepository.class);
-            var mvc = standaloneSetup(new UsuarioController(repo)).build();
+            var jwtSvc = mock(com.licensis.notaire.config.JwtTokenService.class);
+            when(jwtSvc.generateToken(any())).thenReturn("mock-jwt-token");
+            var mvc = standaloneSetup(new UsuarioController(repo, jwtSvc)).build();
             Usuario u = new Usuario(1, "admin", "abc", true, "Escribano");
 
             when(repo.findAll()).thenReturn(List.of(u));

--- a/backend-api/src/test/java/com/licensis/notaire/unit/JwtTokenServiceTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/JwtTokenServiceTest.java
@@ -1,0 +1,77 @@
+package com.licensis.notaire.unit;
+
+import com.licensis.notaire.config.JwtTokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("JwtTokenService unit tests")
+class JwtTokenServiceTest {
+
+    private JwtTokenService jwtTokenService;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenService = new JwtTokenService();
+        ReflectionTestUtils.setField(jwtTokenService, "secretKey",
+                "notaire-test-secret-key-minimum-32-bytes-for-hs256!!");
+        ReflectionTestUtils.setField(jwtTokenService, "expirationMs", 3600000L);
+    }
+
+    @Test
+    @DisplayName("Should generate a non-empty JWT token")
+    void shouldGenerateNonEmptyToken() {
+        String token = jwtTokenService.generateToken("admin");
+        assertThat(token).isNotBlank();
+        assertThat(token.split("\\.")).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("Should extract username from generated token")
+    void shouldExtractUsernameFromToken() {
+        String token = jwtTokenService.generateToken("admin");
+        assertThat(jwtTokenService.extractUsername(token)).isEqualTo("admin");
+    }
+
+    @Test
+    @DisplayName("Should validate a freshly generated token as valid")
+    void shouldValidateFreshToken() {
+        String token = jwtTokenService.generateToken("testuser");
+        assertThat(jwtTokenService.isValid(token)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should reject a garbage string as invalid")
+    void shouldRejectGarbageToken() {
+        assertThat(jwtTokenService.isValid("not.a.jwt")).isFalse();
+        assertThat(jwtTokenService.isValid("")).isFalse();
+        assertThat(jwtTokenService.isValid(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should reject an expired token")
+    void shouldRejectExpiredToken() throws InterruptedException {
+        JwtTokenService expiredService = new JwtTokenService();
+        ReflectionTestUtils.setField(expiredService, "secretKey",
+                "notaire-test-secret-key-minimum-32-bytes-for-hs256!!");
+        ReflectionTestUtils.setField(expiredService, "expirationMs", 1L);
+
+        String token = expiredService.generateToken("admin");
+        Thread.sleep(10);
+        assertThat(expiredService.isValid(token)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should generate different tokens for different users")
+    void shouldGenerateDifferentTokensForDifferentUsers() {
+        String tokenA = jwtTokenService.generateToken("userA");
+        String tokenB = jwtTokenService.generateToken("userB");
+
+        assertThat(tokenA).isNotEqualTo(tokenB);
+        assertThat(jwtTokenService.extractUsername(tokenA)).isEqualTo("userA");
+        assertThat(jwtTokenService.extractUsername(tokenB)).isEqualTo("userB");
+    }
+}

--- a/backend-api/src/test/java/com/licensis/notaire/unit/UsuarioControllerHashTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/UsuarioControllerHashTest.java
@@ -1,6 +1,7 @@
 package com.licensis.notaire.unit;
 
 import com.licensis.notaire.api.UsuarioController;
+import com.licensis.notaire.config.JwtTokenService;
 import com.licensis.notaire.repository.UsuarioRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -14,7 +15,8 @@ class UsuarioControllerHashTest {
 
     @Test
     void shouldGenerateMd5HashForPassword() throws Exception {
-        UsuarioController controller = new UsuarioController(Mockito.mock(UsuarioRepository.class));
+        UsuarioController controller = new UsuarioController(
+                Mockito.mock(UsuarioRepository.class), Mockito.mock(JwtTokenService.class));
         Method method = UsuarioController.class.getDeclaredMethod("encriptaEnMD5", String.class);
         method.setAccessible(true);
 


### PR DESCRIPTION
## Summary
- Adds JWT token generation and validation infrastructure using JJWT 0.12.6
- Login endpoint (`POST /api/v1/usuarios/login`) now returns a `token` field with a signed JWT
- JWT filter authenticates requests with valid `Authorization: Bearer <token>` headers

## Changes
### Added
- `JwtTokenService` — generates/validates HS256 JWT tokens; configurable via `jwt.secret` and `jwt.expiration-ms` properties (24h default)
- `JwtAuthenticationFilter` — reads `Authorization: Bearer <token>` and sets `SecurityContext` when token is valid
- JJWT 0.12.6 dependencies (`jjwt-api`, `jjwt-impl`, `jjwt-jackson`)

### Modified
- `UsuarioController.login` — now includes `token` field in successful login response (backward-compatible)
- `SecurityAndCorsConfig` — JWT filter added to API security filter chain; endpoints remain `permitAll()` for backward compat with Swing client

## Testing
- [x] `JwtTokenServiceTest` — 6 unit tests (generate, extract username, validate, reject invalid, reject expired)
- [x] `JwtAuthIntegrationTest` — 4 integration tests (login returns token, wrong password rejected, unknown user rejected, Bearer token accepted)
- [x] 553 total tests pass, 0 failures

## Notes
- API endpoints remain `permitAll()` — JWT is available but not enforced to preserve backward compatibility with the Swing client
- Secret key is configurable; default is a placeholder — **change via `jwt.secret` in production**

Fixes #245