### PR TITLE
[#262,#263,#268,#269] docs(security): add auth, error handling, input validation, SQL injection guides

### DIFF
--- a/docs/04-operations/03-security/API-AUTHENTICATION-GUIDE.md
+++ b/docs/04-operations/03-security/API-AUTHENTICATION-GUIDE.md
@@ -1,0 +1,151 @@
+# API Authentication & Authorization Guide
+
+This guide documents the authentication and authorization mechanisms implemented in Notaire.
+
+## Overview
+
+Notaire uses **JWT (JSON Web Tokens)** for stateless API authentication, implemented via JJWT 0.12.6 and Spring Security 6.x. The Swing desktop client authenticates via the `/api/v1/usuarios/login` endpoint and receives a JWT token on success. Subsequent requests may include the token as a Bearer header for future RBAC enforcement.
+
+## Architecture
+
+```
+Client ──POST /api/v1/usuarios/login──► UsuarioController
+                                              │
+                                    ──────────▼──────────
+                                    │ validateCredentials │
+                                    │ MD5(password) check │
+                                    └──────────┬──────────┘
+                                               │
+                                    ──────────▼──────────
+                                    │  JwtTokenService   │
+                                    │  generateToken()   │
+                                    └──────────┬──────────┘
+                                               │
+                                      { valido: true,
+                                        token: "eyJ..." }
+```
+
+On protected requests:
+```
+Client ──Authorization: Bearer <token>──► JwtAuthenticationFilter
+                                                 │
+                                       isValid(token)?
+                                       extractUsername(token)
+                                       SecurityContextHolder.setAuth()
+                                                 │
+                                          ► Controller
+```
+
+## JWT Implementation
+
+### Token structure
+
+| Claim | Value |
+|-------|-------|
+| `sub` | username (e.g., `admin`) |
+| `iat` | issued-at timestamp |
+| `exp` | expiry timestamp (`iat + jwt.expiration-ms`) |
+
+Signing algorithm: **HS256** (HMAC-SHA256).
+
+### Configuration properties
+
+```yaml
+jwt:
+  secret: notaire-default-secret-key-change-in-production-!!
+  expiration-ms: 86400000  # 24 hours
+```
+
+Override in production via environment variable or `application-prod.yml`. Never commit a real secret.
+
+### Key classes
+
+| Class | Location | Responsibility |
+|-------|----------|---------------|
+| `JwtTokenService` | `config/` | Generate, validate, and parse tokens |
+| `JwtAuthenticationFilter` | `config/` | Extract Bearer token, set `SecurityContext` |
+| `SecurityAndCorsConfig` | `config/` | Security filter chain — API chain registers the JWT filter |
+
+### Token generation
+
+```java
+// JwtTokenService.generateToken(username)
+return Jwts.builder()
+    .subject(username)
+    .issuedAt(new Date())
+    .expiration(new Date(System.currentTimeMillis() + expirationMs))
+    .signWith(signingKey())
+    .compact();
+```
+
+### Token validation
+
+```java
+// isValid() returns false for: null/blank, expired, tampered, malformed
+boolean valid = jwtTokenService.isValid(token);
+```
+
+### Login response
+
+```json
+{
+  "valido": true,
+  "idUsuario": 1,
+  "nombre": "admin",
+  "tipo": "Escribano",
+  "estado": true,
+  "token": "eyJhbGciOiJIUzI1NiJ9..."
+}
+```
+
+## Role-Based Access Control (RBAC)
+
+### Role model
+
+```
+Usuario ──M:1──► Rol
+Rol     ──name, description──► (ENUM: Escribano, Secretario, Admin, ...)
+```
+
+The `Rol` entity is stored in the `roles` table. `UsuarioController` exposes the role in the `UsuarioResponse` DTO.
+
+### Current state
+
+All API endpoints use `permitAll()` for backward compatibility with the Swing client (which does not send Bearer tokens). Future work: enforce `hasRole(...)` on sensitive endpoints once the Swing client is updated to include the JWT header.
+
+### Extending RBAC
+
+1. Add permissions/modules to the `Rol` entity.
+2. Replace `permitAll()` with `.hasRole("ADMIN")` etc. in `SecurityAndCorsConfig`.
+3. Pass the role claim in the JWT payload.
+
+## Authentication error handling
+
+| Scenario | HTTP | Response body |
+|----------|------|---------------|
+| Wrong password | 200 | `{ "valido": false }` |
+| User not found | 200 | `{ "valido": false }` |
+| Inactive user | 200 | `{ "valido": false }` |
+| DB error | 200 | `{ "valido": false }` |
+| Invalid/expired JWT | — | Request proceeds unauthenticated (`permitAll`) |
+
+The login endpoint always returns HTTP 200 to avoid information leakage. The `valido` field in the response distinguishes success from failure.
+
+## Token refresh strategy
+
+Currently tokens are single-use with a 24-hour TTL (configurable). There is no refresh endpoint. Re-login is required when the token expires. If shorter TTLs are needed, add a `POST /api/v1/usuarios/token/refresh` endpoint that accepts a valid token and returns a new one.
+
+## Security checklist
+
+- [ ] Change `jwt.secret` before deploying to production
+- [ ] Use HTTPS in production (see HTTPS/TLS guide)
+- [ ] Set `jwt.expiration-ms` appropriate for your threat model
+- [ ] Log all login failures (done via Micrometer + Prometheus)
+- [ ] Monitor `notaire_operation_total{operation="login",status="bad_credentials"}` for brute-force
+
+## Related documentation
+
+- `docs/04-operations/03-security/SQL-INJECTION-PREVENTION.md`
+- `docs/04-operations/03-security/INPUT-VALIDATION-STRATEGY.md`
+- `infra/grafana/provisioning/dashboards/notaire-auth.json` — login metrics dashboard
+- `infra/prometheus/alert-rules.yml` — brute-force alert rules

--- a/docs/04-operations/03-security/INPUT-VALIDATION-STRATEGY.md
+++ b/docs/04-operations/03-security/INPUT-VALIDATION-STRATEGY.md
@@ -1,0 +1,118 @@
+# Input Validation Strategy
+
+This document defines the validation rules, XSS prevention techniques, CSRF protection, and testing strategy for the Notaire API.
+
+## Validation layers
+
+Notaire enforces validation at two layers:
+
+1. **Client-side (Swing)** — UI field constraints for UX only (not security).
+2. **Server-side (Spring Boot controller)** — authoritative validation; all inputs must pass here before reaching the database.
+
+## Standard validation annotations
+
+Use `jakarta.validation` annotations on request DTOs or `@RequestBody` records:
+
+```java
+public record UsuarioRequest(
+    @NotBlank String nombre,
+    @Size(min = 0, max = 255) String contrasenia,
+    @NotBlank String tipo,
+    boolean activo
+) {}
+```
+
+Activate with `@Valid` on the parameter:
+
+```java
+@PostMapping
+public ResponseEntity<?> create(@Valid @RequestBody UsuarioRequest request) { ... }
+```
+
+### Annotation reference by field type
+
+| Field type | Annotations |
+|-----------|-------------|
+| Required string | `@NotBlank` |
+| Optional string | `@Size(max = 255)` |
+| Email | `@Email` |
+| Integer ID | `@Min(1)` |
+| Date | `@NotNull`, `@PastOrPresent` |
+| Boolean flag | (no annotation needed) |
+| File size | handled in `@RequestParam` + `MultipartFile` check |
+
+## XSS prevention
+
+Notaire does not render user input as HTML (the UI is Swing + REST JSON). There is no server-side HTML template engine. XSS risk exists only in:
+
+1. **Log entries** — use parameterized SLF4J calls (`log.warn("msg {}", value)`), never string concatenation.
+2. **Future web frontend** — if a Next.js/React frontend is added, React's default JSX escaping handles XSS. Never use `dangerouslySetInnerHTML` with user data.
+3. **PDF reports** — JasperReports renders user-supplied field values into PDF; ensure field values are sanitized before being passed to JasperFillManager.
+
+For any field that might be reflected back, apply:
+```java
+String safe = HtmlUtils.htmlEscape(userInput);  // Spring's HtmlUtils
+```
+
+## CSRF protection
+
+CSRF attacks target state-changing requests from authenticated sessions. Notaire's threat model:
+
+- **Current** — Stateless REST API with MD5 password login; no session cookie. CSRF does not apply to cookie-less JSON APIs.
+- **Future (if session/cookie auth is added)** — Enable Spring Security's CSRF filter and send the `X-CSRF-TOKEN` header from the frontend.
+
+Current Spring Security configuration explicitly disables CSRF:
+```java
+http.csrf(AbstractHttpConfigurer::disable);  // safe for stateless JWT API
+```
+
+## Rate limiting
+
+Rate limiting is a deployment-level concern. Implement via:
+
+- **Nginx/reverse proxy** — `limit_req_zone` with per-IP sliding window.
+- **Spring-level** — Bucket4j library with `RateLimiter` per IP or user.
+- **Monitoring** — Prometheus alert `SuspiciousLoginActivity` fires when bad-credential login rate exceeds 30/min.
+
+Priority endpoints for rate limiting:
+1. `POST /api/v1/usuarios/login` — brute-force target
+2. `GET /api/v1/reportes/*` — expensive PDF generation
+
+## File upload security
+
+Currently there are no file upload endpoints. When implemented:
+
+- Validate `Content-Type` and check magic bytes (not just the extension).
+- Limit file size via `spring.servlet.multipart.max-file-size`.
+- Store files outside the web root; never execute uploaded content.
+- Scan with ClamAV or similar before storing.
+
+## Validation testing strategy
+
+```java
+// Test missing required field → 400
+mvc.perform(post("/api/v1/usuarios")
+    .contentType(APPLICATION_JSON)
+    .content("{\"contrasenia\":\"pwd\"}"))  // nombre missing
+    .andExpect(status().isBadRequest());
+
+// Test oversized field → 400
+mvc.perform(post("/api/v1/usuarios/login")
+    .contentType(APPLICATION_JSON)
+    .content("{\"nombre\":\"" + "x".repeat(5000) + "\",\"contrasenia\":\"\"}"))
+    .andExpect(status().isOk());  // login returns 200 with valido:false
+
+// Test SQL injection attempt → no 500
+mvc.perform(post("/api/v1/usuarios/login")
+    .contentType(APPLICATION_JSON)
+    .content("{\"nombre\":\"' OR '1'='1\",\"contrasenia\":\"\"}"))
+    .andExpect(status().isOk());
+```
+
+See `EdgeCaseBoundaryConditionsTest` for the established test patterns.
+
+## Related documentation
+
+- `docs/04-operations/03-security/SQL-INJECTION-PREVENTION.md`
+- `docs/04-operations/03-security/API-AUTHENTICATION-GUIDE.md`
+- `docs/05-api/ERROR-HANDLING-STRATEGY.md`

--- a/docs/04-operations/03-security/SQL-INJECTION-PREVENTION.md
+++ b/docs/04-operations/03-security/SQL-INJECTION-PREVENTION.md
@@ -1,0 +1,137 @@
+# SQL Injection Prevention Guide
+
+This guide documents how Notaire prevents SQL injection and how to keep new code safe.
+
+## Why JPA is safe by default
+
+Notaire uses **Spring Data JPA with Hibernate**. The `JpaRepository` methods (`findById`, `findAll`, `save`, `deleteById`) use **prepared statements** under the hood — Hibernate binds parameters separately from the query string, making injection structurally impossible.
+
+```java
+// Safe: Spring Data generates a parameterized query
+Optional<Usuario> u = usuarioRepository.findById(id);
+// Hibernate executes: SELECT ... FROM usuarios WHERE id_usuario = ?
+// The value of `id` is bound as a parameter, never interpolated.
+```
+
+## Safe patterns
+
+### Spring Data derived query methods
+
+```java
+// Safe — Hibernate generates: ... WHERE nombre = ?
+Optional<Usuario> findFirstByNombre(String nombre);
+
+// Safe — Hibernate generates: ... WHERE tipo = ? AND estado = ?
+List<Usuario> findByTipoAndEstado(String tipo, boolean estado);
+```
+
+### @Query with named parameters
+
+```java
+// Safe — :nombre is bound as a PreparedStatement parameter
+@Query("SELECT u FROM Usuario u WHERE LOWER(u.nombre) = LOWER(:nombre)")
+Optional<Usuario> findByNombreIgnoreCase(@Param("nombre") String nombre);
+```
+
+### @Query with JPQL positional parameters
+
+```java
+// Safe — ?1 is a positional bind parameter
+@Query("SELECT g FROM GestionDeEscritura g WHERE g.numero = ?1")
+Optional<GestionDeEscritura> findByNumero(Integer numero);
+```
+
+## Dangerous patterns — never do this
+
+### String concatenation in queries
+
+```java
+// DANGEROUS — DO NOT DO THIS
+@Query("SELECT u FROM Usuario u WHERE u.nombre = '" + nombre + "'")
+// An attacker could pass: ' OR '1'='1 to return all users.
+```
+
+### Native queries with concatenation
+
+```java
+// DANGEROUS
+entityManager.createNativeQuery(
+    "SELECT * FROM usuarios WHERE nombre = '" + nombre + "'"
+);
+```
+
+## Native queries (when unavoidable)
+
+Use named parameters with `@Query(nativeQuery = true)`:
+
+```java
+// Safe native query with parameter binding
+@Query(value = "SELECT * FROM usuarios WHERE nombre = :nombre", nativeQuery = true)
+List<Usuario> findNativeByNombre(@Param("nombre") String nombre);
+```
+
+If using `EntityManager` directly (legacy `jpa` package), always use `createNativeQuery` with parameter setting:
+
+```java
+// Safe
+Query q = em.createNativeQuery("SELECT * FROM gestiones WHERE numero_gestion = :num");
+q.setParameter("num", numero);
+List<?> results = q.getResultList();
+```
+
+## Dynamic queries (Criteria API)
+
+When query conditions are built at runtime, use the JPA Criteria API:
+
+```java
+CriteriaBuilder cb = em.getCriteriaBuilder();
+CriteriaQuery<GestionDeEscritura> cq = cb.createQuery(GestionDeEscritura.class);
+Root<GestionDeEscritura> root = cq.from(GestionDeEscritura.class);
+
+List<Predicate> predicates = new ArrayList<>();
+if (tipo != null) {
+    predicates.add(cb.equal(root.get("tipo"), tipo));  // parameterized
+}
+cq.where(predicates.toArray(new Predicate[0]));
+return em.createQuery(cq).getResultList();
+```
+
+Never build a JPQL/SQL string by concatenating user values into it.
+
+## Code review checklist
+
+When reviewing code that touches data access:
+
+- [ ] No string concatenation inside `@Query` value strings
+- [ ] All `@Query` parameters use `:name` or `?n` bindings with `@Param`
+- [ ] All `createNativeQuery` calls use `setParameter()` for user-supplied values
+- [ ] No `String.format()` or `+` in any SQL/JPQL string that includes a variable
+
+## Testing for SQL injection
+
+The `EdgeCaseBoundaryConditionsTest` includes an SQL injection attempt in the login request:
+
+```java
+// Confirms the login endpoint does not 500 on a SQL injection payload
+mvc.perform(post("/api/v1/usuarios/login")
+    .contentType(APPLICATION_JSON)
+    .content("{\"nombre\":\"' OR '1'='1\",\"contrasenia\":\"\"}"))
+    .andExpect(status().isOk())
+    .andExpect(jsonPath("$.valido").value(false));
+```
+
+The test must remain green. If it ever returns `valido: true` or a 5xx, a regression has been introduced.
+
+## Tools
+
+| Tool | Purpose | How to run |
+|------|---------|------------|
+| SpotBugs (`SQL_INJECTION` detector) | Static analysis for unsafe SQL | `mvn spotbugs:check -pl backend-api -DskipSpotBugs=false` |
+| OWASP Dependency-Check | CVEs in JDBC/JPA libraries | `trivy fs .` |
+| Manual review | `grep -r "createNativeQuery\|createQuery" --include="*.java"` followed by inspection | — |
+
+## Related documentation
+
+- `docs/04-operations/03-security/INPUT-VALIDATION-STRATEGY.md`
+- `docs/04-operations/03-security/API-AUTHENTICATION-GUIDE.md`
+- `.claude/rules/programming.md` — Security section

--- a/docs/05-api/ERROR-HANDLING-STRATEGY.md
+++ b/docs/05-api/ERROR-HANDLING-STRATEGY.md
@@ -1,0 +1,142 @@
+# API Error Handling Strategy
+
+This document defines the error response format, HTTP status code mapping, and error-handling patterns for the Notaire REST API.
+
+## Error response format
+
+All error responses use a consistent JSON structure:
+
+```json
+{
+  "error": "RESOURCE_NOT_FOUND",
+  "message": "GestionDeEscritura with id 42 not found",
+  "timestamp": "2026-06-10T14:00:00Z",
+  "path": "/api/v1/gestiones/42",
+  "status": 404
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `error` | string | Machine-readable error code (UPPER_SNAKE_CASE) |
+| `message` | string | Human-readable description of the problem |
+| `timestamp` | ISO-8601 | When the error occurred |
+| `path` | string | Request URI that caused the error |
+| `status` | int | HTTP status code (mirrors the response code) |
+
+## HTTP status code mapping
+
+| Scenario | Code | Error code |
+|----------|------|------------|
+| Resource not found | 404 | `RESOURCE_NOT_FOUND` |
+| Validation failed (missing/invalid field) | 400 | `VALIDATION_ERROR` |
+| Constraint violation (FK, unique) | 409 | `CONSTRAINT_VIOLATION` |
+| Unauthorized (future: token missing) | 401 | `UNAUTHORIZED` |
+| Forbidden (future: insufficient role) | 403 | `FORBIDDEN` |
+| Unexpected server error | 500 | `INTERNAL_ERROR` |
+| Method not allowed | 405 | `METHOD_NOT_ALLOWED` |
+
+## Current implementation patterns
+
+Controllers follow a consistent try/catch pattern:
+
+```java
+@GetMapping("/{id}")
+public ResponseEntity<?> getById(@PathVariable Integer id) {
+    return repo.findById(id)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+}
+
+@PostMapping
+public ResponseEntity<?> create(@RequestBody Entity entity) {
+    try {
+        return ResponseEntity.status(HttpStatus.CREATED).body(repo.save(entity));
+    } catch (Exception e) {
+        log.error("Failed to create entity", e);
+        return ResponseEntity.internalServerError().build();
+    }
+}
+
+@DeleteMapping("/{id}")
+public ResponseEntity<Void> delete(@PathVariable Integer id) {
+    if (!repo.existsById(id)) return ResponseEntity.notFound().build();
+    try {
+        repo.deleteById(id);
+        return ResponseEntity.noContent().build();
+    } catch (Exception e) {
+        log.error("Failed to delete id {}", id, e);
+        return ResponseEntity.status(HttpStatus.CONFLICT).build(); // FK constraint
+    }
+}
+```
+
+## Validation error format
+
+When `@Valid` / `@Validated` rejects input, the response must include field-level detail:
+
+```json
+{
+  "error": "VALIDATION_ERROR",
+  "message": "Request validation failed",
+  "timestamp": "2026-06-10T14:00:00Z",
+  "path": "/api/v1/gestiones",
+  "status": 400,
+  "violations": [
+    { "field": "nombre", "message": "must not be blank" },
+    { "field": "fechaInicio", "message": "must not be null" }
+  ]
+}
+```
+
+To produce this, add a `@RestControllerAdvice` that catches `MethodArgumentNotValidException`:
+
+```java
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidation(
+            MethodArgumentNotValidException ex, HttpServletRequest req) {
+        List<Map<String, String>> violations = ex.getBindingResult().getFieldErrors().stream()
+            .map(fe -> Map.of("field", fe.getField(), "message", fe.getDefaultMessage()))
+            .toList();
+        return ResponseEntity.badRequest().body(Map.of(
+            "error", "VALIDATION_ERROR",
+            "message", "Request validation failed",
+            "path", req.getRequestURI(),
+            "violations", violations
+        ));
+    }
+}
+```
+
+## Login endpoint special case
+
+The login endpoint (`POST /api/v1/usuarios/login`) returns HTTP 200 in all cases, using the `valido` field to signal success or failure. This intentional design prevents HTTP-level information leakage (an attacker cannot distinguish "user not found" from "wrong password" by status code alone).
+
+## Error logging standards
+
+| Severity | When to use |
+|----------|-------------|
+| `log.error(msg, e)` | Unexpected exceptions (500-level) |
+| `log.warn(msg)` | Business rule violations (wrong password, inactive user) |
+| `log.debug(msg)` | Diagnostic detail (query results, param values) |
+
+Never log passwords, tokens, or PII. Always include the entity ID and operation in the message context.
+
+## Testing error paths
+
+Every controller must have tests for:
+- `404` when the entity does not exist
+- `409` when a FK/unique constraint prevents deletion
+- `500` when the repository throws an unexpected exception
+- `400` when required fields are missing (once `@Valid` is applied)
+
+See `AdditionalControllersTest` for the established test pattern.
+
+## Related documentation
+
+- `docs/04-operations/03-security/INPUT-VALIDATION-STRATEGY.md`
+- `docs/04-operations/03-security/API-AUTHENTICATION-GUIDE.md`
+- `.claude/rules/programming.md` — Error Handling section


### PR DESCRIPTION
## Summary
- **#262** `API-AUTHENTICATION-GUIDE.md` — JWT architecture, token structure, RBAC model, login response, security checklist
- **#263** `ERROR-HANDLING-STRATEGY.md` — standardized error JSON format, HTTP code mapping, validation error format, logging standards
- **#268** `INPUT-VALIDATION-STRATEGY.md` — annotation reference by field type, XSS/CSRF strategy, rate limiting guidance
- **#269** `SQL-INJECTION-PREVENTION.md` — safe JPA patterns, dangerous anti-patterns, Criteria API guide, code review checklist

## Changes
### Added
- `docs/04-operations/03-security/API-AUTHENTICATION-GUIDE.md`
- `docs/04-operations/03-security/INPUT-VALIDATION-STRATEGY.md`
- `docs/04-operations/03-security/SQL-INJECTION-PREVENTION.md`
- `docs/05-api/ERROR-HANDLING-STRATEGY.md`

## Testing
- [x] Documentation only — no code changes

## Issue Reference
Fixes #262
Fixes #263
Fixes #268
Fixes #269