### PR TITLE
[#497] fix: test coverage report CI pipeline

### DIFF
--- a/.github/workflows/test-coverage-report.yml
+++ b/.github/workflows/test-coverage-report.yml
@@ -8,43 +8,56 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
-    
     steps:
       - uses: actions/checkout@v6
-      
+
       - uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
-      
+
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: npm
           cache-dependency-path: frontend/package-lock.json
-      
+
       - name: Run test coverage script
         run: bash scripts/generate-coverage-report.sh
-      
+
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v6
         with:
           name: coverage-reports
           path: coverage-reports/
           retention-days: 30
-      
-      - name: Deploy coverage to GitHub Pages
+
+      - name: Prepare Pages artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v4
+        run: |
+          mkdir -p pages-artifact/coverage
+          cp -r coverage-reports/* pages-artifact/coverage/
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./coverage-reports
-          destination_dir: coverage
-      
+          path: ./pages-artifact
+
       - name: Comment PR with coverage summary
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v8
@@ -57,9 +70,21 @@ jobs:
               repo: context.repo.repo,
               body: '## 📊 Test Coverage Report\n\n- **Backend Coverage**: 75% instructions / 60% branches (JaCoCo)\n- **Frontend Coverage**: TBD (Jest)\n- **E2E Coverage**: TBD (Playwright)\n- **API Tests**: 50+ endpoints (Bruno)\n- **Total Unit/Integration Tests**: 611+\n\n[View Full Report](https://matiaspakua.github.io/notaire/coverage/)'
             })
-      
+
       - name: Publish coverage metrics
         run: |
           echo "Backend Coverage: 75% instructions, 60% branches (611+ tests passing)"
           echo "Frontend Coverage: Pending"
           echo "E2E Coverage: Pending"
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: coverage
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy coverage to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/scripts/generate-coverage-report.sh
+++ b/scripts/generate-coverage-report.sh
@@ -12,6 +12,8 @@ TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
 
 # Backend Coverage (JaCoCo)
 echo "1️⃣ Backend Unit & Integration Tests (JaCoCo)..."
+echo "   Installing shared module dependency..."
+mvn install -pl notaire-shared -q 2>/dev/null || true
 cd backend-api
 mvn clean test jacoco:report -q 2>/dev/null || true
 cd ..


### PR DESCRIPTION
## Summary
Fixes two failures in the Test Coverage Report CI workflow:

### 1. Maven dependency resolution
`scripts/generate-coverage-report.sh` ran `mvn clean test` in `backend-api/` without first installing the `notaire-shared` dependency, causing:
```
Could not find artifact com.licensis:notaire-shared:jar:1.0-SNAPSHOT
```

**Fix**: Added `mvn install -pl notaire-shared -q 2>/dev/null || true` before the backend-api test run.

### 2. GitHub Pages deploy (403 permission denied)
`peaceiris/actions-gh-pages@v4` with `GITHUB_TOKEN` failed with:
```
Permission to matiaspakua/notaire.git denied to github-actions[bot].
```

**Fix**: Replaced with the `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4` pattern, which is already proven in the `deploy-github-page.yml` workflow. Added proper `permissions:` block with `pages: write` and `id-token: write`.

## Testing
- [ ] CI workflow will run on this PR to validate fixes

## Checklist
- [x] No dead code
- [x] KIS and SRP applied
- [x] Existing test coverage scripts preserved

Closes #497