### PR TITLE
[#503] fix(testimonio): resolve 500 errors in GET endpoints and NPE in toString

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/TestimonioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TestimonioController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,6 +28,7 @@ public class TestimonioController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los testimonio")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DtoTestimonio>> getAll() {
         List<DtoTestimonio> result = repository.findAll().stream()
                 .map(Testimonio::getDto)
@@ -40,6 +42,7 @@ public class TestimonioController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener testimonio por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<DtoTestimonio> getById(@PathVariable Integer id) {
         return repository.findById(id)
                 .map(e -> ResponseEntity.ok(e.getDto()))

--- a/backend-api/src/main/java/com/licensis/notaire/negocio/Testimonio.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/Testimonio.java
@@ -258,9 +258,10 @@ public class Testimonio implements Serializable
     @Override
     public String toString()
     {
+        String escrituraId = fkIdEscritura != null ? String.valueOf(fkIdEscritura.getIdEscritura()) : "null";
         return "Testimonio[ idTestimonio=" + idTestimonio + " ]"
                 + "[ numero=" + numero + " ]"
-                + "[ idEscritura=" + fkIdEscritura.getIdEscritura() + " ]";
+                + "[ idEscritura=" + escrituraId + " ]";
     }
 
     public int getVersion()

--- a/backend-api/src/test/java/com/licensis/notaire/integration/TestimonioControllerIntegrationTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/TestimonioControllerIntegrationTest.java
@@ -1,0 +1,232 @@
+package com.licensis.notaire.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.licensis.notaire.testing.RequirementCoverage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test-h2")
+@RequirementCoverage({"CU07", "CU08", "CU12", "CU44"})
+@DisplayName("TestimonioController — CU07/CU08 CRUD integration tests")
+class TestimonioControllerIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    private int createEscritura() throws Exception {
+        String escrituraBody = """
+                {
+                  "numero": 3001,
+                  "cuerpo": "Escritura de prueba para testimonio",
+                  "estado": "BORRADOR",
+                  "fechaEscrituracion": "2026-06-16"
+                }
+                """;
+        MvcResult result = mockMvc.perform(post("/api/v1/escrituras")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(escrituraBody))
+                .andExpect(status().isCreated())
+                .andReturn();
+        JsonNode node = mapper.readTree(result.getResponse().getContentAsString());
+        return node.get("idEscritura").asInt();
+    }
+
+    // DtoEscritura.numero is primitive int — must be included in nested object to avoid 400
+    private String testimonioBody(int numero, boolean observado, int escrituraId) {
+        return """
+                {
+                  "numero": %d,
+                  "observado": %s,
+                  "escritura": {"idEscritura": %d, "numero": 0}
+                }
+                """.formatted(numero, observado, escrituraId);
+    }
+
+    @Test
+    @DisplayName("CU07 - Should return 200 and empty array when no testimonios exist")
+    void shouldReturnEmptyListWhenNoTestimonios() throws Exception {
+        mockMvc.perform(get("/api/v1/testimonio"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    @DisplayName("CU07 - Should return 404 for non-existing testimonio")
+    void shouldReturn404ForNonExistingTestimonio() throws Exception {
+        mockMvc.perform(get("/api/v1/testimonio/99999"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("CU07 - Should create testimonio linked to escritura and return 201")
+    void shouldCreateTestimonioLinkedToEscritura() throws Exception {
+        int escrituraId = createEscritura();
+
+        String body = """
+                {
+                  "numero": 1001,
+                  "observado": false,
+                  "observaciones": "Testimonio de prueba",
+                  "escritura": {"idEscritura": %d, "numero": 0}
+                }
+                """.formatted(escrituraId);
+
+        MvcResult result = mockMvc.perform(post("/api/v1/testimonio")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.idTestimonio").isNumber())
+                .andExpect(jsonPath("$.numero").value(1001))
+                .andExpect(jsonPath("$.observado").value(false))
+                .andReturn();
+
+        JsonNode response = mapper.readTree(result.getResponse().getContentAsString());
+        assertThat(response.get("idTestimonio").asInt()).isPositive();
+    }
+
+    @Test
+    @DisplayName("CU07 - Should retrieve created testimonio by ID")
+    void shouldRetrieveTestimonioById() throws Exception {
+        int escrituraId = createEscritura();
+
+        String body = """
+                {
+                  "numero": 1002,
+                  "observado": false,
+                  "escritura": {"idEscritura": %d, "numero": 0}
+                }
+                """.formatted(escrituraId);
+
+        MvcResult created = mockMvc.perform(post("/api/v1/testimonio")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        int id = mapper.readTree(created.getResponse().getContentAsString()).get("idTestimonio").asInt();
+
+        mockMvc.perform(get("/api/v1/testimonio/" + id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.idTestimonio").value(id))
+                .andExpect(jsonPath("$.numero").value(1002));
+    }
+
+    @Test
+    @DisplayName("CU08 - Should verify (mark as observado) an existing testimonio")
+    void shouldMarkTestimonioAsObservado() throws Exception {
+        int escrituraId = createEscritura();
+
+        String createBody = """
+                {
+                  "numero": 1003,
+                  "observado": false,
+                  "escritura": {"idEscritura": %d, "numero": 0}
+                }
+                """.formatted(escrituraId);
+
+        MvcResult created = mockMvc.perform(post("/api/v1/testimonio")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createBody))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        JsonNode createdNode = mapper.readTree(created.getResponse().getContentAsString());
+        int id = createdNode.get("idTestimonio").asInt();
+        int version = createdNode.get("version").asInt();
+
+        String updateBody = """
+                {
+                  "idTestimonio": %d,
+                  "numero": 1003,
+                  "observado": true,
+                  "observaciones": "Verificado por escribano",
+                  "version": %d,
+                  "escritura": {"idEscritura": %d, "numero": 0}
+                }
+                """.formatted(id, version, escrituraId);
+
+        mockMvc.perform(put("/api/v1/testimonio/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateBody))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/testimonio/" + id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.observado").value(true))
+                .andExpect(jsonPath("$.observaciones").value("Verificado por escribano"));
+    }
+
+    @Test
+    @DisplayName("CU12 - Should delete an existing testimonio")
+    void shouldDeleteExistingTestimonio() throws Exception {
+        int escrituraId = createEscritura();
+
+        String body = """
+                {
+                  "numero": 1004,
+                  "observado": false,
+                  "escritura": {"idEscritura": %d, "numero": 0}
+                }
+                """.formatted(escrituraId);
+
+        MvcResult created = mockMvc.perform(post("/api/v1/testimonio")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        int id = mapper.readTree(created.getResponse().getContentAsString()).get("idTestimonio").asInt();
+
+        mockMvc.perform(delete("/api/v1/testimonio/" + id))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/testimonio/" + id))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("CU07 - Should return 404 when updating non-existing testimonio")
+    void shouldReturn404WhenUpdatingNonExistingTestimonio() throws Exception {
+        String body = """
+                {"numero": 9999, "observado": false}
+                """;
+        mockMvc.perform(put("/api/v1/testimonio/99999")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("CU07 - Should return 404 when deleting non-existing testimonio")
+    void shouldReturn404WhenDeletingNonExistingTestimonio() throws Exception {
+        mockMvc.perform(delete("/api/v1/testimonio/99999"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/backend-api/src/test/java/com/licensis/notaire/unit/TestimonioEntityTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/TestimonioEntityTest.java
@@ -178,5 +178,13 @@ class TestimonioEntityTest {
             assertThat(testimonio.toString()).contains("33");
             assertThat(testimonio.toString()).contains("101");
         }
+
+        @Test
+        @DisplayName("toString should not throw when escritura is null")
+        void toStringShouldNotThrowWhenEscrituraIsNull() {
+            Testimonio testimonio = new Testimonio(7, 200, false);
+
+            assertThat(testimonio.toString()).contains("7").contains("200").contains("null");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fixed `LazyInitializationException` (500) on GET /api/v1/testimonio and GET /api/v1/testimonio/{id}
- Fixed NPE in `Testimonio.toString()` when `fkIdEscritura` is null
- Added integration tests covering CU07/CU08/CU12 CRUD flows (8 tests)

## Changes
### Fixed
- `TestimonioController.getAll()` — added `@Transactional(readOnly = true)` to keep Hibernate session open while mapping lazy `movimientoTestimonioList` to DTO
- `TestimonioController.getById()` — same fix
- `Testimonio.toString()` — null guard for `fkIdEscritura` prevents NPE

### Added
- `TestimonioControllerIntegrationTest` — 8 integration tests (H2, CU07/CU08/CU12/CU44)
- `TestimonioEntityTest#toStringShouldNotThrowWhenEscrituraIsNull` — regression test

## Root Cause
`spring.jpa.open-in-view=false` closes the Hibernate session after `repository.findAll()` returns. The lazy `movimientoTestimonioList` is accessed in the subsequent `.stream().map(Testimonio::getDto)` call outside any transaction, causing `LazyInitializationException` → HTTP 500.

## Testing
- [x] Unit tests pass (24 total)
- [x] Integration tests pass (8 new tests, 0 failures)
- [x] All tests: `mvn test -pl backend-api -Dtest="TestimonioEntityTest,TestimonioControllerIntegrationTest"`

## Use Case Reference
CU07 - Registrar Testimonio, CU08 - Verificar Testimonio, CU12 - Eliminar Testimonio

Fixes #503