### PR TITLE
[#505] fix(api): add @Transactional(readOnly=true) to GET methods in 24 controllers

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/ConceptoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/ConceptoController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,7 @@ public class ConceptoController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los conceptos")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DtoConcepto>> getAllConceptos() {
         List<DtoConcepto> result = repository.findAll().stream()
                 .map(Concepto::getDto)
@@ -49,6 +51,7 @@ public class ConceptoController {
 
     @GetMapping("/search")
     @Operation(summary = "Buscar conceptos por nombre")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DtoConcepto>> searchConceptos(@RequestParam String nombre) {
         List<DtoConcepto> result = repository.findByNombreContaining(nombre).stream()
                 .map(Concepto::getDto)
@@ -58,6 +61,7 @@ public class ConceptoController {
 
     @GetMapping("/{id}/in-use")
     @Operation(summary = "Verificar si un concepto está en uso")
+    @Transactional(readOnly = true)
     public ResponseEntity<Map<String, Boolean>> isConceptoInUse(@PathVariable Integer id) {
         if (!repository.existsById(id)) {
             return ResponseEntity.notFound().build();
@@ -72,6 +76,7 @@ public class ConceptoController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener concepto por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<DtoConcepto> getConceptoById(@PathVariable Integer id) {
         return repository.findById(id)
                 .map(e -> ResponseEntity.ok(e.getDto()))

--- a/backend-api/src/main/java/com/licensis/notaire/api/CopiaController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/CopiaController.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -29,6 +30,7 @@ public class CopiaController {
 
     @GetMapping
     @Operation(summary = "Obtener todas las copias")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<Copia>> getAll() {
         return ResponseEntity.ok(repository.findAll());
     }
@@ -39,6 +41,7 @@ public class CopiaController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener copia por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<Copia> getById(@PathVariable Integer id) {
         return repository.findById(id)
                 .map(ResponseEntity::ok)

--- a/backend-api/src/main/java/com/licensis/notaire/api/DocumentoPresentadoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/DocumentoPresentadoController.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -77,6 +78,7 @@ public class DocumentoPresentadoController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los documentos presentados")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DocumentoPresentadoResponse>> getAll() {
         return ResponseEntity.ok(repository.findAll().stream().map(this::toResponse).toList());
     }
@@ -87,6 +89,7 @@ public class DocumentoPresentadoController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener documento presentado por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<DocumentoPresentadoResponse> getById(@PathVariable Integer id) {
         return repository.findById(id)
                 .map(this::toResponse)

--- a/backend-api/src/main/java/com/licensis/notaire/api/EstadoDeGestionController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/EstadoDeGestionController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,7 @@ public class EstadoDeGestionController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los estados de gestion")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DtoEstadoDeGestion>> getAll() {
         List<DtoEstadoDeGestion> result = repository.findAll().stream()
                 .map(EstadoDeGestion::getDto)
@@ -53,6 +55,7 @@ public class EstadoDeGestionController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener estado de gestion por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<DtoEstadoDeGestion> getById(@PathVariable Integer id) {
         return repository.findById(id)
                 .map(e -> ResponseEntity.ok(e.getDto()))
@@ -61,6 +64,7 @@ public class EstadoDeGestionController {
 
     @GetMapping("/search")
     @Operation(summary = "Buscar estados de gestion por nombre")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DtoEstadoDeGestion>> search(@RequestParam String nombre) {
         List<DtoEstadoDeGestion> result = repository.findByNombreContaining(nombre).stream()
                 .map(EstadoDeGestion::getDto)
@@ -70,6 +74,7 @@ public class EstadoDeGestionController {
 
     @GetMapping("/{id}/in-use")
     @Operation(summary = "Verificar si el estado esta referenciado")
+    @Transactional(readOnly = true)
     public ResponseEntity<Map<String, Boolean>> isInUse(@PathVariable Integer id) {
         if (!repository.existsById(id)) {
             return ResponseEntity.notFound().build();

--- a/backend-api/src/main/java/com/licensis/notaire/api/GestionController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/GestionController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.transaction.annotation.Transactional;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -50,6 +51,7 @@ public class GestionController {
 
     @GetMapping
     @Operation(summary = "Obtener todas las gestiones")
+    @Transactional(readOnly = true)
     public ResponseEntity<Page<DtoGestionSummary>> getAll(
             @PageableDefault(size = 20) Pageable pageable) {
         return ResponseEntity.ok(gestionQueryService.findAll(pageable));
@@ -61,6 +63,7 @@ public class GestionController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener gestion por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<DtoGestionSummary> getById(@PathVariable Integer id) {
         return gestionQueryService.findById(id)
                 .map(ResponseEntity::ok)
@@ -69,6 +72,7 @@ public class GestionController {
 
     @GetMapping("/numero/{numero}")
     @Operation(summary = "Obtener gestion por numero")
+    @Transactional(readOnly = true)
     public ResponseEntity<DtoGestionSummary> getByNumero(@PathVariable Integer numero) {
         return gestionQueryService.findByNumero(numero)
                 .map(ResponseEntity::ok)
@@ -77,12 +81,14 @@ public class GestionController {
 
     @GetMapping("/cliente/{idPersona}")
     @Operation(summary = "Obtener gestiones de un cliente (CU19)")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<GestionDeEscritura>> getByCliente(@PathVariable Integer idPersona) {
         return ResponseEntity.ok(List.of());
     }
 
     @GetMapping("/{id}/estado-actual")
     @Operation(summary = "Obtener estado actual de una gestion")
+    @Transactional(readOnly = true)
     public ResponseEntity<DtoHistorialSummary> getEstadoActual(@PathVariable Integer id) {
         List<Historial> historiales = historialRepository.findByFkIdGestionIdGestion(id);
         if (historiales.isEmpty()) {
@@ -157,6 +163,7 @@ public class GestionController {
     })
     @GetMapping("/{id}/workflow-trace")
     @Operation(summary = "Obtener trace del workflow de una gestion (con nodos, transiciones, historial y estados)")
+    @Transactional(readOnly = true)
     public ResponseEntity<Object> getWorkflowTrace(@PathVariable Integer id) {
         try {
             DtoGestionWorkflowTrace trace = workflowTraceService.buildTrace(id);

--- a/backend-api/src/main/java/com/licensis/notaire/api/HistorialController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/HistorialController.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -30,6 +31,7 @@ public class HistorialController {
 
     @GetMapping
     @Operation(summary = "Obtener todo el historial")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DtoHistorialSummary>> getAll() {
         return ResponseEntity.ok(repository.findAll().stream()
                 .map(DtoHistorialSummary::from)
@@ -42,6 +44,7 @@ public class HistorialController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener historial por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<DtoHistorialSummary> getById(@PathVariable Integer id) {
         return repository.findById(id)
                 .map(h -> ResponseEntity.ok(DtoHistorialSummary.from(h)))
@@ -50,6 +53,7 @@ public class HistorialController {
 
     @GetMapping("/gestion/{idGestion}")
     @Operation(summary = "Obtener historial de una gestion (CU13)")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DtoHistorialSummary>> getByGestion(@PathVariable Integer idGestion) {
         return ResponseEntity.ok(repository.findByFkIdGestionIdGestion(idGestion).stream()
                 .map(DtoHistorialSummary::from)

--- a/backend-api/src/main/java/com/licensis/notaire/api/InmuebleController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/InmuebleController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @RestController
@@ -24,6 +25,7 @@ public class InmuebleController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los inmueble")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<Inmueble>> getAll() {
         try {
             return ResponseEntity.ok(getJpaController().findInmuebleEntities());
@@ -38,6 +40,7 @@ public class InmuebleController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener inmueble por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<Inmueble> getById(@PathVariable Integer id) {
         try {
             return ResponseEntity.ok(getJpaController().findInmueble(id));

--- a/backend-api/src/main/java/com/licensis/notaire/api/ItemController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/ItemController.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -29,6 +30,7 @@ public class ItemController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los ítems")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<Item>> getAll() {
         return ResponseEntity.ok(repository.findAll());
     }
@@ -39,6 +41,7 @@ public class ItemController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener ítem por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<Item> getById(@PathVariable Integer id) {
         return repository.findById(id)
                 .map(ResponseEntity::ok)
@@ -47,6 +50,7 @@ public class ItemController {
 
     @GetMapping("/presupuesto/{idPresupuesto}")
     @Operation(summary = "Obtener ítems por presupuesto")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<Item>> getByPresupuesto(@PathVariable Integer idPresupuesto) {
         return ResponseEntity.ok(repository.findByFkIdPresupuestoIdPresupuesto(idPresupuesto));
     }

--- a/backend-api/src/main/java/com/licensis/notaire/api/MovimientoTestimonioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/MovimientoTestimonioController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +28,7 @@ public class MovimientoTestimonioController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los movimiento-testimonio")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DtoMovimientoTestimonio>> getAll() {
         List<DtoMovimientoTestimonio> result = repository.findAll().stream()
                 .map(MovimientoTestimonio::getDto)
@@ -40,6 +42,7 @@ public class MovimientoTestimonioController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener movimiento-testimonio por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<DtoMovimientoTestimonio> getById(@PathVariable Integer id) {
         return repository.findById(id)
                 .map(e -> ResponseEntity.ok(e.getDto()))

--- a/backend-api/src/main/java/com/licensis/notaire/api/PagoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/PagoController.java
@@ -13,6 +13,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
 import java.util.List;
@@ -32,6 +33,7 @@ public class PagoController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los pagos")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<Pago>> getAll() {
         try {
             return ResponseEntity.ok(pagoService.findAll());
@@ -47,6 +49,7 @@ public class PagoController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "CU47 - Consultar pago por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<Pago> getById(@PathVariable Integer id) {
         try {
             return pagoService.consultarPago(id)
@@ -60,6 +63,7 @@ public class PagoController {
 
     @GetMapping("/presupuesto/{idPresupuesto}")
     @Operation(summary = "Obtener pagos por presupuesto")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<Pago>> getByPresupuesto(@PathVariable Integer idPresupuesto) {
         try {
             return ResponseEntity.ok(pagoService.findPagosByPresupuesto(idPresupuesto));
@@ -71,6 +75,7 @@ public class PagoController {
 
     @GetMapping("/presupuesto/{idPresupuesto}/saldo")
     @Operation(summary = "Calcular saldo pendiente de un presupuesto")
+    @Transactional(readOnly = true)
     public ResponseEntity<Float> getSaldoPendiente(@PathVariable Integer idPresupuesto) {
         try {
             Float saldo = pagoService.calcularSaldoPendiente(idPresupuesto);
@@ -85,6 +90,7 @@ public class PagoController {
 
     @GetMapping("/fecha")
     @Operation(summary = "Obtener pagos por rango de fechas")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<Pago>> getByFechaRange(
             @Parameter(description = "Fecha inicio (YYYY-MM-DD)")
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") Date startDate,

--- a/backend-api/src/main/java/com/licensis/notaire/api/PlantillaPresupuestoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/PlantillaPresupuestoController.java
@@ -14,6 +14,7 @@ import jakarta.persistence.OptimisticLockException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,7 @@ public class PlantillaPresupuestoController {
 
     @GetMapping
     @Operation(summary = "Obtener todas las plantillas de presupuesto")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<PlantillaPresupuesto>> getAll() {
         try {
             return ResponseEntity.ok(getJpaController().findPlantillaPresupuestoEntities());
@@ -54,6 +56,7 @@ public class PlantillaPresupuestoController {
 
     @GetMapping("/tipo-tramite/{idTipoTramite}")
     @Operation(summary = "Obtener plantillas de presupuesto por tipo de tramite")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<PlantillaPresupuesto>> getByTipoTramite(@PathVariable Integer idTipoTramite) {
         try {
             return ResponseEntity.ok(getJpaController().findPlantillasDePresupuesto(idTipoTramite));

--- a/backend-api/src/main/java/com/licensis/notaire/api/PlantillaTramiteController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/PlantillaTramiteController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -33,12 +34,14 @@ public class PlantillaTramiteController {
 
     @GetMapping
     @Operation(summary = "Obtener todas las plantillas de tramite")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<PlantillaTramite>> getAll() {
         return ResponseEntity.ok(repository.findAll());
     }
 
     @GetMapping("/tipo-tramite/{idTipoTramite}")
     @Operation(summary = "Obtener plantillas de tramite por tipo de tramite")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<PlantillaTramite>> getByTipoTramite(@PathVariable Integer idTipoTramite) {
         return ResponseEntity.ok(repository.findByTipoDeTramiteIdTipoTramite(idTipoTramite));
     }
@@ -49,6 +52,7 @@ public class PlantillaTramiteController {
     })
     @GetMapping("/{idTipoTramite}/{idTipoDocumento}")
     @Operation(summary = "Obtener plantilla por clave compuesta (CU55)")
+    @Transactional(readOnly = true)
     public ResponseEntity<PlantillaTramite> getById(@PathVariable Integer idTipoTramite,
             @PathVariable Integer idTipoDocumento) {
         return repository.findById(new PlantillaTramitePK(idTipoTramite, idTipoDocumento))

--- a/backend-api/src/main/java/com/licensis/notaire/api/PresupuestoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/PresupuestoController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -55,6 +56,7 @@ public class PresupuestoController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener presupuesto por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<Presupuesto> getById(@PathVariable Integer id) {
         return presupuestoService.findById(id)
                 .map(ResponseEntity::ok)
@@ -63,12 +65,14 @@ public class PresupuestoController {
 
     @GetMapping("/persona/{idPersona}")
     @Operation(summary = "Obtener presupuestos de una persona (CU60)")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<Presupuesto>> getByPersona(@PathVariable Integer idPersona) {
         return ResponseEntity.ok(presupuestoService.findByPersona(idPersona));
     }
 
     @GetMapping("/buscar")
     @Operation(summary = "Buscar presupuestos por estado (CU60)")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<Presupuesto>> buscar(
             @Parameter(description = "Estado del presupuesto") @RequestParam(required = false) String estado) {
         return ResponseEntity.ok(presupuestoService.findByEstado(estado));

--- a/backend-api/src/main/java/com/licensis/notaire/api/RegistroAuditoriaController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/RegistroAuditoriaController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -44,6 +45,7 @@ public class RegistroAuditoriaController {
      */
     @GetMapping
     @Operation(summary = "Obtener los registros de auditoria con paginación y filtros opcionales")
+    @Transactional(readOnly = true)
     public ResponseEntity<?> getAll(
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Integer size,
@@ -75,6 +77,7 @@ public class RegistroAuditoriaController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener registro de auditoria por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<DtoRegistroAuditoria> getById(@PathVariable Integer id) {
         return service.findByIdAsDto(id)
                 .map(ResponseEntity::ok)
@@ -83,6 +86,7 @@ public class RegistroAuditoriaController {
 
     @GetMapping("/usuario/{idUsuario}")
     @Operation(summary = "Obtener registros de auditoria por usuario")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DtoRegistroAuditoria>> getByUsuario(@PathVariable Integer idUsuario) {
         return ResponseEntity.ok(service.findByUsuarioIdAsDto(idUsuario));
     }

--- a/backend-api/src/main/java/com/licensis/notaire/api/RolController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/RolController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,7 @@ public class RolController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los roles")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<RolResponse>> getAllRoles() {
         return ResponseEntity.ok(rolRepository.findAll().stream().map(this::toResponse).toList());
     }
@@ -57,6 +59,7 @@ public class RolController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener rol por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<RolResponse> getRolById(@PathVariable Integer id) {
         return rolRepository.findById(id)
                 .map(this::toResponse)

--- a/backend-api/src/main/java/com/licensis/notaire/api/SuplenciaController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/SuplenciaController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @RestController
@@ -24,6 +25,7 @@ public class SuplenciaController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los suplencia")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<Suplencia>> getAll() {
         try {
             return ResponseEntity.ok(getJpaController().findSuplenciaEntities());
@@ -38,6 +40,7 @@ public class SuplenciaController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener suplencia por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<Suplencia> getById(@PathVariable Integer id) {
         try {
             return ResponseEntity.ok(getJpaController().findSuplencia(id));

--- a/backend-api/src/main/java/com/licensis/notaire/api/TipoDeDocumentoController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TipoDeDocumentoController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -36,6 +37,7 @@ public class TipoDeDocumentoController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los tipo-de-documento")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DtoTipoDeDocumento>> getAll() {
         return ResponseEntity.ok(repository.findAll().stream()
                 .map(TipoDeDocumento::getDto)
@@ -44,6 +46,7 @@ public class TipoDeDocumentoController {
 
     @GetMapping("/search")
     @Operation(summary = "Buscar tipo-de-documento por nombre")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DtoTipoDeDocumento>> search(@RequestParam String nombre) {
         return ResponseEntity.ok(repository.findByNombreContaining(nombre).stream()
                 .map(TipoDeDocumento::getDto)
@@ -56,6 +59,7 @@ public class TipoDeDocumentoController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener tipo-de-documento por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<DtoTipoDeDocumento> getById(@PathVariable Integer id) {
         return repository.findById(id)
                 .map(e -> ResponseEntity.ok(e.getDto()))
@@ -64,6 +68,7 @@ public class TipoDeDocumentoController {
 
     @GetMapping("/{id}/in-use")
     @Operation(summary = "Verificar si el tipo de documento está en uso")
+    @Transactional(readOnly = true)
     public ResponseEntity<Map<String, Boolean>> isInUse(@PathVariable Integer id) {
         if (!repository.existsById(id)) {
             return ResponseEntity.notFound().build();

--- a/backend-api/src/main/java/com/licensis/notaire/api/TipoDeFolioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TipoDeFolioController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +28,7 @@ public class TipoDeFolioController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los tipos de folio")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DtoTipoDeFolio>> getAll() {
         List<DtoTipoDeFolio> result = repository.findAll().stream()
                 .map(TipoDeFolio::getDto)
@@ -40,6 +42,7 @@ public class TipoDeFolioController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener tipo de folio por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<DtoTipoDeFolio> getById(@PathVariable Integer id) {
         return repository.findById(id)
                 .map(e -> ResponseEntity.ok(e.getDto()))

--- a/backend-api/src/main/java/com/licensis/notaire/api/TipoIdentificacionController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TipoIdentificacionController.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -29,6 +30,7 @@ public class TipoIdentificacionController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los tipos de identificacion")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<TipoIdentificacion>> getAll() {
         return ResponseEntity.ok(repository.findAll());
     }
@@ -39,6 +41,7 @@ public class TipoIdentificacionController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener tipo de identificacion por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<TipoIdentificacion> getById(@PathVariable Integer id) {
         return repository.findById(id)
                 .map(ResponseEntity::ok)

--- a/backend-api/src/main/java/com/licensis/notaire/api/TramiteController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TramiteController.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.transaction.annotation.Transactional;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,6 +34,7 @@ public class TramiteController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los trámites")
+    @Transactional(readOnly = true)
     public ResponseEntity<Page<Tramite>> getAll(
             @PageableDefault(size = 20) Pageable pageable) {
         return ResponseEntity.ok(repository.findAll(pageable));
@@ -44,6 +46,7 @@ public class TramiteController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener trámite por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<Tramite> getById(@PathVariable Integer id) {
         return repository.findById(id)
                 .map(ResponseEntity::ok)

--- a/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -66,12 +67,14 @@ public class UsuarioController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los usuarios")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<UsuarioResponse>> getAllUsuarios() {
         return ResponseEntity.ok(usuarioRepository.findAll().stream().map(this::toResponse).toList());
     }
 
     @GetMapping("/persona/{idPersona}")
     @Operation(summary = "Obtener usuario por id de persona asociada")
+    @Transactional(readOnly = true)
     public ResponseEntity<UsuarioResponse> getUsuarioByPersona(@PathVariable Integer idPersona) {
         return usuarioRepository.findFirstByFkIdPersonaIdPersona(idPersona)
                 .map(this::toResponse)
@@ -85,6 +88,7 @@ public class UsuarioController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener usuario por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<UsuarioResponse> getUsuarioById(@PathVariable Integer id) {
         return usuarioRepository.findById(id)
                 .map(this::toResponse)

--- a/backend-api/src/main/java/com/licensis/notaire/api/WorkflowDefinitionController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/WorkflowDefinitionController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,7 @@ public class WorkflowDefinitionController {
 
     @GetMapping
     @Operation(summary = "Obtener todos los workflows")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DtoWorkflowDefinition>> getAll() {
         return ResponseEntity.ok(repository.findAll().stream().map(WorkflowDefinition::toDto).toList());
     }
@@ -53,6 +55,7 @@ public class WorkflowDefinitionController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener workflow por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<DtoWorkflowDefinition> getById(@PathVariable Integer id) {
         return repository.findById(id)
                 .map(wf -> ResponseEntity.ok(wf.toDto()))

--- a/backend-api/src/main/java/com/licensis/notaire/api/WorkflowNodeController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/WorkflowNodeController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -50,6 +51,7 @@ public class WorkflowNodeController {
 
     @GetMapping("/by-workflow/{workflowId}")
     @Operation(summary = "Obtener nodos por workflow")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DtoWorkflowNode>> getByWorkflow(@PathVariable Integer workflowId) {
         return ResponseEntity.ok(repository.findByWorkflowDefinitionId(workflowId)
                 .stream().map(WorkflowNode::toDto).toList());
@@ -61,6 +63,7 @@ public class WorkflowNodeController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener nodo por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<DtoWorkflowNode> getById(@PathVariable Integer id) {
         return repository.findById(id)
                 .map(n -> ResponseEntity.ok(n.toDto()))

--- a/backend-api/src/main/java/com/licensis/notaire/api/WorkflowTransitionController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/WorkflowTransitionController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -45,6 +46,7 @@ public class WorkflowTransitionController {
 
     @GetMapping("/by-workflow/{workflowId}")
     @Operation(summary = "Obtener transiciones por workflow")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<DtoWorkflowTransition>> getByWorkflow(@PathVariable Integer workflowId) {
         return ResponseEntity.ok(repository.findByWorkflowDefinitionId(workflowId)
                 .stream().map(WorkflowTransition::toDto).toList());
@@ -56,6 +58,7 @@ public class WorkflowTransitionController {
 })
     @GetMapping("/{id}")
     @Operation(summary = "Obtener transición por ID")
+    @Transactional(readOnly = true)
     public ResponseEntity<DtoWorkflowTransition> getById(@PathVariable Integer id) {
         return repository.findById(id)
                 .map(t -> ResponseEntity.ok(t.toDto()))


### PR DESCRIPTION
## Summary
- Fixed systemic `LazyInitializationException` → HTTP 500 affecting all GET endpoints with lazy-loaded entity associations
- 24 controllers updated: added `@Transactional(readOnly = true)` to all `@GetMapping` methods
- No behavior change; purely fixes the session-closed scenario with `spring.jpa.open-in-view=false`

## Root Cause
`spring.jpa.open-in-view=false` closes the Hibernate session as soon as the repository method returns. The subsequent `.stream().map(Entity::getDto)` chain accesses `FetchType.LAZY` collections outside any transaction scope → `LazyInitializationException`.

## Testing
- [x] All 985 unit + integration tests pass (`mvn test -pl backend-api`)
- [x] No test regressions

## Use Case Reference
CU07, CU08, and all read endpoints — any use case calling a GET endpoint on entities with LAZY associations.

Fixes #505