### PR TITLE
[#277,#278] docs: Spring transaction and JPA lazy loading guides

### DIFF
--- a/docs/03-development/04-code-standards/JPA-LAZY-LOADING-GUIDE.md
+++ b/docs/03-development/04-code-standards/JPA-LAZY-LOADING-GUIDE.md
@@ -1,0 +1,133 @@
+# JPA Lazy/Eager Loading Guide
+
+## Summary
+
+With `spring.jpa.open-in-view=false`, lazy loading only works inside an active Hibernate session (i.e., inside a `@Transactional` method). Any lazy collection accessed outside a transaction throws `LazyInitializationException`.
+
+## Entities with Lazy Collections
+
+The following entities have `FetchType.LAZY` associations that are accessed during DTO mapping:
+
+| Entity | Lazy Field | Accessed in `getDto()`? | Controller fix needed |
+|--------|-----------|-------------------------|-----------------------|
+| `Testimonio` | `movimientoTestimonioList` | Yes (iterates) | ✅ Fixed PR #504 |
+| `Testimonio` | `copiaList` | No (not in `getDto()`) | N/A |
+| `Escritura` | `folioList`, `tramiteList`, `testimonioList` | Yes | ✅ Fixed PR #506 |
+| `GestionDeEscritura` | `tramiteList` | Yes | ✅ Fixed PR #506 |
+| `Presupuesto` | `itemList`, `movimientosPresupuestoList` | Entity returned directly | ✅ Fixed PR #506 |
+| `Tramite` | `tramiteItemList`, `personaList` | Yes | ✅ Fixed PR #506 |
+| `WorkflowDefinition` | `steps`, `transitions` | Entity returned directly | ✅ Fixed PR #506 |
+| `Persona` | `identificacionList`, `tramiteList` | Yes | ✅ Fixed PR #506 |
+| `Usuario` | `registroAuditoriaList` | Entity returned directly | ✅ Fixed PR #506 |
+| `TipoDeTramite` | Multiple | Yes | ✅ Fixed PR #506 |
+
+All `@GetMapping` methods across all 30 controllers now have `@Transactional(readOnly = true)` applied.
+
+## When to Use LAZY vs EAGER
+
+### Use `FetchType.LAZY` (default for `@OneToMany`, `@ManyToMany`)
+
+Collections that are large or rarely needed in every query:
+
+```java
+@OneToMany(cascade = CascadeType.ALL, mappedBy = "fkIdTestimonio", fetch = FetchType.LAZY)
+private List<MovimientoTestimonio> movimientoTestimonioList = new ArrayList<>();
+```
+
+**Requirement**: the code that accesses this list must run inside a transaction.
+
+### Use `FetchType.EAGER` (default for `@ManyToOne`, `@OneToOne`)
+
+Single associations that are almost always needed. The `@ManyToOne` default is `EAGER` for a reason — the parent record is almost always needed when loading the child:
+
+```java
+@ManyToOne(optional = false, fetch = FetchType.EAGER)
+private Escritura fkIdEscritura;
+```
+
+**Caution**: never use `EAGER` on `@OneToMany` / `@ManyToMany` — it generates N+1 queries or Cartesian products.
+
+## Patterns
+
+### Pattern 1: Controller with direct repository call (our current pattern)
+
+```java
+@GetMapping
+@Transactional(readOnly = true)          // required
+public ResponseEntity<List<DtoFoo>> getAll() {
+    return ResponseEntity.ok(
+        repository.findAll().stream()
+            .map(Foo::getDto)            // touches lazy fields safely
+            .toList()
+    );
+}
+```
+
+### Pattern 2: Service-layer encapsulation (preferred for complex logic)
+
+```java
+@Service
+public class FooService {
+    @Transactional(readOnly = true)
+    public List<DtoFoo> findAll() {
+        return repository.findAll().stream()
+            .map(Foo::getDto)
+            .toList();
+    }
+}
+
+@RestController
+public class FooController {
+    @GetMapping
+    public ResponseEntity<List<DtoFoo>> getAll() {
+        return ResponseEntity.ok(fooService.findAll()); // transaction in service
+    }
+}
+```
+
+### Pattern 3: Fetch join to avoid N+1 (for performance)
+
+If the lazy collection is always needed, use a JPQL fetch join instead of changing to EAGER:
+
+```java
+@Query("SELECT t FROM Testimonio t LEFT JOIN FETCH t.movimientoTestimonioList WHERE t.idTestimonio = :id")
+Optional<Testimonio> findByIdWithMovimientos(@Param("id") Integer id);
+```
+
+This fetches the collection in a single SQL query without triggering N+1.
+
+## Diagnosing LazyInitializationException
+
+```
+org.hibernate.LazyInitializationException: failed to lazily initialize a collection
+    of role: com.licensis.notaire.negocio.Foo.barList,
+    could not initialize proxy - no Session
+```
+
+**Checklist:**
+1. Is `spring.jpa.open-in-view=false` set? (Yes — this is correct)
+2. Which lazy collection triggered the error? (`barList` in the example)
+3. Which method accesses it? Typically `getDto()` or a serialization step
+4. Is that method called from a `@Transactional` context? If not, add it.
+
+## N+1 Query Detection
+
+The current architecture calls `.getDto()` inside a stream over `findAll()` results. Each `getDto()` that accesses a lazy collection triggers an additional SELECT. For large datasets, use fetch joins or `@EntityGraph`:
+
+```java
+// Option 1: EntityGraph on repository method
+@EntityGraph(attributePaths = {"movimientoTestimonioList"})
+List<Testimonio> findAll();
+
+// Option 2: Explicit JPQL fetch join
+@Query("SELECT t FROM Testimonio t LEFT JOIN FETCH t.movimientoTestimonioList")
+List<Testimonio> findAllWithMovimientos();
+```
+
+For the current scale of the Notaire system (notarial office, hundreds of records) the N+1 impact is acceptable. Monitor via the Grafana `notaire-backend` dashboard if response times degrade.
+
+## Related
+
+- `SPRING-TRANSACTION-GUIDE.md` — transaction boundary management
+- `@.claude/rules/database-migrations.md` — schema management
+- Issues: #277 (transaction guide), #278 (this guide)

--- a/docs/03-development/04-code-standards/SPRING-TRANSACTION-GUIDE.md
+++ b/docs/03-development/04-code-standards/SPRING-TRANSACTION-GUIDE.md
@@ -1,0 +1,121 @@
+# Spring Transaction Management Guide
+
+## Context
+
+The Notaire backend sets `spring.jpa.open-in-view=false` (see `application.properties`). This is the correct production setting — it means the Hibernate session is opened and closed within the service/repository call boundary, not the full HTTP request. Without this understanding, accessing lazy-loaded collections outside a transaction boundary throws `LazyInitializationException` → HTTP 500.
+
+## The Root Problem
+
+```java
+// BROKEN — session closes after findAll() returns, before .map() runs
+@GetMapping
+public ResponseEntity<List<DtoFoo>> getAll() {
+    return ResponseEntity.ok(
+        repository.findAll().stream()   // ← session opens and closes HERE
+            .map(Foo::getDto)           // ← LazyInitializationException if getDto() touches LAZY fields
+            .toList()
+    );
+}
+```
+
+## The Fix
+
+Add `@Transactional(readOnly = true)` to any controller or service method that maps lazy-loaded entities to DTOs:
+
+```java
+import org.springframework.transaction.annotation.Transactional;
+
+@GetMapping
+@Transactional(readOnly = true)         // ← session stays open through the whole method
+public ResponseEntity<List<DtoFoo>> getAll() {
+    return ResponseEntity.ok(
+        repository.findAll().stream()
+            .map(Foo::getDto)           // ← safe, session still open
+            .toList()
+    );
+}
+```
+
+## Rules
+
+### 1. Use `readOnly = true` for GET methods
+
+```java
+@GetMapping
+@Transactional(readOnly = true)
+public ResponseEntity<List<DtoX>> getAll() { ... }
+
+@GetMapping("/{id}")
+@Transactional(readOnly = true)
+public ResponseEntity<DtoX> getById(@PathVariable Integer id) { ... }
+```
+
+`readOnly = true` enables Hibernate optimizations (no dirty checking, smaller memory footprint) and signals intent.
+
+### 2. Mutation methods need `@Transactional` (without readOnly)
+
+```java
+@PostMapping
+@Transactional
+public ResponseEntity<Object> create(@RequestBody DtoX dto) { ... }
+
+@PutMapping("/{id}")
+@Transactional
+public ResponseEntity<Object> update(...) { ... }
+
+@DeleteMapping("/{id}")
+@Transactional
+public ResponseEntity<Object> delete(...) { ... }
+```
+
+### 3. Service layer is the preferred boundary
+
+When business logic is in a `@Service` class, the transaction should be on the service, not the controller. Controllers that call services inherit the service transaction. However, controllers that call `repository` methods directly (the pattern in this codebase) must manage their own transaction.
+
+```java
+// Service with its own transaction — controller needs none
+@Service
+public class EscrituraService {
+    @Transactional(readOnly = true)
+    public Page<Escritura> findAllPaged(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+}
+```
+
+### 4. Identify LAZY fields that need covering
+
+When a new `@OneToMany(fetch = FetchType.LAZY)` is added to an entity whose `getDto()` iterates that collection, the controller or service calling `.getDto()` must be transactional. Check with:
+
+```bash
+grep -rn "FetchType.LAZY" backend-api/src/main/java/com/licensis/notaire/negocio/
+```
+
+## Verification
+
+If a GET endpoint returns HTTP 500 with `LazyInitializationException` in the logs:
+
+1. Find the entity's `getDto()` method — which lazy collections does it access?
+2. Find the controller method calling `.getDto()`.
+3. Add `@Transactional(readOnly = true)` to that controller method.
+4. Write an integration test that exercises the full GET → DTO mapping:
+
+```java
+@Test
+@DisplayName("GET /api/v1/foo should return 200 and list")
+void shouldReturnAll() throws Exception {
+    mockMvc.perform(get("/api/v1/foo"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray());
+}
+```
+
+## History
+
+- **2026-06-16**: Fixed `LazyInitializationException` in 25 controllers (PR #504, PR #506). All `@GetMapping` methods in the `api` package now have `@Transactional(readOnly = true)`. Root cause: `spring.jpa.open-in-view=false` + `FetchType.LAZY` on entity associations + controller calling `.stream().map(Entity::getDto)` outside any transaction.
+
+## Related
+
+- `@.claude/rules/database-migrations.md` — schema management
+- `JPA-LAZY-LOADING-GUIDE.md` — which entities have lazy associations and why
+- Issues: #277 (this guide), #278 (lazy loading guide), #503 (Testimonio fix), #505 (systemic fix)

--- a/docs/metrics/coverage-snapshot.json
+++ b/docs/metrics/coverage-snapshot.json
@@ -1,6 +1,6 @@
 {
-  "backendInstruction": 77,
-  "backendBranch": 62,
+  "backendInstruction": 80,
+  "backendBranch": 65,
   "frontendComponent": 45,
   "e2eTests": 85,
   "apiEndpoints": 78,


### PR DESCRIPTION
## Summary
- Added `SPRING-TRANSACTION-GUIDE.md` — documents the \`spring.jpa.open-in-view=false\` + \`@Transactional(readOnly=true)\` pattern that fixed 25 controllers (PR #504, #506)
- Added `JPA-LAZY-LOADING-GUIDE.md` — documents which entities have lazy associations, LAZY vs EAGER guidance, N+1 patterns, and fetch join alternatives  
- Updated `coverage-snapshot.json` to 80% instruction / 65% branch (post PR #508)

## Documentation
- [x] Guides based on actual code patterns in this codebase
- [x] Includes concrete code examples and history

Closes #277
Closes #278