### PR TITLE
[#512] fix: remove dead useCopiasByTestimonio hook calling non-existent endpoint

### DIFF
--- a/AUDIT_FINDINGS_CORRECTED_20260616.md
+++ b/AUDIT_FINDINGS_CORRECTED_20260616.md
@@ -114,16 +114,16 @@ Captures:
 | **Custom (GET /path/*)** | 19 | 17 | 89% |
 | **TOTAL** | **126** | **113** | **90%** |
 
-### Unmapped Frontend Calls (4)
+### Unmapped Frontend Calls (4) — Resolved 2026-06-17
 
-These are likely test-data endpoints or edge cases:
+Re-investigated directly against the live codebase:
 
-| Call | Reason | Recommendation |
+| Call | Finding | Resolution |
 |---|---|---|
-| `/copia/testimonio/${idTestimonio}` | Specific subresource not in API | Check if endpoint exists with different path |
-| `/folios` | Should be `/folio` (singular) | Verify API contract |
-| `/gestiones/1` | Test data ID | Not a real endpoint pattern |
-| `/gestiones/999` | Test data ID | Not a real endpoint pattern |
+| `/copia/testimonio/${idTestimonio}` | Confirmed: `CopiaController` only exposes `/copia` and `/copia/{id}`; the hook calling this path was unused anywhere in the UI | Removed as dead code (#512, PR #513) rather than adding an unexercised endpoint |
+| `/folios` | Not found — frontend's `useFolios.ts` correctly calls singular `/folio`, matching `FolioController`'s `@RequestMapping("/api/v1/folio")` | No mismatch; original finding was stale/incorrect |
+| `/gestiones/1` | Only appears in `frontend/src/tests/unit/api-client.test.ts` as a mock fixture | Test data, not a real endpoint call; no action needed |
+| `/gestiones/999` | Only appears in `frontend/src/tests/unit/api-client.test.ts` as a mock fixture | Test data, not a real endpoint call; no action needed |
 
 ### Unused Backend Endpoints (25)
 

--- a/frontend/src/hooks/useCopias.ts
+++ b/frontend/src/hooks/useCopias.ts
@@ -5,21 +5,12 @@ import type { Copia } from "@/types";
 export const copiasKeys = {
   all: ["copias"] as const,
   detail: (id: number) => ["copias", id] as const,
-  byTestimonio: (id: number) => ["copias", "testimonio", id] as const,
 };
 
 export function useCopias() {
   return useQuery({
     queryKey: copiasKeys.all,
     queryFn: () => apiGet<Copia[]>("/copia"),
-  });
-}
-
-export function useCopiasByTestimonio(idTestimonio: number) {
-  return useQuery({
-    queryKey: copiasKeys.byTestimonio(idTestimonio),
-    queryFn: () => apiGet<Copia[]>(`/copia/testimonio/${idTestimonio}`),
-    enabled: idTestimonio > 0,
   });
 }
 

--- a/frontend/src/tests/unit/business-logic-hooks.test.ts
+++ b/frontend/src/tests/unit/business-logic-hooks.test.ts
@@ -107,10 +107,6 @@ describe("copiasKeys (CU44, CU53)", () => {
   it("detail key includes id", () => {
     expect(copiasKeys.detail(8)).toEqual(["copias", 8]);
   });
-
-  it("byTestimonio key includes testimonio id", () => {
-    expect(copiasKeys.byTestimonio(12)).toEqual(["copias", "testimonio", 12]);
-  });
 });
 
 describe("documentosKeys (CU27, CU65)", () => {


### PR DESCRIPTION
## Summary
- Removed `useCopiasByTestimonio` hook from `frontend/src/hooks/useCopias.ts` — it called `/copia/testimonio/{id}`, a route that does not exist on `CopiaController` (only `/copia` and `/copia/{id}` CRUD are exposed)
- The hook was unused anywhere in the UI; only its own unit test referenced the `byTestimonio` query key, which was also removed

## Testing
- [x] `npx vitest run` (full frontend unit suite) passes
- [x] Confirmed zero remaining references to the removed hook/key via grep
- [x] `npx tsc --noEmit` shows no new errors (4 pre-existing, unrelated `tramiteList` errors in `pages.test.tsx` are untouched and out of scope)

## Documentation
- No UC needed; dead-code removal per `.claude/rules/general.md` #13 and the UI-endpoint-traceability rule

## Checklist
- [x] Code follows project conventions
- [x] No hardcoded credentials
- [x] No dead code
- [x] No TODO comments left
- [x] KIS and SRP applied

## Issue Reference
Fixes #512