### PR TITLE
[#516] fix: close CU63/CU68 search and in-use guard gaps for Folio/TipoDeFolio

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/FolioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/FolioController.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @RestController
@@ -26,6 +27,8 @@ import java.util.Optional;
 public class FolioController {
 
     private static final Logger log = LoggerFactory.getLogger(FolioController.class);
+
+    private static final String ESTADO_UTILIZADO = "Utilizado";
 
     record FolioRequest(
             int numero,
@@ -60,6 +63,23 @@ public class FolioController {
             log.error("Failed to list folios", e);
             return ResponseEntity.internalServerError().build();
         }
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "Buscar folios por estado")
+    public ResponseEntity<List<DtoFolio>> search(@RequestParam String estado) {
+        List<DtoFolio> result = folioRepository.findByEstado(estado).stream()
+                .map(Folio::getDto)
+                .toList();
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{id}/in-use")
+    @Operation(summary = "Verificar si un folio está en uso")
+    public ResponseEntity<Map<String, Boolean>> isInUse(@PathVariable Integer id) {
+        return folioRepository.findById(id)
+                .map(f -> ResponseEntity.ok(Map.of("inUse", ESTADO_UTILIZADO.equals(f.getEstado()))))
+                .orElse(ResponseEntity.notFound().build());
     }
 
     @ApiResponses({
@@ -112,10 +132,14 @@ public class FolioController {
 })
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar folio")
-    public ResponseEntity<DtoFolio> update(@PathVariable Integer id, @RequestBody FolioRequest request) {
+    public ResponseEntity<Object> update(@PathVariable Integer id, @RequestBody FolioRequest request) {
         Optional<Folio> existing = folioRepository.findById(id);
         if (existing.isEmpty()) {
             return ResponseEntity.notFound().build();
+        }
+        if (ESTADO_UTILIZADO.equals(existing.get().getEstado())) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("error", "Este folio está en uso (Utilizado) y no puede modificarse."));
         }
         Folio folio = existing.get();
         folio.setNumero(request.numero());
@@ -144,10 +168,14 @@ public class FolioController {
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar folio")
     @Transactional
-    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+    public ResponseEntity<Object> delete(@PathVariable Integer id) {
         Optional<Folio> opt = folioRepository.findById(id);
         if (opt.isEmpty()) {
             return ResponseEntity.notFound().build();
+        }
+        if (ESTADO_UTILIZADO.equals(opt.get().getEstado())) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("error", "No se puede eliminar: el folio está en uso (Utilizado)."));
         }
         try {
             Folio folio = opt.get();

--- a/backend-api/src/main/java/com/licensis/notaire/api/TipoDeFolioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/TipoDeFolioController.java
@@ -2,6 +2,7 @@ package com.licensis.notaire.api;
 
 import com.licensis.notaire.dto.DtoTipoDeFolio;
 import com.licensis.notaire.negocio.TipoDeFolio;
+import com.licensis.notaire.repository.FolioRepository;
 import com.licensis.notaire.repository.TipoDeFolioRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @RestController
@@ -21,9 +23,11 @@ import java.util.Optional;
 public class TipoDeFolioController {
 
     private final TipoDeFolioRepository repository;
+    private final FolioRepository folioRepository;
 
-    public TipoDeFolioController(TipoDeFolioRepository repository) {
+    public TipoDeFolioController(TipoDeFolioRepository repository, FolioRepository folioRepository) {
         this.repository = repository;
+        this.folioRepository = folioRepository;
     }
 
     @GetMapping
@@ -34,6 +38,27 @@ public class TipoDeFolioController {
                 .map(TipoDeFolio::getDto)
                 .toList();
         return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "Buscar tipos de folio por nombre")
+    @Transactional(readOnly = true)
+    public ResponseEntity<List<DtoTipoDeFolio>> search(@RequestParam String nombre) {
+        List<DtoTipoDeFolio> result = repository.findByNombreContaining(nombre).stream()
+                .map(TipoDeFolio::getDto)
+                .toList();
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{id}/in-use")
+    @Operation(summary = "Verificar si un tipo de folio está en uso")
+    @Transactional(readOnly = true)
+    public ResponseEntity<Map<String, Boolean>> isInUse(@PathVariable Integer id) {
+        if (!repository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        boolean inUse = !folioRepository.findByFkIdTipoFolioIdTipoFolio(id).isEmpty();
+        return ResponseEntity.ok(Map.of("inUse", inUse));
     }
 
     @ApiResponses({
@@ -78,6 +103,10 @@ public class TipoDeFolioController {
         if (existing.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
+        if (!folioRepository.findByFkIdTipoFolioIdTipoFolio(id).isEmpty()) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("error", "Este tipo de folio está en uso y no puede modificarse. Cree uno nuevo."));
+        }
         try {
             TipoDeFolio entity = existing.get();
             dto.setIdTipoFolio(id);
@@ -98,6 +127,10 @@ public class TipoDeFolioController {
     public ResponseEntity<Object> delete(@PathVariable Integer id) {
         if (!repository.existsById(id)) {
             return ResponseEntity.notFound().build();
+        }
+        if (!folioRepository.findByFkIdTipoFolioIdTipoFolio(id).isEmpty()) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("error", "No se puede eliminar: el tipo de folio está siendo utilizado por folios."));
         }
         try {
             repository.deleteById(id);

--- a/backend-api/src/main/java/com/licensis/notaire/repository/FolioRepository.java
+++ b/backend-api/src/main/java/com/licensis/notaire/repository/FolioRepository.java
@@ -23,4 +23,6 @@ public interface FolioRepository extends JpaRepository<Folio, Integer> {
     List<Folio> findByFkIdPersonaEscribanoIdPersona(Integer idEscribano);
 
     List<Folio> findByAnio(int anio);
+
+    List<Folio> findByEstado(String estado);
 }

--- a/backend-api/src/main/java/com/licensis/notaire/repository/TipoDeFolioRepository.java
+++ b/backend-api/src/main/java/com/licensis/notaire/repository/TipoDeFolioRepository.java
@@ -2,8 +2,11 @@ package com.licensis.notaire.repository;
 
 import com.licensis.notaire.negocio.TipoDeFolio;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,4 +15,7 @@ public interface TipoDeFolioRepository extends JpaRepository<TipoDeFolio, Intege
     Optional<TipoDeFolio> findByNombre(String nombre);
 
     boolean existsByNombre(String nombre);
+
+    @Query("SELECT t FROM TipoDeFolio t WHERE t.nombre LIKE %:nombre%")
+    List<TipoDeFolio> findByNombreContaining(@Param("nombre") String nombre);
 }

--- a/backend-api/src/test/java/com/licensis/notaire/integration/FolioControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/FolioControllerTest.java
@@ -163,4 +163,80 @@ class FolioControllerTest {
         mockMvc.perform(delete("/api/v1/folio/999999"))
                 .andExpect(status().isNotFound());
     }
+
+    @Test
+    @DisplayName("CU63 — GET /search?estado= should return only folios matching the estado")
+    void shouldSearchFoliosByEstado() throws Exception {
+        mockMvc.perform(post("/api/v1/folio").contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody(9010, "Errose")))
+                .andExpect(status().isCreated());
+
+        MvcResult result = mockMvc.perform(get("/api/v1/folio/search").param("estado", "Errose"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        var nodes = mapper.readTree(result.getResponse().getContentAsString());
+        assertThat(nodes.isArray()).isTrue();
+        for (var node : nodes) {
+            assertThat(node.get("estado").asText()).isEqualTo("Errose");
+        }
+    }
+
+    @Test
+    @DisplayName("GET /{id}/in-use should report false for a folio with estado Nuevo")
+    void shouldReportNotInUseForNuevoFolio() throws Exception {
+        MvcResult create = mockMvc.perform(post("/api/v1/folio").contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody(9011, "Nuevo")))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Integer id = mapper.readTree(create.getResponse().getContentAsString()).get("idFolio").asInt();
+
+        mockMvc.perform(get("/api/v1/folio/" + id + "/in-use"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.inUse").value(false));
+    }
+
+    @Test
+    @DisplayName("GET /{id}/in-use should report true for a folio with estado Utilizado")
+    void shouldReportInUseForUtilizadoFolio() throws Exception {
+        MvcResult create = mockMvc.perform(post("/api/v1/folio").contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody(9012, "Utilizado")))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Integer id = mapper.readTree(create.getResponse().getContentAsString()).get("idFolio").asInt();
+
+        mockMvc.perform(get("/api/v1/folio/" + id + "/in-use"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.inUse").value(true));
+    }
+
+    @Test
+    @DisplayName("PUT should return 409 when folio is already Utilizado")
+    void shouldReturn409WhenUpdatingUtilizadoFolio() throws Exception {
+        MvcResult create = mockMvc.perform(post("/api/v1/folio").contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody(9013, "Utilizado")))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Integer id = mapper.readTree(create.getResponse().getContentAsString()).get("idFolio").asInt();
+
+        mockMvc.perform(put("/api/v1/folio/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody(9013, "Errose")))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @DisplayName("DELETE should return 409 when folio is already Utilizado")
+    void shouldReturn409WhenDeletingUtilizadoFolio() throws Exception {
+        MvcResult create = mockMvc.perform(post("/api/v1/folio").contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody(9014, "Utilizado")))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Integer id = mapper.readTree(create.getResponse().getContentAsString()).get("idFolio").asInt();
+
+        mockMvc.perform(delete("/api/v1/folio/" + id))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").exists());
+    }
 }

--- a/backend-api/src/test/java/com/licensis/notaire/unit/SimpleControllersTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/SimpleControllersTest.java
@@ -576,8 +576,10 @@ class SimpleControllersTest {
     @DisplayName("TipoDeFolioController")
     class TipoDeFolioControllerTests {
         private final TipoDeFolioRepository repo = mock(TipoDeFolioRepository.class);
+        private final com.licensis.notaire.repository.FolioRepository folioRepo =
+                mock(com.licensis.notaire.repository.FolioRepository.class);
         private final org.springframework.test.web.servlet.MockMvc mvc =
-                standaloneSetup(new TipoDeFolioController(repo)).build();
+                standaloneSetup(new TipoDeFolioController(repo, folioRepo)).build();
 
         @Test
         @DisplayName("Cover all paths")

--- a/backend-api/src/test/java/com/licensis/notaire/unit/TipoDeFolioControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/TipoDeFolioControllerTest.java
@@ -1,0 +1,144 @@
+package com.licensis.notaire.unit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.licensis.notaire.api.TipoDeFolioController;
+import com.licensis.notaire.dto.DtoTipoDeFolio;
+import com.licensis.notaire.negocio.Folio;
+import com.licensis.notaire.negocio.TipoDeFolio;
+import com.licensis.notaire.repository.FolioRepository;
+import com.licensis.notaire.repository.TipoDeFolioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("TipoDeFolioController unit tests — CU68 Buscar tipos de folio + integridad referencial")
+@ExtendWith(MockitoExtension.class)
+class TipoDeFolioControllerTest {
+
+    @Mock
+    private TipoDeFolioRepository repository;
+
+    @Mock
+    private FolioRepository folioRepository;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        TipoDeFolioController controller = new TipoDeFolioController(repository, folioRepository);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    private TipoDeFolio buildEntity() {
+        TipoDeFolio t = new TipoDeFolio();
+        t.setIdTipoFolio(1);
+        t.setNombre("Protocolo");
+        return t;
+    }
+
+    @Test
+    @DisplayName("CU68 — GET /search?nombre= should return matching tipos de folio")
+    void shouldSearchByNombre() throws Exception {
+        when(repository.findByNombreContaining("Proto")).thenReturn(List.of(buildEntity()));
+        mockMvc.perform(get("/api/v1/tipo-folio/search").param("nombre", "Proto"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].nombre").value("Protocolo"));
+    }
+
+    @Test
+    @DisplayName("GET /{id}/in-use should return false when no folio references the tipo")
+    void shouldReportNotInUse() throws Exception {
+        when(repository.existsById(1)).thenReturn(true);
+        when(folioRepository.findByFkIdTipoFolioIdTipoFolio(1)).thenReturn(List.of());
+        mockMvc.perform(get("/api/v1/tipo-folio/1/in-use"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.inUse").value(false));
+    }
+
+    @Test
+    @DisplayName("GET /{id}/in-use should return true when at least one folio references the tipo")
+    void shouldReportInUse() throws Exception {
+        when(repository.existsById(1)).thenReturn(true);
+        when(folioRepository.findByFkIdTipoFolioIdTipoFolio(1)).thenReturn(List.of(new Folio()));
+        mockMvc.perform(get("/api/v1/tipo-folio/1/in-use"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.inUse").value(true));
+    }
+
+    @Test
+    @DisplayName("GET /{id}/in-use should return 404 when tipo de folio does not exist")
+    void shouldReturn404WhenCheckingInUseForMissingTipo() throws Exception {
+        when(repository.existsById(99)).thenReturn(false);
+        mockMvc.perform(get("/api/v1/tipo-folio/99/in-use"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("PUT /{id} should return 409 when tipo de folio is in use")
+    void shouldReturn409WhenUpdatingInUseTipo() throws Exception {
+        when(repository.findById(1)).thenReturn(Optional.of(buildEntity()));
+        when(folioRepository.findByFkIdTipoFolioIdTipoFolio(1)).thenReturn(List.of(new Folio()));
+
+        DtoTipoDeFolio dto = new DtoTipoDeFolio();
+        dto.setNombre("Protocolo Modificado");
+
+        mockMvc.perform(put("/api/v1/tipo-folio/1")
+                        .contentType("application/json")
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("PUT /{id} should succeed when tipo de folio is not in use")
+    void shouldUpdateWhenNotInUse() throws Exception {
+        TipoDeFolio existing = buildEntity();
+        when(repository.findById(1)).thenReturn(Optional.of(existing));
+        when(folioRepository.findByFkIdTipoFolioIdTipoFolio(1)).thenReturn(List.of());
+        when(repository.save(any(TipoDeFolio.class))).thenReturn(existing);
+
+        DtoTipoDeFolio dto = new DtoTipoDeFolio();
+        dto.setNombre("Protocolo Modificado");
+
+        mockMvc.perform(put("/api/v1/tipo-folio/1")
+                        .contentType("application/json")
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("DELETE /{id} should return 409 when tipo de folio is in use")
+    void shouldReturn409WhenDeletingInUseTipo() throws Exception {
+        when(repository.existsById(1)).thenReturn(true);
+        when(folioRepository.findByFkIdTipoFolioIdTipoFolio(1)).thenReturn(List.of(new Folio()));
+
+        mockMvc.perform(delete("/api/v1/tipo-folio/1"))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("DELETE /{id} should succeed when tipo de folio is not in use")
+    void shouldDeleteWhenNotInUse() throws Exception {
+        when(repository.existsById(1)).thenReturn(true);
+        when(folioRepository.findByFkIdTipoFolioIdTipoFolio(1)).thenReturn(List.of());
+
+        mockMvc.perform(delete("/api/v1/tipo-folio/1"))
+                .andExpect(status().isOk());
+    }
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -44,7 +44,8 @@
     "noData": "No data",
     "required": "required",
     "optional": "optional",
-    "language": "Language"
+    "language": "Language",
+    "all": "All"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -453,7 +454,22 @@
       "updated": "Folio updated",
       "deleted": "Folio deleted",
       "errorDelete": "Error deleting folio",
-      "editFolio": "Edit Folio"
+      "editFolio": "Edit Folio",
+      "inUseCannotModify": "This folio is in use (Utilizado) and cannot be modified",
+      "tiposDeFolio": {
+        "title": "Folio Types",
+        "newTipo": "New Folio Type",
+        "editTipo": "Edit Folio Type",
+        "searchPlaceholder": "Search by name...",
+        "nameRequired": "Name is required",
+        "created": "Folio type created",
+        "updated": "Folio type updated",
+        "deleted": "Folio type deleted",
+        "errorSave": "Error saving folio type",
+        "errorDelete": "Error deleting folio type",
+        "inUseCannotDelete": "Cannot delete: it is in use by folios",
+        "noData": "No folio types"
+      }
     },
     "tramites": {
       "title": "Case Types",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -44,7 +44,8 @@
     "noData": "Sin datos",
     "required": "requerido",
     "optional": "opcional",
-    "language": "Idioma"
+    "language": "Idioma",
+    "all": "Todos"
   },
   "dashboard": {
     "title": "Panel de Control",
@@ -453,7 +454,22 @@
       "updated": "Folio actualizado",
       "deleted": "Folio eliminado",
       "errorDelete": "Error al eliminar el folio",
-      "editFolio": "Editar Folio"
+      "editFolio": "Editar Folio",
+      "inUseCannotModify": "Este folio está en uso (Utilizado) y no puede modificarse",
+      "tiposDeFolio": {
+        "title": "Tipos de Folio",
+        "newTipo": "Nuevo Tipo de Folio",
+        "editTipo": "Editar Tipo de Folio",
+        "searchPlaceholder": "Buscar por nombre...",
+        "nameRequired": "El nombre es requerido",
+        "created": "Tipo de folio creado",
+        "updated": "Tipo de folio actualizado",
+        "deleted": "Tipo de folio eliminado",
+        "errorSave": "Error al guardar el tipo de folio",
+        "errorDelete": "Error al eliminar el tipo de folio",
+        "inUseCannotDelete": "No se puede eliminar: está siendo utilizado por folios",
+        "noData": "No hay tipos de folio"
+      }
     },
     "tramites": {
       "title": "Tipos de Trámite",

--- a/frontend/src/app/dashboard/administracion/folios/page.tsx
+++ b/frontend/src/app/dashboard/administracion/folios/page.tsx
@@ -84,9 +84,13 @@ export default function FoliosAdminPage() {
   const [tipoSaving, setTipoSaving] = useState(false);
   const [tipoDeleting, setTipoDeleting] = useState(false);
 
-  const filteredTiposFolio = tipoSearch
-    ? tiposFolio.filter((tf) => tf.nombre?.toLowerCase().includes(tipoSearch.toLowerCase()))
-    : tiposFolio;
+  const { data: filteredTiposFolio = [] } = useQuery({
+    queryKey: ["tipos-folio", "search", tipoSearch, tiposFolio],
+    queryFn: () =>
+      tipoSearch
+        ? apiGet<TipoDeFolioRow[]>(`/tipo-folio/search?nombre=${encodeURIComponent(tipoSearch)}`)
+        : Promise.resolve(tiposFolio),
+  });
 
   function openCreateTipo() {
     setTipoEditing(null);

--- a/frontend/src/app/dashboard/administracion/folios/page.tsx
+++ b/frontend/src/app/dashboard/administracion/folios/page.tsx
@@ -17,6 +17,26 @@ import { apiGet, apiPost, apiPut, apiDelete } from "@/lib/api-client";
 import type { Folio, Persona } from "@/types";
 
 const ESTADOS_FOLIO = ["Nuevo", "Utilizado", "Errose"] as const;
+const ESTADO_UTILIZADO = "Utilizado";
+
+interface TipoDeFolioRow {
+  idTipoFolio: number;
+  nombre: string;
+}
+
+function extractApiError(err: unknown): string | null {
+  if (!(err instanceof Error)) return null;
+  try {
+    const jsonStart = err.message.indexOf("{");
+    if (jsonStart !== -1) {
+      const body = JSON.parse(err.message.slice(jsonStart)) as { error?: string };
+      return body.error ?? null;
+    }
+  } catch {
+    // not JSON — fall through
+  }
+  return null;
+}
 
 interface FolioFormState {
   idFolio?: number;
@@ -41,15 +61,95 @@ export default function FoliosAdminPage() {
   const t = useTranslations("administracion.folios");
   const tc = useTranslations("common");
 
+  const [estadoFilter, setEstadoFilter] = useState<string>("");
+
   const { data = [], isLoading, refetch } = useQuery({
-    queryKey: ["folios"],
-    queryFn: () => apiGet<Folio[]>("/folio"),
+    queryKey: ["folios", estadoFilter],
+    queryFn: () =>
+      estadoFilter
+        ? apiGet<Folio[]>(`/folio/search?estado=${encodeURIComponent(estadoFilter)}`)
+        : apiGet<Folio[]>("/folio"),
   });
 
-  const { data: tiposFolio = [] } = useQuery({
+  const { data: tiposFolio = [], refetch: refetchTiposFolio } = useQuery({
     queryKey: ["tipos-folio"],
-    queryFn: () => apiGet<{ idTipoFolio: number; nombre: string }[]>("/tipo-folio"),
+    queryFn: () => apiGet<TipoDeFolioRow[]>("/tipo-folio"),
   });
+
+  const [tipoSearch, setTipoSearch] = useState("");
+  const [tipoModalOpen, setTipoModalOpen] = useState(false);
+  const [tipoEditing, setTipoEditing] = useState<TipoDeFolioRow | null>(null);
+  const [tipoNombre, setTipoNombre] = useState("");
+  const [tipoDeleteId, setTipoDeleteId] = useState<number | null>(null);
+  const [tipoSaving, setTipoSaving] = useState(false);
+  const [tipoDeleting, setTipoDeleting] = useState(false);
+
+  const filteredTiposFolio = tipoSearch
+    ? tiposFolio.filter((tf) => tf.nombre?.toLowerCase().includes(tipoSearch.toLowerCase()))
+    : tiposFolio;
+
+  function openCreateTipo() {
+    setTipoEditing(null);
+    setTipoNombre("");
+    setTipoModalOpen(true);
+  }
+
+  function openEditTipo(tf: TipoDeFolioRow) {
+    setTipoEditing(tf);
+    setTipoNombre(tf.nombre);
+    setTipoModalOpen(true);
+  }
+
+  async function handleSaveTipo() {
+    if (!tipoNombre.trim()) {
+      toast.error(t("tiposDeFolio.nameRequired"));
+      return;
+    }
+    setTipoSaving(true);
+    try {
+      if (tipoEditing) {
+        await apiPut(`/tipo-folio/${tipoEditing.idTipoFolio}`, { nombre: tipoNombre });
+        toast.success(t("tiposDeFolio.updated"));
+      } else {
+        await apiPost("/tipo-folio", { nombre: tipoNombre });
+        toast.success(t("tiposDeFolio.created"));
+      }
+      setTipoModalOpen(false);
+      refetchTiposFolio();
+    } catch (err) {
+      toast.error(extractApiError(err) ?? t("tiposDeFolio.errorSave"));
+    } finally {
+      setTipoSaving(false);
+    }
+  }
+
+  async function handleDeleteTipoClick(tf: TipoDeFolioRow) {
+    try {
+      const { inUse } = await apiGet<{ inUse: boolean }>(`/tipo-folio/${tf.idTipoFolio}/in-use`);
+      if (inUse) {
+        toast.error(t("tiposDeFolio.inUseCannotDelete"));
+        return;
+      }
+      setTipoDeleteId(tf.idTipoFolio);
+    } catch {
+      toast.error(t("tiposDeFolio.errorDelete"));
+    }
+  }
+
+  async function handleConfirmDeleteTipo() {
+    if (!tipoDeleteId) return;
+    setTipoDeleting(true);
+    try {
+      await apiDelete(`/tipo-folio/${tipoDeleteId}`);
+      toast.success(t("tiposDeFolio.deleted"));
+      refetchTiposFolio();
+    } catch (err) {
+      toast.error(extractApiError(err) ?? t("tiposDeFolio.errorDelete"));
+    } finally {
+      setTipoDeleting(false);
+      setTipoDeleteId(null);
+    }
+  }
 
   const { data: escribanos = [] } = useQuery({
     queryKey: ["escribanos-disponibles"],
@@ -115,8 +215,8 @@ export default function FoliosAdminPage() {
       }
       setModalOpen(false);
       refetch();
-    } catch {
-      toast.error(t("errorCreate"));
+    } catch (err) {
+      toast.error(extractApiError(err) ?? t("errorCreate"));
     } finally {
       setSaving(false);
     }
@@ -129,8 +229,8 @@ export default function FoliosAdminPage() {
       await apiDelete(`/folio/${deleteId}`);
       toast.success(t("deleted"));
       refetch();
-    } catch {
-      toast.error(t("errorDelete"));
+    } catch (err) {
+      toast.error(extractApiError(err) ?? t("errorDelete"));
     } finally {
       setDeleting(false);
       setDeleteId(null);
@@ -151,23 +251,36 @@ export default function FoliosAdminPage() {
       key: "actions",
       header: "",
       className: "w-24",
-      render: (f) => (
-        <div className="flex gap-2 justify-end">
-          <Button size="sm" variant="ghost" onClick={() => openEdit(f)} data-testid="btn-edit-folio" aria-label={tc("edit")}>
-            <NotaireIcon src="/icons/actions/generar.png" alt={tc("edit")} size={16} />
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            className="text-destructive hover:text-destructive"
-            onClick={() => setDeleteId(f.idFolio!)}
-            data-testid="btn-delete-folio"
-            aria-label={tc("delete")}
-          >
-            <NotaireIcon src="/icons/actions/borrar.png" alt={tc("delete")} size={16} />
-          </Button>
-        </div>
-      ),
+      render: (f) => {
+        const inUse = f.estado === ESTADO_UTILIZADO;
+        return (
+          <div className="flex gap-2 justify-end">
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => openEdit(f)}
+              disabled={inUse}
+              title={inUse ? t("inUseCannotModify") : undefined}
+              data-testid="btn-edit-folio"
+              aria-label={tc("edit")}
+            >
+              <NotaireIcon src="/icons/actions/generar.png" alt={tc("edit")} size={16} />
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="text-destructive hover:text-destructive"
+              onClick={() => setDeleteId(f.idFolio!)}
+              disabled={inUse}
+              title={inUse ? t("inUseCannotModify") : undefined}
+              data-testid="btn-delete-folio"
+              aria-label={tc("delete")}
+            >
+              <NotaireIcon src="/icons/actions/borrar.png" alt={tc("delete")} size={16} />
+            </Button>
+          </div>
+        );
+      },
     },
   ];
 
@@ -183,6 +296,20 @@ export default function FoliosAdminPage() {
           </Button>
         }
       />
+      <div className="px-4 pb-4 flex items-center gap-2">
+        <Select value={estadoFilter || "all"} onValueChange={(v) => setEstadoFilter(v === "all" ? "" : v)}>
+          <SelectTrigger className="w-48" data-testid="select-filter-estado-folio">
+            <SelectValue placeholder={t("fields.estadoPlaceholder")} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{tc("all")}</SelectItem>
+            {ESTADOS_FOLIO.map((e) => (
+              <SelectItem key={e} value={e}>{e}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
       <DataTable data={data} columns={columns} isLoading={isLoading} keyExtractor={(f) => f.idFolio!} emptyMessage={t("noData")} />
 
       <Dialog open={modalOpen} onOpenChange={setModalOpen}>
@@ -281,6 +408,91 @@ export default function FoliosAdminPage() {
       </Dialog>
 
       <ConfirmDialog open={!!deleteId} onOpenChange={(v) => !v && setDeleteId(null)} onConfirm={handleDelete} loading={deleting} />
+
+      <div className="mt-8">
+        <AppHeader
+          title={t("tiposDeFolio.title")}
+          actions={
+            <Button onClick={openCreateTipo} data-testid="btn-nuevo-tipo-folio">
+              <NotaireIcon src="/icons/actions/agregar.png" alt={tc("add")} size={16} className="mr-1" />
+              {t("tiposDeFolio.newTipo")}
+            </Button>
+          }
+        />
+        <div className="px-4 pb-4">
+          <Input
+            placeholder={t("tiposDeFolio.searchPlaceholder")}
+            value={tipoSearch}
+            onChange={(e) => setTipoSearch(e.target.value)}
+            className="w-64"
+            data-testid="input-search-tipo-folio"
+          />
+        </div>
+        <DataTable
+          data={filteredTiposFolio}
+          keyExtractor={(tf) => tf.idTipoFolio}
+          emptyMessage={t("tiposDeFolio.noData")}
+          columns={[
+            { key: "id", header: tc("id"), render: (tf) => <span className="text-xs text-muted-foreground">{tf.idTipoFolio}</span>, className: "w-12" },
+            { key: "nombre", header: tc("name"), render: (tf) => <span className="font-medium">{tf.nombre}</span> },
+            {
+              key: "actions",
+              header: "",
+              className: "w-24",
+              render: (tf) => (
+                <div className="flex gap-2 justify-end">
+                  <Button size="sm" variant="ghost" onClick={() => openEditTipo(tf)} data-testid="btn-edit-tipo-folio" aria-label={tc("edit")}>
+                    <NotaireIcon src="/icons/actions/generar.png" alt={tc("edit")} size={16} />
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="text-destructive hover:text-destructive"
+                    onClick={() => handleDeleteTipoClick(tf)}
+                    data-testid="btn-delete-tipo-folio"
+                    aria-label={tc("delete")}
+                  >
+                    <NotaireIcon src="/icons/actions/borrar.png" alt={tc("delete")} size={16} />
+                  </Button>
+                </div>
+              ),
+            },
+          ]}
+        />
+      </div>
+
+      <Dialog open={tipoModalOpen} onOpenChange={setTipoModalOpen}>
+        <DialogContent>
+          <FormContainer>
+            <FormSection title={tipoEditing ? t("tiposDeFolio.editTipo") : t("tiposDeFolio.newTipo")}>
+              <FormField label={tc("name")} required>
+                <Input
+                  value={tipoNombre}
+                  onChange={(e) => setTipoNombre(e.target.value)}
+                  data-testid="input-nombre-tipo-folio"
+                />
+              </FormField>
+            </FormSection>
+            <FormActions align="right">
+              <Button variant="secondary" onClick={() => setTipoModalOpen(false)}>
+                <NotaireIcon src="/icons/actions/cerrar.png" alt={tc("cancel")} size={16} className="mr-1" />
+                {tc("cancel")}
+              </Button>
+              <Button onClick={handleSaveTipo} disabled={tipoSaving} data-testid="btn-save-tipo-folio">
+                <NotaireIcon src="/icons/actions/guardar.png" alt={tc("save")} size={16} className="mr-1 brightness-0 invert" />
+                {tipoEditing ? tc("update") : tc("save")}
+              </Button>
+            </FormActions>
+          </FormContainer>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={!!tipoDeleteId}
+        onOpenChange={(v) => !v && setTipoDeleteId(null)}
+        onConfirm={handleConfirmDeleteTipo}
+        loading={tipoDeleting}
+      />
     </div>
   );
 }

--- a/frontend/tests/e2e/admin.spec.ts
+++ b/frontend/tests/e2e/admin.spec.ts
@@ -115,6 +115,40 @@ test.describe("CU28/CU40/CU58/CU68 — Folios", () => {
     await expect(dialog.getByLabel(/número/i)).toBeVisible();
     await expect(dialog.getByLabel(/año/i)).toBeVisible();
   });
+
+  test("CU63 — estado filter select is present and usable", async ({ page }) => {
+    await expect(page.getByTestId("select-filter-estado-folio")).toBeVisible();
+  });
+
+  test("Tipos de Folio section: full CRUD via search + create + edit + delete", async ({ page }) => {
+    const uniqueName = `TipoTest${Date.now()}`;
+    const renamed = `${uniqueName}-edit`;
+
+    await expect(page.getByRole("heading", { name: /tipos de folio/i })).toBeVisible();
+
+    await page.getByTestId("btn-nuevo-tipo-folio").click();
+    const createDialog = page.getByRole("dialog");
+    await createDialog.getByTestId("input-nombre-tipo-folio").fill(uniqueName);
+    await createDialog.getByTestId("btn-save-tipo-folio").click();
+    await expect(createDialog).toBeHidden();
+
+    await page.getByTestId("input-search-tipo-folio").fill(uniqueName);
+    const row = page.getByText(uniqueName, { exact: true });
+    await expect(row).toBeVisible();
+
+    await page.getByTestId("btn-edit-tipo-folio").first().click();
+    const editDialog = page.getByRole("dialog");
+    await editDialog.getByTestId("input-nombre-tipo-folio").fill(renamed);
+    await editDialog.getByTestId("btn-save-tipo-folio").click();
+    await expect(editDialog).toBeHidden();
+
+    await page.getByTestId("input-search-tipo-folio").fill(renamed);
+    await expect(page.getByText(renamed, { exact: true })).toBeVisible();
+
+    await page.getByTestId("btn-delete-tipo-folio").first().click();
+    await page.getByRole("alertdialog").getByRole("button", { name: /eliminar/i }).click();
+    await expect(page.getByText(renamed, { exact: true })).toBeHidden();
+  });
 });
 
 test.describe("CU39/CU49/CU55 — Plantillas de Presupuesto", () => {


### PR DESCRIPTION
## Summary
- Added `GET /api/v1/folio/search?estado=` and `GET /api/v1/folio/{id}/in-use`; PUT/DELETE now return 409 when a folio's estado is "Utilizado" — closes the part of #429's acceptance criteria (CU63) left open
- Added `GET /api/v1/tipo-folio/search?nombre=` and `GET /api/v1/tipo-folio/{id}/in-use`; PUT/DELETE now return 409 when a tipo is referenced by a Folio (CU68)
- Folios admin page: wired an estado filter to the new search endpoint, disabled edit/delete for in-use folios, and added a full "Tipos de Folio" CRUD section — this was the only way to invoke TipoDeFolioController's create/update/delete/search from the UI at all (it previously had zero UI traceability)

## Testing
- [x] New `TipoDeFolioControllerTest` (8 unit tests) + extended `FolioControllerTest` (5 new integration tests)
- [x] `mvn verify -pl backend-api` passes (checkstyle + JaCoCo ratchet floor maintained)
- [x] Frontend `npx vitest run` passes (217/217); `tsc --noEmit` shows no new errors (4 pre-existing unrelated errors in `pages.test.tsx` untouched)
- [x] Playwright E2E added to `admin.spec.ts`: estado filter visibility + full Tipos de Folio create/search/edit/delete flow

## Documentation
- Issue #516 documents the audit finding and the "in-use" semantics decision (Folio: estado==Utilizado; TipoDeFolio: referenced by a Folio)

## Checklist
- [x] Code follows project conventions
- [x] No hardcoded credentials
- [x] No dead code
- [x] No TODO comments left
- [x] KIS and SRP applied

## Issue Reference
Fixes #516