### PR TITLE
[#520] fix: wire CU19/CU60/CU61/CU62 search endpoints to UI

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -169,6 +169,7 @@
     "errorSave": "Error saving case",
     "errorDelete": "Error deleting case",
     "noData": "No cases registered",
+    "filterByCliente": "Filter by client...",
     "fields": {
       "numero": "Number",
       "tipo": "Case type",
@@ -190,6 +191,7 @@
     "errorSave": "Error saving",
     "errorDelete": "Error deleting",
     "noData": "No deeds registered",
+    "searchPlaceholder": "Search by number...",
     "fields": {
       "numero": "Number",
       "fecha": "Date",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -169,6 +169,7 @@
     "errorSave": "Error al guardar la gestión",
     "errorDelete": "Error al eliminar la gestión",
     "noData": "No hay gestiones registradas",
+    "filterByCliente": "Filtrar por cliente...",
     "fields": {
       "numero": "Número",
       "tipo": "Tipo de Trámite",
@@ -190,6 +191,7 @@
     "errorSave": "Error al guardar",
     "errorDelete": "Error al eliminar",
     "noData": "No hay escrituras registradas",
+    "searchPlaceholder": "Buscar por número...",
     "fields": {
       "numero": "Número",
       "fecha": "Fecha",

--- a/frontend/src/app/dashboard/escrituras/page.tsx
+++ b/frontend/src/app/dashboard/escrituras/page.tsx
@@ -11,6 +11,8 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { FormContainer, FormSection, FormField, FormActions } from "@/theme/form-patterns";
+import { useQuery } from "@tanstack/react-query";
+import { apiGet } from "@/lib/api-client";
 import {
   useEscrituras,
   useCreateEscritura,
@@ -35,6 +37,15 @@ export default function EscriturasPage() {
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [editing, setEditing] = useState<Partial<Escritura>>(EMPTY);
   const [isEditMode, setIsEditMode] = useState(false);
+  const [searchNumero, setSearchNumero] = useState("");
+
+  const { data: filteredEscrituras = escrituras } = useQuery({
+    queryKey: ["escrituras", "buscar", searchNumero, escrituras],
+    queryFn: () =>
+      searchNumero.trim()
+        ? apiGet<Escritura[]>(`/escrituras/buscar?numero=${encodeURIComponent(searchNumero.trim())}`)
+        : Promise.resolve(escrituras),
+  });
 
   function openCreate() { setEditing(EMPTY); setIsEditMode(false); setModalOpen(true); }
   function openEdit(e: Escritura) { setEditing(e); setIsEditMode(true); setModalOpen(true); }
@@ -83,7 +94,17 @@ export default function EscriturasPage() {
         title={t("title")}
         actions={<Button onClick={openCreate}><Plus className="h-4 w-4" />{t("newEscritura")}</Button>}
       />
-      <DataTable data={escrituras} columns={columns} isLoading={isLoading} keyExtractor={(e) => e.idEscritura!} emptyMessage={t("noData")} />
+      <div className="px-4 pb-4">
+        <Input
+          placeholder={t("searchPlaceholder")}
+          value={searchNumero}
+          onChange={(e) => setSearchNumero(e.target.value)}
+          className="w-48"
+          type="number"
+          data-testid="input-search-escritura"
+        />
+      </div>
+      <DataTable data={filteredEscrituras} columns={columns} isLoading={isLoading} keyExtractor={(e) => e.idEscritura!} emptyMessage={t("noData")} />
 
       <Dialog open={modalOpen} onOpenChange={setModalOpen}>
         <DialogContent>

--- a/frontend/src/app/dashboard/gestiones/page.tsx
+++ b/frontend/src/app/dashboard/gestiones/page.tsx
@@ -10,19 +10,24 @@ import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { FormContainer, FormSection, FormField, FormActions } from "@/theme/form-patterns";
 import {
   useGestiones,
+  useGestionesByCliente,
   useCreateGestion,
   useUpdateGestion,
   useDeleteGestion,
 } from "@/hooks/useGestiones";
+import { usePersonas } from "@/hooks/usePersonas";
+import { fullName } from "@/lib/utils";
 import type { GestionDeEscritura } from "@/types";
 
 export default function GestionesPage() {
   const t = useTranslations("gestiones");
   const tc = useTranslations("common");
   const { data: gestiones = [], isLoading } = useGestiones();
+  const { data: personas = [] } = usePersonas();
   const createMutation = useCreateGestion();
   const updateMutation = useUpdateGestion();
   const deleteMutation = useDeleteGestion();
@@ -31,6 +36,14 @@ export default function GestionesPage() {
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [editing, setEditing] = useState<GestionDeEscritura | null>(null);
   const [numero, setNumero] = useState("");
+  const [clienteFilter, setClienteFilter] = useState("");
+
+  const { data: gestionesByCliente = [], isLoading: isLoadingByCliente } = useGestionesByCliente(
+    clienteFilter ? Number(clienteFilter) : 0
+  );
+
+  const visibleGestiones = clienteFilter ? gestionesByCliente : gestiones;
+  const isLoadingVisible = clienteFilter ? isLoadingByCliente : isLoading;
 
   function openCreate() {
     setEditing(null);
@@ -126,10 +139,24 @@ export default function GestionesPage() {
         }
       />
 
+      <div className="px-4 pb-4 flex items-center gap-2">
+        <Select value={clienteFilter || "all"} onValueChange={(v) => setClienteFilter(v === "all" ? "" : v)}>
+          <SelectTrigger className="w-56" data-testid="select-filter-cliente-gestion">
+            <SelectValue placeholder={t("filterByCliente")} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{tc("all")}</SelectItem>
+            {personas.filter((p) => p.esCliente).map((p) => (
+              <SelectItem key={p.idPersona} value={String(p.idPersona)}>{fullName(p)}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
       <DataTable
-        data={gestiones}
+        data={visibleGestiones}
         columns={columns}
-        isLoading={isLoading}
+        isLoading={isLoadingVisible}
         keyExtractor={(g) => g.idGestion!}
         emptyMessage={t("noData")}
       />

--- a/frontend/src/app/dashboard/personas/page.tsx
+++ b/frontend/src/app/dashboard/personas/page.tsx
@@ -12,6 +12,8 @@ import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { FormContainer, FormSection, FormField, FormActions, CheckboxField } from "@/theme/form-patterns";
+import { useQuery } from "@tanstack/react-query";
+import { apiGet } from "@/lib/api-client";
 import {
   usePersonas,
   useCreatePersona,
@@ -50,12 +52,21 @@ export default function PersonasPage() {
   const [searchDni, setSearchDni] = useState("");
   const [filterClientes, setFilterClientes] = useState(false);
 
-  const filteredPersonas = personas.filter((p) => {
-    if (filterClientes && !p.esCliente) return false;
-    if (searchNombre && !p.nombre?.toLowerCase().includes(searchNombre.toLowerCase())) return false;
-    if (searchApellido && !p.apellido?.toLowerCase().includes(searchApellido.toLowerCase())) return false;
-    if (searchDni && !p.dni?.toLowerCase().includes(searchDni.toLowerCase())) return false;
-    return true;
+  const hasSearchCriteria = !!(searchNombre || searchApellido || searchDni || filterClientes);
+
+  const { data: filteredPersonas = personas } = useQuery({
+    queryKey: ["personas", "buscar", searchNombre, searchApellido, searchDni, filterClientes, personas],
+    queryFn: () => {
+      if (!hasSearchCriteria) {
+        return Promise.resolve(personas);
+      }
+      const params = new URLSearchParams();
+      if (searchNombre) params.set("nombre", searchNombre);
+      if (searchApellido) params.set("apellido", searchApellido);
+      if (searchDni) params.set("numeroIdentificacion", searchDni);
+      if (filterClientes) params.set("esCliente", "true");
+      return apiGet<Persona[]>(`/personas/buscar?${params.toString()}`);
+    },
   });
 
   function openCreate() {

--- a/frontend/src/app/dashboard/presupuestos/page.tsx
+++ b/frontend/src/app/dashboard/presupuestos/page.tsx
@@ -18,6 +18,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { FormContainer, FormSection, FormField, FormActions } from "@/theme/form-patterns";
+import { useQuery } from "@tanstack/react-query";
+import { apiGet } from "@/lib/api-client";
 import {
   usePresupuestos,
   useCreatePresupuesto,
@@ -48,8 +50,15 @@ export default function PresupuestosPage() {
   const [searchPresupuesto, setSearchPresupuesto] = useState("");
   const [filterEstado, setFilterEstado] = useState<string>("TODOS");
 
-  const filteredPresupuestos = presupuestos.filter((p) => {
-    if (filterEstado !== "TODOS" && p.estado !== filterEstado) return false;
+  const { data: byEstado = presupuestos } = useQuery({
+    queryKey: ["presupuestos", "buscar", filterEstado, presupuestos],
+    queryFn: () =>
+      filterEstado !== "TODOS"
+        ? apiGet<Presupuesto[]>(`/presupuestos/buscar?estado=${encodeURIComponent(filterEstado)}`)
+        : Promise.resolve(presupuestos),
+  });
+
+  const filteredPresupuestos = byEstado.filter((p) => {
     if (searchPresupuesto) {
       const q = searchPresupuesto.toLowerCase();
       const matchId = p.idPresupuesto?.toString().includes(q);

--- a/frontend/tests/e2e/cu02-gestiones.spec.ts
+++ b/frontend/tests/e2e/cu02-gestiones.spec.ts
@@ -4,6 +4,7 @@
  * CU14 - Consultar estado gestión
  * CU16 - Archivar Gestión
  * CU53 - Modificar Gestión
+ * CU19 - Buscar gestiones de un Cliente
  */
 import { test, expect } from "@playwright/test";
 import { GherkinSteps, TestData } from "./gherkin-helpers";
@@ -80,5 +81,29 @@ test.describe("CU16 - Archivar Gestión", () => {
 
   test.skip("CU16-GW01: Given gestion exists, When archivar clicked, Then status changes", async () => {
     // Skipped: gestiones page has no "archivar" button. Row actions are edit/delete only.
+  });
+});
+
+test.describe("CU19 - Buscar gestiones de un Cliente", () => {
+  let steps: GherkinSteps;
+
+  test.beforeEach(async ({ page }) => {
+    steps = new GherkinSteps(page);
+    await steps.givenUserIsLoggedIn();
+    await steps.givenUserIsOnPage("/dashboard/gestiones");
+  });
+
+  test("CU19-GW01: Given personas exist, When a cliente is selected, Then calls GET /gestiones/cliente/{id}", async () => {
+    await steps.page.getByTestId("select-filter-cliente-gestion").click();
+    const firstOption = steps.page.getByRole("option").filter({ hasNotText: /^Todos$/ }).first();
+    if (await firstOption.count() === 0) {
+      // No cliente seeded in this environment — nothing to filter by, skip assertion.
+      return;
+    }
+    const searchRequest = steps.page.waitForRequest((req) =>
+      /\/api\/v1\/gestiones\/cliente\/\d+/.test(req.url()) && req.method() === "GET"
+    );
+    await firstOption.click();
+    await searchRequest;
   });
 });

--- a/frontend/tests/e2e/cu05-escrituras.spec.ts
+++ b/frontend/tests/e2e/cu05-escrituras.spec.ts
@@ -87,7 +87,11 @@ test.describe("CU63 - Buscar Escritura", () => {
     await steps.givenUserIsOnPage("/dashboard/escrituras");
   });
 
-  test.skip("CU63-GW01: Given on escrituras page, When search by number, Then shows results", async () => {
-    // Skipped: escrituras page has no search bar in the current UI.
+  test("CU63-GW01: Given on escrituras page, When search by number, Then calls GET /escrituras/buscar", async () => {
+    const searchRequest = steps.page.waitForRequest((req) =>
+      req.url().includes("/api/v1/escrituras/buscar") && req.method() === "GET"
+    );
+    await steps.page.getByTestId("input-search-escritura").fill("1");
+    await searchRequest;
   });
 });

--- a/frontend/tests/e2e/personas.spec.ts
+++ b/frontend/tests/e2e/personas.spec.ts
@@ -62,4 +62,12 @@ test.describe("Personas module (CU17, CU18)", () => {
       .or(page.getByText(/no hay personas|no data/i));
     await expect(tableOrEmpty).toBeVisible({ timeout: 10000 });
   });
+
+  test("CU61 — escribir en búsqueda por nombre llama a GET /personas/buscar", async ({ page }) => {
+    const searchRequest = page.waitForRequest((req) =>
+      req.url().includes("/api/v1/personas/buscar") && req.method() === "GET"
+    );
+    await page.getByTestId("input-search-nombre").fill("Juan");
+    await searchRequest;
+  });
 });

--- a/frontend/tests/e2e/presupuestos.spec.ts
+++ b/frontend/tests/e2e/presupuestos.spec.ts
@@ -69,6 +69,15 @@ test.describe("Presupuestos module (CU01, CU39)", () => {
       .or(page.getByText(/no hay presupuestos/i));
     await expect(tableOrEmpty).toBeVisible({ timeout: 10000 });
   });
+
+  test("CU60 — seleccionar un estado llama a GET /presupuestos/buscar", async ({ page }) => {
+    const searchRequest = page.waitForRequest((req) =>
+      req.url().includes("/api/v1/presupuestos/buscar") && req.method() === "GET"
+    );
+    await page.getByTestId("select-estado").click();
+    await page.getByRole("option", { name: /borrador/i }).click();
+    await searchRequest;
+  });
 });
 
 test.describe("Pagos module (CU15, CU47)", () => {


### PR DESCRIPTION
## Summary
- Persona (CU61), Presupuesto (CU60), Escritura (CU62), Gestion-by-cliente (CU19) backend search endpoints existed but were never invoked from the UI — the last batch of orphaned "Buscar" UCs after #516 and #518
- Personas/Presupuestos pages: rewired existing search inputs to call the real backend endpoints instead of filtering client-side
- Escrituras/Gestiones pages: had no search UI at all; added a search-by-numero input and a cliente filter Select respectively

## Testing
- [x] `npx tsc --noEmit` — no new errors
- [x] `npx vitest run` — 217/217 passing
- [x] Un-skipped a pre-existing Playwright test in `cu05-escrituras.spec.ts` that explicitly documented "escrituras page has no search bar" — now implemented and asserting the real request
- [x] New Playwright tests for CU19 (`cu02-gestiones.spec.ts`), CU60 (`presupuestos.spec.ts`), CU61 (`personas.spec.ts`)
- [x] No backend changes — all four endpoints already exist and are tested

## Documentation
- Issue #520 documents the audit finding; this closes out the "Buscar" UC audit started in #516

## Checklist
- [x] Code follows project conventions
- [x] No hardcoded credentials
- [x] No dead code
- [x] No TODO comments left
- [x] KIS and SRP applied

## Issue Reference
Fixes #520