### PR TITLE
[#524] chore: remove 11 unused individual exports across hook files

### DIFF
--- a/frontend/src/hooks/useDocumentos.ts
+++ b/frontend/src/hooks/useDocumentos.ts
@@ -2,8 +2,8 @@
  * React Query hooks for TipoDeDocumento (CU27, CU65 — Tipos de documento).
  * Endpoint: GET/POST/PUT/DELETE /api/v1/tipo-de-documento
  */
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { apiGet, apiPost, apiPut, apiDelete } from "@/lib/api-client";
+import { useQuery } from "@tanstack/react-query";
+import { apiGet } from "@/lib/api-client";
 import type { TipoDeDocumento } from "@/types";
 
 export const documentosKeys = {
@@ -15,34 +15,5 @@ export function useTiposDocumento() {
   return useQuery({
     queryKey: documentosKeys.all,
     queryFn: () => apiGet<TipoDeDocumento[]>("/tipo-de-documento"),
-  });
-}
-
-export function useCreateTipoDocumento() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (data: Partial<TipoDeDocumento>) =>
-      apiPost<void>("/tipo-de-documento", data),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: documentosKeys.all }),
-  });
-}
-
-export function useUpdateTipoDocumento() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: ({ id, data }: { id: number; data: Partial<TipoDeDocumento> }) =>
-      apiPut<void>(`/tipo-de-documento/${id}`, data),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: documentosKeys.all }),
-  });
-}
-
-export function useDeleteTipoDocumento() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (id: number) => apiDelete(`/tipo-de-documento/${id}`),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: documentosKeys.all }),
   });
 }

--- a/frontend/src/hooks/useEscrituras.ts
+++ b/frontend/src/hooks/useEscrituras.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { apiGet, apiGetPaged, apiPost, apiPut, apiDelete } from "@/lib/api-client";
+import { apiGetPaged, apiPost, apiPut, apiDelete } from "@/lib/api-client";
 import type { Escritura } from "@/types";
 
 export const escriturasKeys = {
@@ -11,14 +11,6 @@ export function useEscrituras() {
   return useQuery({
     queryKey: escriturasKeys.all,
     queryFn: () => apiGetPaged<Escritura>("/escrituras"),
-  });
-}
-
-export function useEscritura(id: number) {
-  return useQuery({
-    queryKey: escriturasKeys.detail(id),
-    queryFn: () => apiGet<Escritura>(`/escrituras/${id}`),
-    enabled: id > 0,
   });
 }
 

--- a/frontend/src/hooks/useEstadosGestion.ts
+++ b/frontend/src/hooks/useEstadosGestion.ts
@@ -2,8 +2,8 @@
  * React Query hooks for EstadoDeGestion (CU67 — Gestionar estados de gestión).
  * Endpoint: GET/POST/PUT/DELETE /api/v1/estado-gestion
  */
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { apiGet, apiPost, apiPut, apiDelete } from "@/lib/api-client";
+import { useQuery } from "@tanstack/react-query";
+import { apiGet } from "@/lib/api-client";
 import type { EstadoDeGestion } from "@/types";
 
 export const estadosGestionKeys = {
@@ -15,34 +15,5 @@ export function useEstadosGestion() {
   return useQuery({
     queryKey: estadosGestionKeys.all,
     queryFn: () => apiGet<EstadoDeGestion[]>("/estado-gestion"),
-  });
-}
-
-export function useCreateEstadoGestion() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (data: Partial<EstadoDeGestion>) =>
-      apiPost<void>("/estado-gestion", data),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: estadosGestionKeys.all }),
-  });
-}
-
-export function useUpdateEstadoGestion() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: ({ id, data }: { id: number; data: Partial<EstadoDeGestion> }) =>
-      apiPut<void>(`/estado-gestion/${id}`, data),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: estadosGestionKeys.all }),
-  });
-}
-
-export function useDeleteEstadoGestion() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (id: number) => apiDelete(`/estado-gestion/${id}`),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: estadosGestionKeys.all }),
   });
 }

--- a/frontend/src/hooks/useGestiones.ts
+++ b/frontend/src/hooks/useGestiones.ts
@@ -25,14 +25,6 @@ export function useGestionByNumero(numero: number | undefined) {
   });
 }
 
-export function useGestion(id: number) {
-  return useQuery({
-    queryKey: gestionesKeys.detail(id),
-    queryFn: () => apiGet<GestionDeEscritura>(`/gestiones/${id}`),
-    enabled: id > 0,
-  });
-}
-
 export function useGestionesByCliente(idPersona: number) {
   return useQuery({
     queryKey: gestionesKeys.byCliente(idPersona),

--- a/frontend/src/hooks/useItems.ts
+++ b/frontend/src/hooks/useItems.ts
@@ -15,15 +15,6 @@ export function useItems() {
   });
 }
 
-/** CU01, CU39 — Obtener ítems de un presupuesto específico */
-export function useItemsByPresupuesto(idPresupuesto: number) {
-  return useQuery({
-    queryKey: itemsKeys.byPresupuesto(idPresupuesto),
-    queryFn: () => apiGet<Item[]>(`/items/presupuesto/${idPresupuesto}`),
-    enabled: idPresupuesto > 0,
-  });
-}
-
 export function useCreateItem() {
   const qc = useQueryClient();
   return useMutation({

--- a/frontend/src/hooks/usePersonas.ts
+++ b/frontend/src/hooks/usePersonas.ts
@@ -14,14 +14,6 @@ export function usePersonas() {
   });
 }
 
-export function usePersona(id: number) {
-  return useQuery({
-    queryKey: personasKeys.detail(id),
-    queryFn: () => apiGet<Persona>(`/personas/${id}`),
-    enabled: id > 0,
-  });
-}
-
 export function useCreatePersona() {
   const qc = useQueryClient();
   return useMutation({

--- a/frontend/src/hooks/usePresupuestos.ts
+++ b/frontend/src/hooks/usePresupuestos.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { apiGet, apiGetPaged, apiPost, apiPut, apiDelete } from "@/lib/api-client";
+import { apiGetPaged, apiPost, apiPut, apiDelete } from "@/lib/api-client";
 import type { Presupuesto } from "@/types";
 
 export const presupuestosKeys = {
@@ -12,22 +12,6 @@ export function usePresupuestos() {
   return useQuery({
     queryKey: presupuestosKeys.all,
     queryFn: () => apiGetPaged<Presupuesto>("/presupuestos"),
-  });
-}
-
-export function usePresupuesto(id: number) {
-  return useQuery({
-    queryKey: presupuestosKeys.detail(id),
-    queryFn: () => apiGet<Presupuesto>(`/presupuestos/${id}`),
-    enabled: id > 0,
-  });
-}
-
-export function usePresupuestosByPersona(idPersona: number) {
-  return useQuery({
-    queryKey: presupuestosKeys.byPersona(idPersona),
-    queryFn: () => apiGet<Presupuesto[]>(`/presupuestos/persona/${idPersona}`),
-    enabled: idPersona > 0,
   });
 }
 

--- a/frontend/src/hooks/useSuplencias.ts
+++ b/frontend/src/hooks/useSuplencias.ts
@@ -15,14 +15,6 @@ export function useSuplencias() {
   });
 }
 
-export function useSuplencia(id: number) {
-  return useQuery({
-    queryKey: suplenciasKeys.detail(id),
-    queryFn: () => apiGet<Suplencia>(`/suplencia/${id}`),
-    enabled: id > 0,
-  });
-}
-
 export function useCreateSuplencia() {
   const qc = useQueryClient();
   return useMutation({

--- a/frontend/src/tests/unit/business-logic-hooks.test.ts
+++ b/frontend/src/tests/unit/business-logic-hooks.test.ts
@@ -244,27 +244,6 @@ describe("Persona display name (CU17, CU18, CU61)", () => {
 });
 
 // ──────────────────────────────────────────────
-// Gestiones enabled condition (CU02, CU24)
-// ──────────────────────────────────────────────
-
-describe("useGestion enabled condition (CU02, CU24)", () => {
-  const isEnabled = (id: number) => id > 0;
-
-  it("enabled when id > 0", () => {
-    expect(isEnabled(1)).toBe(true);
-    expect(isEnabled(100)).toBe(true);
-  });
-
-  it("disabled when id is 0", () => {
-    expect(isEnabled(0)).toBe(false);
-  });
-
-  it("disabled when id is negative", () => {
-    expect(isEnabled(-1)).toBe(false);
-  });
-});
-
-// ──────────────────────────────────────────────
 // Copia type shape (CU44, CU53)
 // ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Removed 11 hook exports (create/update/delete/detail variants) with zero UI call-sites, across useEstadosGestion, useDocumentos, useEscrituras, useGestiones, usePersonas, usePresupuestos, useItems, useSuplencias
- Each entity already has full CRUD UI — these specific operations were reimplemented inline in their pages instead of using the hook
- Explicitly left `useReporteListaDocumentos` and `useAuditoriaByUsuario` alone: they look like missing-UI gaps, not dead code (flagged for separate follow-up, not blocking this cleanup)

## Testing
- [x] Project-wide grep confirms zero remaining references to any removed export
- [x] `npx tsc --noEmit` — no new errors
- [x] `npx vitest run` — 205/205 passing (down from 208; removed tests only exercised deleted logic)
- [x] No backend changes

## Documentation
- Issue #524 documents the audit and the two explicitly-excluded items

## Checklist
- [x] Code follows project conventions
- [x] No hardcoded credentials
- [x] No dead code
- [x] No TODO comments left
- [x] KIS and SRP applied

## Issue Reference
Fixes #524