### PR TITLE
[#526] chore: remove dead commented-out code blocks in entities

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/negocio/GestionDeEscritura.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/GestionDeEscritura.java
@@ -232,11 +232,6 @@ public class GestionDeEscritura implements Serializable {
 
             dtoTramite.setGestionDeEscritura(dtoGestion);
             dtoTramite.setInmueble(new DtoInmueble());
-
-            // Tramite tramiteAsociado = new Tramite();
-            // tramiteAsociado.setAtributos(dtoTramite);
-            //
-            // this.getTramiteList().add(tramiteAsociado);
         }
 
         // Estado de la gestion

--- a/backend-api/src/main/java/com/licensis/notaire/negocio/Tramite.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/Tramite.java
@@ -318,18 +318,6 @@ public class Tramite implements Serializable {
 
         this.documentoPresentadoList = new ArrayList<>();
 
-        // //Documentos asociados al tramite
-        // if((this.getDocumentoPresentadoList() != null) &&
-        // (!this.getDocumentoPresentadoList().isEmpty()))
-        // {
-        // for (Iterator<DocumentoPresentado> it =
-        // this.getDocumentoPresentadoList().iterator(); it.hasNext();)
-        // {
-        // DocumentoPresentado documentoPresentado = it.next();
-        //
-        // miDto.getListaDocumentosPresentados().add(documentoPresentado.getDto());
-        // }
-        // }
         return miDto;
     }
 


### PR DESCRIPTION
## Summary
- Removed two multi-line commented-out code blocks (actual dead code, not docs) in `Tramite.java` and `GestionDeEscritura.java`
- Comments only — zero behavior change

## Testing
- [x] `mvn test -pl backend-api -Dtest=TramiteEntityTest,GestionDeEscrituraEntityTest` passes
- [x] `mvn verify -pl backend-api` passes (checkstyle + JaCoCo ratchet floor maintained)

## Documentation
- Issue #526 documents the finding

## Checklist
- [x] Code follows project conventions
- [x] No hardcoded credentials
- [x] No dead code
- [x] No TODO comments left
- [x] KIS and SRP applied

## Issue Reference
Fixes #526