### PR TITLE
fix(github-pages): validate static export and support Next 16

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -108,6 +108,19 @@ jobs:
         env:
           NODE_ENV: production
 
+      - name: Validate exported site
+        run: |
+          if [ ! -f out/index.html ]; then
+            echo "ERROR: Static export did not generate out/index.html" >&2
+            ls -la out || true
+            exit 1
+          fi
+          if [ ! -d out/_next ] && [ ! -d out/_not-found ]; then
+            echo "ERROR: Static export missing required directories in out/" >&2
+            ls -la out || true
+            exit 1
+          fi
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/github-page/package.json
+++ b/github-page/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && next export",
+    "build": "next build",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
- Add pre-upload validation step for Pages artifact to ensure out/index.html and required exported directories exist before upload.\n- Fix github-page build script to use Next 16  mode without deprecated .\n\nVerified locally:  succeeds and  is present.,