### PR TITLE
fix(ci): correct Pages artifact path for upload

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: out
+          path: github-page/out
 
   deploy:
     needs: build


### PR DESCRIPTION
Fix GitHub Actions upload path for the Pages artifact to repo-relative github-page/out, which is required because actions/upload-pages-artifact runs from the default repo root and does not use the working-directory default. This prevents the Pages upload from failing due to missing artifact path.