### PR TITLE
[#533] fix(ci): rebuild GitHub Pages on every main push

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -3,7 +3,6 @@ name: Deploy GitHub Page
 on:
   push:
     branches: [main]
-    paths: ["github-page/**", "docs/metrics/**"]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Remove restrictive  filter from Pages deploy workflow
- Ensure repository-wide changes trigger a fresh GitHub Pages build

## Changes
- Updated 

## Testing
- Verified local build and metrics file generation

Closes #533