### PR TITLE
ci(pages): expose GITHUB_TOKEN for gh CLI in metrics step

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Fetch repository metrics
         working-directory: .
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           REPO="${{ github.repository }}"


### PR DESCRIPTION
Ensure the metrics fetch step can authenticate gh CLI by providing GITHUB_TOKEN and GH_TOKEN environment variables.