### PR TITLE
ci(pages): remove npm run export (Next 16 removed)

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -104,9 +104,7 @@ jobs:
         run: npm ci
 
       - name: Build static site
-        run: |
-          npm run build
-          npm run export
+        run: npm run build
         env:
           NODE_ENV: production
 


### PR DESCRIPTION
next export was removed in Next 16; remove the export step to avoid failure and rely on committed static  or Next build behavior.