### PR TITLE
[#616] refactor: dedupe extractApiError into lib/utils

### DIFF
--- a/frontend/src/app/dashboard/administracion/conceptos/page.tsx
+++ b/frontend/src/app/dashboard/administracion/conceptos/page.tsx
@@ -14,26 +14,10 @@ import { FormContainer, FormSection, FormField, FormActions } from "@/theme/form
 import { useQuery } from "@tanstack/react-query";
 import { apiGet } from "@/lib/api-client";
 import { useConceptos, useCreateConcepto, useUpdateConcepto, useDeleteConcepto } from "@/hooks/useConceptos";
-import { formatCurrency } from "@/lib/utils";
+import { formatCurrency, extractApiError } from "@/lib/utils";
 import type { Concepto } from "@/types";
 
 const EMPTY: Partial<Concepto> = { nombre: "", descripcion: "", valor: undefined };
-
-function extractApiError(err: unknown): string | null {
-  if (!(err instanceof Error)) return null;
-  const match = err.message.match(/\[409\]/);
-  if (!match) return null;
-  try {
-    const jsonStart = err.message.indexOf("{");
-    if (jsonStart !== -1) {
-      const body = JSON.parse(err.message.slice(jsonStart)) as { error?: string };
-      return body.error ?? null;
-    }
-  } catch {
-    // not JSON — return null
-  }
-  return null;
-}
 
 export default function ConceptosPage() {
   const t = useTranslations("administracion.conceptos");

--- a/frontend/src/app/dashboard/administracion/documentos/page.tsx
+++ b/frontend/src/app/dashboard/administracion/documentos/page.tsx
@@ -12,22 +12,10 @@ import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { FormContainer, FormSection, FormField, FormActions } from "@/theme/form-patterns";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiGet, apiPost, apiPut, apiDelete } from "@/lib/api-client";
+import { extractApiError } from "@/lib/utils";
 import type { TipoDeDocumento } from "@/types";
 
 const EMPTY: Partial<TipoDeDocumento> = { nombre: "" };
-
-function extractApiError(err: unknown): string | null {
-  if (!(err instanceof Error)) return null;
-  if (!err.message.includes("[409]")) return null;
-  try {
-    const jsonStart = err.message.indexOf("{");
-    if (jsonStart !== -1) {
-      const body = JSON.parse(err.message.slice(jsonStart)) as { error?: string };
-      return body.error ?? null;
-    }
-  } catch { }
-  return null;
-}
 
 export default function DocumentosPage() {
   const t = useTranslations("administracion.documentos");

--- a/frontend/src/app/dashboard/administracion/estados-gestion/page.tsx
+++ b/frontend/src/app/dashboard/administracion/estados-gestion/page.tsx
@@ -14,22 +14,10 @@ import { FormContainer, FormSection, FormField, FormActions } from "@/theme/form
 import { useQuery } from "@tanstack/react-query";
 import { apiGet, apiPost, apiPut, apiDelete } from "@/lib/api-client";
 import { useWorkflowDefinitions, useWorkflowNodes, useWorkflowTransitions } from "@/hooks/useWorkflow";
+import { extractApiError } from "@/lib/utils";
 import type { EstadoDeGestion } from "@/types";
 
 const EMPTY: Partial<EstadoDeGestion> = { nombre: "", observaciones: "" };
-
-function extractApiError(err: unknown): string | null {
-  if (!(err instanceof Error)) return null;
-  if (!err.message.includes("[409]")) return null;
-  try {
-    const jsonStart = err.message.indexOf("{");
-    if (jsonStart !== -1) {
-      const body = JSON.parse(err.message.slice(jsonStart)) as { error?: string };
-      return body.error ?? null;
-    }
-  } catch { }
-  return null;
-}
 
 export default function EstadosGestionPage() {
   const t = useTranslations("administracion.estadosGestion");

--- a/frontend/src/app/dashboard/administracion/folios/page.tsx
+++ b/frontend/src/app/dashboard/administracion/folios/page.tsx
@@ -14,6 +14,7 @@ import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { FormContainer, FormSection, FormField, FormActions } from "@/theme/form-patterns";
 import { useQuery } from "@tanstack/react-query";
 import { apiGet, apiPost, apiPut, apiDelete } from "@/lib/api-client";
+import { extractApiError } from "@/lib/utils";
 import type { Folio, Persona } from "@/types";
 
 const ESTADOS_FOLIO = ["Nuevo", "Utilizado", "Errose"] as const;
@@ -22,20 +23,6 @@ const ESTADO_UTILIZADO = "Utilizado";
 interface TipoDeFolioRow {
   idTipoFolio: number;
   nombre: string;
-}
-
-function extractApiError(err: unknown): string | null {
-  if (!(err instanceof Error)) return null;
-  try {
-    const jsonStart = err.message.indexOf("{");
-    if (jsonStart !== -1) {
-      const body = JSON.parse(err.message.slice(jsonStart)) as { error?: string };
-      return body.error ?? null;
-    }
-  } catch {
-    // not JSON — fall through
-  }
-  return null;
 }
 
 interface FolioFormState {

--- a/frontend/src/app/dashboard/administracion/tramites/page.tsx
+++ b/frontend/src/app/dashboard/administracion/tramites/page.tsx
@@ -14,22 +14,10 @@ import { useQuery } from "@tanstack/react-query";
 import { apiGet } from "@/lib/api-client";
 import { useTiposTramite, useCreateTipoTramite, useUpdateTipoTramite, useDeleteTipoTramite, useAssignWorkflowToTipoTramite } from "@/hooks/useTiposTramite";
 import { useWorkflowDefinitions } from "@/hooks/useWorkflow";
+import { extractApiError } from "@/lib/utils";
 import type { TipoDeTramite } from "@/types";
 
 const EMPTY: Partial<TipoDeTramite> = { nombre: "", descripcion: "" };
-
-function extractApiError(err: unknown): string | null {
-  if (!(err instanceof Error)) return null;
-  if (!err.message.includes("[409]")) return null;
-  try {
-    const jsonStart = err.message.indexOf("{");
-    if (jsonStart !== -1) {
-      const body = JSON.parse(err.message.slice(jsonStart)) as { error?: string };
-      return body.error ?? null;
-    }
-  } catch { }
-  return null;
-}
 
 export default function TramitesPage() {
   const t = useTranslations("administracion.tramites");

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -33,3 +33,23 @@ export function fullName(p?: {
   if (!p) return "—";
   return [p.nombre, p.apellido].filter(Boolean).join(" ") || "—";
 }
+
+/**
+ * Extract the server-side error message from a 409 Conflict Error.
+ * Returns the `error` field from the JSON body embedded in the message,
+ * or null when the message isn't a 409 or carries no parseable JSON.
+ */
+export function extractApiError(err: unknown): string | null {
+  if (!(err instanceof Error)) return null;
+  if (!err.message.includes("[409]")) return null;
+  try {
+    const jsonStart = err.message.indexOf("{");
+    if (jsonStart !== -1) {
+      const body = JSON.parse(err.message.slice(jsonStart)) as { error?: string };
+      return body.error ?? null;
+    }
+  } catch {
+    // message is not JSON — fall through
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- Extracted the duplicated `extractApiError` helper (previously copy-pasted in `conceptos`, `documentos`, `tramites`, `estados-gestion`, and `folios` pages) into a single shared implementation in `frontend/src/lib/utils.ts`

## Changes
### Fixed
- `frontend/src/lib/utils.ts` — new shared `extractApiError`, gated on `[409]` (matching the majority pre-existing behavior)
- Note: `folios.tsx`'s original copy lacked the `[409]` guard and would attempt JSON-parsing on any error message; consolidating onto the guarded version fixes that inconsistency as a side effect, while preserving behavior for the other 4 pages exactly

### Removed
- Duplicated `extractApiError` function bodies from all 5 admin pages, now importing from `lib/utils`

## Testing
- No existing test coverage for `extractApiError`; behavior verified by diff review to match prior per-page implementations (with folios' guard bug fixed)
- N/A automated tests added (pre-existing gap, out of scope for this dedup)

## Documentation
- N/A

## Checklist
- [x] Code follows project conventions
- [x] No hardcoded credentials
- [x] No dead code
- [x] No duplicate code (this is the fix)

## Issue Reference
Closes #616