### PR TITLE
[#556] fix(audit): make audit trail append-only, remove DELETE endpoint

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/RegistroAuditoriaController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/RegistroAuditoriaController.java
@@ -12,7 +12,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -101,20 +100,6 @@ public class RegistroAuditoriaController {
     public ResponseEntity<RegistroAuditoria> create(@RequestBody RegistroAuditoria entity) {
         RegistroAuditoria saved = service.save(entity);
         return ResponseEntity.ok(saved);
-    }
-
-    @ApiResponses({
-    @ApiResponse(responseCode = "204", description = "Eliminado"),
-    @ApiResponse(responseCode = "404", description = "No encontrado")
-})
-    @DeleteMapping("/{id}")
-    @Operation(summary = "Eliminar registro de auditoria")
-    public ResponseEntity<Void> delete(@PathVariable Integer id) {
-        if (service.findById(id).isEmpty()) {
-            return ResponseEntity.notFound().build();
-        }
-        service.deleteById(id);
-        return ResponseEntity.ok().build();
     }
 
     private Pageable buildPageable(Integer page, Integer size, String sort) {

--- a/backend-api/src/main/java/com/licensis/notaire/service/RegistroAuditoriaService.java
+++ b/backend-api/src/main/java/com/licensis/notaire/service/RegistroAuditoriaService.java
@@ -111,12 +111,6 @@ public class RegistroAuditoriaService {
         return repository.save(registroAuditoria);
     }
 
-    @Transactional
-    public void deleteById(Integer id) {
-        logger.debug("Deleting RegistroAuditoria by id: {}", id);
-        repository.deleteById(id);
-    }
-
     /**
      * Maps a {@link RegistroAuditoria} entity to its DTO inside the current
      * transaction so that the LAZY {@code fkIdUsuario} association can be

--- a/backend-api/src/test/java/com/licensis/notaire/service/unit/RegistroAuditoriaServiceTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/service/unit/RegistroAuditoriaServiceTest.java
@@ -295,14 +295,6 @@ class RegistroAuditoriaServiceTest {
     }
 
     @Test
-    @DisplayName("Should delete registro by id")
-    void shouldDeleteRegistroById() {
-        service.deleteById(1);
-
-        verify(repository, times(1)).deleteById(1);
-    }
-
-    @Test
     @DisplayName("Should map registro to DTO correctly")
     void shouldMapRegistroToDto() {
         DtoRegistroAuditoria dto = RegistroAuditoriaService.toDto(testRegistro);

--- a/backend-api/src/test/java/com/licensis/notaire/unit/RegistroAuditoriaControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/RegistroAuditoriaControllerTest.java
@@ -183,25 +183,10 @@ class RegistroAuditoriaControllerTest {
     }
 
     @Test
-    @DisplayName("Should delete an existing registro and return 200")
-    void shouldDeleteExistingRegistro() throws Exception {
-        when(service.findById(100)).thenReturn(Optional.of(sampleEntity));
-
+    @DisplayName("Should reject deletion of audit records - the trail is append-only (issue #556)")
+    void shouldRejectDeleteOfAuditRecords() throws Exception {
         mockMvc.perform(delete("/api/v1/registro-auditoria/100"))
-                .andExpect(status().isOk());
-
-        verify(service).deleteById(100);
-    }
-
-    @Test
-    @DisplayName("Should return 404 when deleting a non-existent registro")
-    void shouldReturn404WhenDeletingMissingRegistro() throws Exception {
-        when(service.findById(999)).thenReturn(Optional.empty());
-
-        mockMvc.perform(delete("/api/v1/registro-auditoria/999"))
-                .andExpect(status().isNotFound());
-
-        verify(service, never()).deleteById(999);
+                .andExpect(status().isMethodNotAllowed());
     }
 
     @Test

--- a/backend-api/src/test/java/com/licensis/notaire/unit/RegistroAuditoriaServiceTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/RegistroAuditoriaServiceTest.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -273,21 +272,6 @@ class RegistroAuditoriaServiceTest {
             assertThat(result).isEqualTo(testRegistro);
             assertThat(result.getDetalleOperacion()).isEqualTo("LOGIN");
             verify(repository).save(testRegistro);
-        }
-    }
-
-    @Nested
-    @DisplayName("deleteById")
-    class DeleteById {
-
-        @Test
-        @DisplayName("Should delegate to repository deleteById")
-        void shouldDeleteRegistro() {
-            doNothing().when(repository).deleteById(1);
-
-            service.deleteById(1);
-
-            verify(repository).deleteById(1);
         }
     }
 

--- a/docs/03-api/ENDPOINT_REGISTRY.md
+++ b/docs/03-api/ENDPOINT_REGISTRY.md
@@ -126,7 +126,9 @@ These endpoints are actively called from the Next.js frontend:
 - `GET /api/v1/registro-auditoria` - List audit records
 - `GET /api/v1/registro-auditoria/usuario/{idUsuario}` - Get records by user
 - `GET /api/v1/registro-auditoria/{id}` - Get audit record
-- `DELETE /api/v1/registro-auditoria/{id}` - Delete audit record
+- `POST /api/v1/registro-auditoria` - Create audit record
+
+Audit records are append-only: no DELETE endpoint exists (see issue #556).
 
 ### Roles & Usuarios
 - `GET /api/v1/roles` - List roles


### PR DESCRIPTION
## Summary
- Removed `DELETE /api/v1/registro-auditoria/{id}` — any authenticated user could delete audit records, defeating the purpose of an audit trail
- Removed the now-dead `RegistroAuditoriaService.deleteById` method
- Updated unit tests: controller test now asserts `405 Method Not Allowed` on DELETE; removed obsolete delete-path tests from both service test classes
- Updated `docs/03-api/ENDPOINT_REGISTRY.md` to drop the stale DELETE line and note the append-only design

## Why
RBAC (#559) doesn't exist yet, so there's no way to gate deletion to admins only. Per the issue's own suggested fix and standard audit-log practice, the correct fix is to remove delete capability entirely rather than partially gate it.

## Testing
- [x] Unit tests added/updated (TDD: confirmed RED — 404 before removal, then 405 after)
- [x] Full backend suite: 1374 tests, 0 failures (2 pre-existing errors unrelated to this change, tracked in #628)
- [x] Checkstyle: no new violations
- [x] Confirmed no E2E/Bruno tests call DELETE on this endpoint — no CI regression risk

## Documentation
- [x] `docs/03-api/ENDPOINT_REGISTRY.md` updated
- [x] Use Case: CU73 – Registro de Auditoría (existing, no new UC needed)

## Issue Reference
Closes #556