### PR TITLE
fix(dto): DtoUsuario.contrasenia lacks proper Jackson protection

### DIFF
--- a/backend-api/src/test/java/com/licensis/notaire/unit/DtoUsuarioSerializationTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/DtoUsuarioSerializationTest.java
@@ -1,0 +1,46 @@
+package com.licensis.notaire.unit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.licensis.notaire.dto.DtoUsuario;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@DisplayName("DtoUsuario JSON serialization")
+class DtoUsuarioSerializationTest {
+
+    @Test
+    @DisplayName("Should never include the password hash in serialized JSON (issue #564)")
+    void shouldNotSerializeContrasenia() throws Exception {
+        DtoUsuario dto = new DtoUsuario();
+        dto.setIdUsuario(1);
+        dto.setNombre("admin");
+        dto.setContrasenia("5f4dcc3b5aa765d61d8327deb882cf99");
+
+        String json = new ObjectMapper().writeValueAsString(dto);
+
+        assertFalse(json.contains("contrasenia"), "Serialized DtoUsuario must not contain the password field");
+        assertFalse(json.contains("5f4dcc3b5aa765d61d8327deb882cf99"), "Serialized DtoUsuario must not leak the password hash");
+    }
+
+    @Test
+    @DisplayName("Should still expose contrasenia to plain Java callers (getter not removed, only hidden from Jackson)")
+    void shouldStillExposeContraseniaViaGetter() {
+        DtoUsuario dto = new DtoUsuario();
+        dto.setContrasenia("5f4dcc3b5aa765d61d8327deb882cf99");
+
+        assertEquals("5f4dcc3b5aa765d61d8327deb882cf99", dto.getContrasenia());
+    }
+
+    @Test
+    @DisplayName("Should still deserialize contrasenia from incoming JSON (login request body)")
+    void shouldStillDeserializeContraseniaFromJson() throws Exception {
+        String json = "{\"nombre\":\"admin\",\"contrasenia\":\"5f4dcc3b5aa765d61d8327deb882cf99\"}";
+
+        DtoUsuario dto = new ObjectMapper().readValue(json, DtoUsuario.class);
+
+        assertEquals("5f4dcc3b5aa765d61d8327deb882cf99", dto.getContrasenia());
+    }
+}

--- a/notaire-shared/src/main/java/com/licensis/notaire/dto/DtoUsuario.java
+++ b/notaire-shared/src/main/java/com/licensis/notaire/dto/DtoUsuario.java
@@ -1,6 +1,7 @@
 package com.licensis.notaire.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * DTO que representa un Usuario.
@@ -65,6 +66,7 @@ public class DtoUsuario
         this.nombre = nombre;
     }
 
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     public String getContrasenia()
     {
         return this.contrasenia;


### PR DESCRIPTION
## Summary
- `DtoUsuario.getContrasenia()` had no Jackson annotation, so the password hash was serialized into any JSON response containing a `DtoUsuario` (e.g. nested under `usuarios` in audit records, user listings).
- Fixed with `@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)` — allows deserialization (login request body still populates the password) while suppressing serialization (never appears in any outgoing JSON).
- A naive `@JsonIgnore` was tried first but breaks login: Jackson's `@JsonIgnore` on a getter disables the property for both directions, and `DtoUsuario` doubles as the login request body.

## Testing
- [x] New `DtoUsuarioSerializationTest` (TDD): confirms password never appears in serialized JSON, confirms it still deserializes from incoming JSON, confirms plain Java getter still works.
- [x] Full backend-api suite: 1377 tests, 0 failures, 2 pre-existing errors (tracked in #628, unrelated).
- [x] Checkstyle: no new violations in touched files.

## Documentation
- `docs/05-api/REST-API-REFERENCE.md`'s login response example already omits `contrasenia` — no doc change needed.

## Issue Reference
Closes #564