### PR TITLE
[#553] fix(security): stop overwriting admin user on every startup

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/config/DataInitializer.java
+++ b/backend-api/src/main/java/com/licensis/notaire/config/DataInitializer.java
@@ -15,17 +15,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Optional;
 
 /**
- * Garantiza que el usuario por defecto {@code admin}/{@code admin} exista y pueda
- * iniciar sesión en cada arranque del backend.
+ * Siembra el usuario por defecto {@code admin}/{@code admin} una única vez, si no
+ * existe ninguno.
  *
  * <p>La contraseña se almacena como hash MD5, coincidiendo con la verificación que
- * realiza {@code UsuarioController#login}. Es idempotente: si el usuario ya existe
- * (sembrado por Flyway V2) se actualiza su contraseña y estado; si no existe, se
- * crea junto con su persona asociada. Esto asegura el acceso por defecto incluso
- * sobre una base de datos preexistente donde las migraciones no se vuelven a ejecutar.</p>
+ * realiza {@code UsuarioController#login}. Es un seed de una sola vez: si el usuario
+ * ya existe (sembrado por Flyway V2, o porque un operador ya rotó su contraseña) no
+ * se toca — de lo contrario cualquier cambio de credenciales quedaría deshecho en
+ * cada reinicio del backend (issue #553).</p>
  */
 @Component
 public class DataInitializer implements ApplicationRunner {
@@ -57,13 +56,8 @@ public class DataInitializer implements ApplicationRunner {
     }
 
     private void ensureAdminUser() {
-        Optional<Usuario> existing = usuarioRepository.findByNombre(ADMIN_USER);
-        if (existing.isPresent()) {
-            Usuario admin = existing.get();
-            admin.setContrasenia(md5(ADMIN_PASS_PLAIN));
-            admin.setEstado(true);
-            usuarioRepository.save(admin);
-            log.info("Usuario 'admin' verificado: contraseña por defecto y estado activo asegurados.");
+        if (usuarioRepository.findByNombre(ADMIN_USER).isPresent()) {
+            log.debug("Usuario 'admin' ya existe; no se modifican sus credenciales.");
             return;
         }
 

--- a/backend-api/src/test/java/com/licensis/notaire/unit/DataInitializerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/DataInitializerTest.java
@@ -46,22 +46,20 @@ class DataInitializerTest {
     }
 
     @Test
-    @DisplayName("Should reset password and activate existing admin user")
-    void shouldResetPasswordAndActivateExistingAdminUser() {
+    @DisplayName("Should not modify an already-existing admin user (issue #553)")
+    void shouldNotModifyExistingAdminUser() {
         Usuario existing = new Usuario();
         existing.setNombre("admin");
-        existing.setContrasenia("hash-obsoleto");
+        existing.setContrasenia("hash-ya-rotado-por-el-operador");
         existing.setEstado(false);
         when(usuarioRepository.findByNombre("admin")).thenReturn(Optional.of(existing));
 
         dataInitializer.run(null);
 
-        ArgumentCaptor<Usuario> captor = ArgumentCaptor.forClass(Usuario.class);
-        verify(usuarioRepository).save(captor.capture());
-        Usuario saved = captor.getValue();
-        assertThat(saved.getContrasenia()).isEqualTo(MD5_ADMIN);
-        assertThat(saved.getEstado()).isTrue();
+        verify(usuarioRepository, never()).save(any());
         verify(personaRepository, never()).save(any());
+        assertThat(existing.getContrasenia()).isEqualTo("hash-ya-rotado-por-el-operador");
+        assertThat(existing.getEstado()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `DataInitializer.ensureAdminUser()` forcibly reset the `admin` user's password hash and re-activated it on every backend boot, even if it already existed — a backdoor that silently undid any credential rotation an operator performed, with no way to durably disable it short of a code change.
- Changed the seed to a true one-time operation: if the `admin` user already exists, it is left completely untouched; the default `admin`/`admin` account is only created when none exists yet.

## Changes
### Modified
- `DataInitializer.ensureAdminUser()` — removed the branch that updated an existing admin's password/estado; now only acts when the user is absent.
- `DataInitializerTest` — replaced `shouldResetPasswordAndActivateExistingAdminUser` with `shouldNotModifyExistingAdminUser`, asserting no save/mutation occurs when the admin user already exists.

## Testing
- [x] Unit tests added/updated (TDD: confirmed RED against old behavior, then GREEN).
- [x] Full backend suite: `Tests run: 1377, Failures: 0, Errors: 2` — the 2 errors are the pre-existing, already-tracked `RegistroAuditoriaJpaControllerTest`/`UsuarioJpaControllerTest` failures (issue #628), unrelated to this change.
- [x] Checkstyle: clean.

## Documentation
- No docs described the "reset on startup" behavior as intended; nothing to update. The separate systemic-default-credentials concern is tracked independently in #565.

## Issue Reference
Closes #553