### PR TITLE
[#635] fix(ci): E2E workflow backend fails to start — jwt.secret unresolved placeholder

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -165,11 +165,14 @@ jobs:
             --spring.datasource.url=jdbc:postgresql://localhost:5432/notaire \
             --spring.datasource.username=notaire \
             --spring.datasource.password=notaire \
-            --spring.jpa.hibernate.ddl-auto=update &
+            --spring.jpa.hibernate.ddl-auto=update \
+            --jwt.secret="${JWT_SECRET}" &
           echo "Waiting for backend..."
           sleep 15
           timeout 60 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8080/actuator/health)" != "200" ]]; do sleep 2; done'
           echo "Backend is ready"
+        env:
+          JWT_SECRET: ci-e2e-only-jwt-secret-do-not-use-in-prod-!!
 
       # ── Start frontend ──
       - name: Start frontend


### PR DESCRIPTION
## Summary
- `main`'s E2E workflow has been red since #634 merged: the "Start backend API" step launches the jar directly with no `jwt.secret`, and the new fail-fast validation from #558 kills startup.
- Adds `--jwt.secret="${JWT_SECRET}"` to the CLI launch and a correctly-scoped step `env:` with a CI-only fixed value.

## Testing
- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"` — parses cleanly, `run:` script and `env:` are correctly separated (previous attempt on the old #558 branch had accidentally nested `env:` inside the `run: |` block scalar, truncating the script)
- [ ] CI E2E job green (pending this PR's run)

## Documentation
- N/A — CI-only workflow fix, no behavior/API change

## Issue Reference
Closes #635