### PR TITLE
[#555] fix(audit): stop trusting spoofable X-Notaire-User header

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/audit/AuditoriaAspect.java
+++ b/backend-api/src/main/java/com/licensis/notaire/audit/AuditoriaAspect.java
@@ -18,8 +18,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.lang.reflect.Method;
 import java.util.Date;
@@ -42,10 +40,10 @@ public class AuditoriaAspect {
     private static final Logger log = LoggerFactory.getLogger(AuditoriaAspect.class);
 
     /**
-     * Header set by the Next.js frontend carrying the name of the currently
-     * logged-in application user. Used to attribute audit records since the
-     * REST API itself is stateless and does not establish a Spring Security
-     * session for application logins.
+     * Legacy header the Next.js frontend still sends with the logged-in
+     * user's name. No longer trusted for audit attribution (issue #555):
+     * a client-supplied header is trivially forgeable. Kept here only as
+     * the well-known header name for tests asserting it is ignored.
      */
     public static final String ACTING_USER_HEADER = "X-Notaire-User";
 
@@ -153,9 +151,11 @@ public class AuditoriaAspect {
     }
 
     /**
-     * Resolves the acting user from (1) the Spring Security context, then
-     * (2) the {@link #ACTING_USER_HEADER} request header set by the frontend.
-     * The application login is stateless, so in practice (2) is the common path.
+     * Resolves the acting user solely from the verified Spring Security
+     * context populated by {@link com.licensis.notaire.config.JwtAuthenticationFilter}
+     * for a valid Bearer token. No client-supplied header is trusted (issue #555):
+     * every state-changing {@code /api/**} request requires authentication, so by
+     * the time this aspect runs, an authenticated request always has one.
      */
     private Optional<Usuario> resolveCurrentUser() {
         String name = resolveActingUsername();
@@ -174,19 +174,6 @@ public class AuditoriaAspect {
             if (name != null && !name.isBlank() && !"anonymousUser".equals(name)) {
                 return name;
             }
-        }
-        return currentRequestHeader(ACTING_USER_HEADER);
-    }
-
-    private String currentRequestHeader(String headerName) {
-        try {
-            ServletRequestAttributes attributes =
-                    (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-            if (attributes != null) {
-                return attributes.getRequest().getHeader(headerName);
-            }
-        } catch (RuntimeException ignored) {
-            // No request bound to the current thread (e.g. async); not auditable.
         }
         return null;
     }

--- a/backend-api/src/test/java/com/licensis/notaire/unit/AuditoriaAspectTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/AuditoriaAspectTest.java
@@ -123,20 +123,18 @@ class AuditoriaAspectTest {
     }
 
     @Test
-    @DisplayName("Should resolve acting user from X-Notaire-User header when no security context")
-    void shouldResolveActingUserFromHeaderWhenNoSecurityContext() throws NoSuchMethodException {
+    @DisplayName("Should NOT trust a spoofed X-Notaire-User header when there is no verified authentication (issue #555)")
+    void shouldNotTrustSpoofedHeaderWhenNoSecurityContext() throws NoSuchMethodException {
         SecurityContextHolder.clearContext();
         bindRequestWithUserHeader("admin");
-        when(usuarioRepository.findAll()).thenReturn(List.of(adminUser));
+        lenient().when(usuarioRepository.findAll()).thenReturn(List.of(adminUser));
 
         Method method = escrituraMethod("update", Integer.class, Escritura.class);
         stubJoinPoint(EscrituraController.class, method, new Object[]{5, null});
 
         aspect.auditAfterControllerInvocation(joinPoint);
 
-        ArgumentCaptor<RegistroAuditoria> captor = ArgumentCaptor.forClass(RegistroAuditoria.class);
-        verify(auditoriaService).save(captor.capture());
-        assertThat(captor.getValue().getFkIdUsuario()).isSameAs(adminUser);
+        verify(auditoriaService, never()).save(any());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `AuditoriaAspect.resolveCurrentUser()` trusted a client-supplied `X-Notaire-User` header for audit attribution whenever there was no Spring Security authentication in context.
- That header is built entirely client-side from `localStorage` (`frontend/src/lib/api-client.ts`), so any caller could forge or erase who performed a business operation in the audit trail.
- Fix: resolve the acting user solely from the verified `SecurityContextHolder` authentication populated by `JwtAuthenticationFilter` for a valid Bearer token. Every state-changing `/api/**` endpoint already requires authentication (`SecurityAndCorsConfig`), so by the time this aspect runs an authenticated request always has one.

## Changes
### Modified
- `AuditoriaAspect.java` — removed the `RequestContextHolder`/header fallback; `resolveActingUsername()` now reads only `SecurityContextHolder`.
- `AuditoriaAspectTest.java` — replaced the test asserting the old (insecure) header-trust behavior with `shouldNotTrustSpoofedHeaderWhenNoSecurityContext`, which proves a spoofed header is ignored when there's no verified authentication.

## Testing
- [x] Unit tests added/updated — TDD: confirmed RED against the vulnerable code first (caught a false-positive in my own first draft where an over-eager mock removal masked the vulnerability; fixed by keeping the `usuarioRepository.findAll()` stub so the test could actually exercise the spoofing path), then GREEN after the fix.
- [x] Full backend suite: `1381 tests, 4 failures, 2 errors` — all 6 pre-existing and unrelated to this change:
  - 4x `PrometheusMetricsIntegrationTest` — a classpath-shadowing regression on `main` (independently confirmed via a clean `git worktree` of `main`, unrelated to this PR; will be filed as its own issue/PR).
  - 2x pre-existing baseline from #628 (`RegistroAuditoriaJpaControllerTest`, `UsuarioJpaControllerTest`).
- [x] Checkstyle clean (`mvn checkstyle:check`).

## Documentation
- [x] No business/engineering docs reference the old header-trust behavior; no updates needed.
- [x] Use Case referenced via existing issue body.

## Checklist
- [x] Code follows project conventions
- [x] No hardcoded credentials
- [x] No dead code
- [x] No TODO comments left
- [x] KIS and SRP applied

## Issue Reference
Fixes #555