### PR TITLE
[#638] fix(test): src/test/resources/application.properties shadows main config

### DIFF
--- a/backend-api/src/test/resources/application-integration.properties
+++ b/backend-api/src/test/resources/application-integration.properties
@@ -1,0 +1,11 @@
+# Test configuration for the "integration" profile — used by
+# FlywaySchemaValidationIntegrationTest, which boots the full Spring context
+# against a real PostgreSQL container with Flyway managing the schema
+# (ddl-auto=none), guarded by the pg-integration Maven profile.
+
+# jwt.secret has no default in production code (issue #558); the full
+# Spring context requires one to pass JwtTokenService#validateSecret
+# (>= 32 bytes, not the old insecure default). Lives here (not in the
+# profile-agnostic base application.properties) so it doesn't shadow
+# src/main/resources config for every test profile (issue #638).
+jwt.secret=notaire-test-only-jwt-secret-do-not-use-in-prod!!

--- a/backend-api/src/test/resources/application-test-h2.properties
+++ b/backend-api/src/test/resources/application-test-h2.properties
@@ -11,3 +11,10 @@ spring.sql.init.mode=always
 # Flyway must be disabled for H2 profile — Hibernate ddl-auto=create manages the schema here.
 # In Spring Boot 4.x, Flyway auto-configuration is enabled by default (matchIfMissing=true).
 spring.flyway.enabled=false
+
+# jwt.secret has no default in production code (issue #558); tests need a
+# fixed value that passes JwtTokenService#validateSecret (>= 32 bytes, not
+# the old insecure default). Lives here (not in the profile-agnostic base
+# application.properties) so it doesn't shadow src/main/resources config
+# for every test profile (issue #638).
+jwt.secret=notaire-test-only-jwt-secret-do-not-use-in-prod!!

--- a/backend-api/src/test/resources/application.properties
+++ b/backend-api/src/test/resources/application.properties
@@ -1,8 +1,0 @@
-# Base test configuration applied to every test execution regardless of
-# active profile (test, test-h2, testcontainers, integration). Not packaged
-# into the production JAR — src/test/resources only affects the test classpath.
-
-# jwt.secret has no default in production code (issue #558); tests need a
-# fixed value that passes JwtTokenService#validateSecret (>= 32 bytes, not
-# the old insecure default).
-jwt.secret=notaire-test-only-jwt-secret-do-not-use-in-prod!!


### PR DESCRIPTION
## Summary
- `src/test/resources/application.properties` was a bare, profile-agnostic file whose only content was `jwt.secret`. Because `test-classes` precedes `classes` on the test classpath and Spring Boot's config loading takes only the *first* `application.properties` match (profile-specific files merge additively; this bare one does not), it completely shadowed `src/main/resources/application.properties` — including the `management.endpoints.web.exposure.include` line — for every test profile. Result: `/actuator/prometheus` 404'd everywhere.
- Same class of bug already fixed once during #558; reappeared after PR #634's squash-merge.

## Changes
### Added
- `application-integration.properties` — didn't exist before; `FlywaySchemaValidationIntegrationTest` (the only test using the `integration` profile) boots a full Spring context and needs `jwt.secret` too.

### Modified
- `application-test-h2.properties` — added `jwt.secret` (used by 26 of 27 `@SpringBootTest` classes).

### Removed
- `application.properties` (bare, test-resources) — deleted; nothing else in it was needed, and its only effect was the shadowing bug.

## Testing
- [x] `PrometheusMetricsIntegrationTest` — reproduced RED first (4/4 failing, 404s, confirming the reported bug), GREEN after the fix (4/4 passing).
- [x] Full backend suite: `1381 tests, 0 failures, 2 errors` — both errors are the pre-existing #628 baseline, confirmed unrelated.
- [x] Checkstyle clean.

## Documentation
- [x] No docs referenced the shadowing file; no updates needed.

## Checklist
- [x] Code follows project conventions
- [x] No hardcoded credentials (test-only JWT secret, consistent with existing convention)
- [x] No dead code
- [x] No TODO comments left
- [x] KIS and SRP applied

## Issue Reference
Fixes #638