### PR TITLE
[#628] test: fix pre-existing failures in JPA controller tests

### DIFF
--- a/backend-api/src/test/java/com/licensis/notaire/unit/jpa/RegistroAuditoriaJpaControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/jpa/RegistroAuditoriaJpaControllerTest.java
@@ -127,6 +127,7 @@ class RegistroAuditoriaJpaControllerTest {
             inputRA.setFkIdUsuario(usuario);
 
             when(em.find(RegistroAuditoria.class, id)).thenReturn(persistentRA);
+            when(em.getReference(Usuario.class, 1)).thenReturn(usuario);
 
             controller.edit(inputRA);
 

--- a/backend-api/src/test/java/com/licensis/notaire/unit/jpa/UsuarioJpaControllerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/jpa/UsuarioJpaControllerTest.java
@@ -452,6 +452,7 @@ class UsuarioJpaControllerTest {
             inputUsuario.setVersion(0);
 
             when(em.find(Usuario.class, id)).thenReturn(persistentUsuario);
+            when(em.getTransaction()).thenReturn(tx);
 
             Boolean result = controller.modificarUsuario(inputUsuario);
 


### PR DESCRIPTION
## Summary
- Fixes `UsuarioJpaControllerTest#shouldUpdateWhenVersionMatches`: added the missing `em.getTransaction()` stub for the version-match path (the `ModificarUsuario` nested class was the only one of `Create`/`Edit`/`Destroy`/`ModificarUsuario` without it).
- Fixes `RegistroAuditoriaJpaControllerTest#shouldMergeWhenFkUnchanged`: added the missing `em.getReference()` stub — without it the mock returned `null`, which `edit()` read as the FK usuario changing, triggering an NPE against an uninitialized list field.

## Root cause
Both are mock/stub setup gaps versus actual JPA controller behavior, not production bugs:
- `modificarUsuario()` only calls `em.getTransaction()` on the version-match branch (unlike `edit()`, which begins the transaction unconditionally), so the stub had to be scoped to the one test that needs it rather than a shared `@BeforeEach`.
- `edit()` calls `em.getReference(...)` to re-resolve the FK usuario; leaving it unstubbed made the mock return `null`, which the equality check read as "FK changed."

## Testing
- [x] Full local suite green: `mvn test -q` (unit + H2 integration) — 107 report files, 593 tests, 0 failures, 0 errors (previously 2 errors).
- [x] Checkstyle clean on both files.
- [x] No other files touched.

## Issue Reference
Closes #628