### PR TITLE
[#554] fix(auth): migrate password hashing from MD5 to BCrypt

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,12 +43,14 @@ public class UsuarioController {
     private final UsuarioRepository usuarioRepository;
     private final JwtTokenService jwtTokenService;
     private final MetricsUtil metricsUtil;
+    private final PasswordEncoder passwordEncoder;
 
     public UsuarioController(UsuarioRepository usuarioRepository, JwtTokenService jwtTokenService,
-                             MetricsUtil metricsUtil) {
+                             MetricsUtil metricsUtil, PasswordEncoder passwordEncoder) {
         this.usuarioRepository = usuarioRepository;
         this.jwtTokenService = jwtTokenService;
         this.metricsUtil = metricsUtil;
+        this.passwordEncoder = passwordEncoder;
     }
 
     record PersonaInfo(Integer idPersona, String nombre, String apellido) {}
@@ -117,7 +120,7 @@ public class UsuarioController {
             usuario.setTipo(request.tipo());
             usuario.setEstado(request.activo());
             String pwd = request.contrasenia();
-            usuario.setContrasenia(pwd != null && !pwd.isEmpty() ? encriptaEnMD5(pwd) : "");
+            usuario.setContrasenia(pwd != null && !pwd.isEmpty() ? passwordEncoder.encode(pwd) : "");
             usuario = usuarioRepository.save(usuario);
             return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(usuario));
         } catch (Exception e) {
@@ -144,7 +147,7 @@ public class UsuarioController {
             usuario.setEstado(request.activo());
             String pwd = request.contrasenia();
             if (pwd != null && !pwd.isEmpty()) {
-                usuario.setContrasenia(encriptaEnMD5(pwd));
+                usuario.setContrasenia(passwordEncoder.encode(pwd));
             }
             usuarioRepository.save(usuario);
             return ResponseEntity.ok().build();
@@ -186,14 +189,11 @@ public class UsuarioController {
                 return ResponseEntity.ok(errorResponse);
             }
 
-            String passwordIngresado = encriptaEnMD5(loginRequest.getContrasenia());
-            log.debug("Intento de login para usuario: '{}' (hash: '{}')", loginRequest.getNombre(), passwordIngresado);
+            log.debug("Intento de login para usuario: '{}'", loginRequest.getNombre());
 
             for (Usuario usuario : usuarios) {
-                log.debug("Comparando con usuario en DB: '{}' (estado: {}, hash_db: '{}')",
-                        usuario.getNombre(), usuario.getEstado(), usuario.getContrasenia());
                 if (usuario.getNombre().equalsIgnoreCase(loginRequest.getNombre())) {
-                    if (usuario.getContrasenia().equals(passwordIngresado)) {
+                    if (passwordMatches(loginRequest.getContrasenia(), usuario)) {
                         if (usuario.getEstado()) {
                             log.info("Login exitoso para usuario: '{}'", usuario.getNombre());
                             metricsUtil.incrementCounter("login", "success");
@@ -258,10 +258,34 @@ public class UsuarioController {
     }
 
     /**
-     * Encripta una cadena usando MD5
+     * Verifica la contraseña ingresada contra el hash almacenado, soportando tanto el
+     * nuevo formato BCrypt como el legado MD5 (issue #554). Si el hash almacenado
+     * todavía es MD5 y la contraseña coincide, se re-encripta en BCrypt y se persiste
+     * de forma transparente, migrando la credencial sin exigir un reseteo al usuario.
      */
-    private String encriptaEnMD5(String stringAEncriptar) {
-        char[] CONSTS_HEX = {
+    private boolean passwordMatches(String rawPassword, Usuario usuario) {
+        String storedHash = usuario.getContrasenia();
+        if (isBcryptHash(storedHash)) {
+            return passwordEncoder.matches(rawPassword, storedHash);
+        }
+        if (!legacyMd5Hash(rawPassword).equals(storedHash)) {
+            return false;
+        }
+        usuario.setContrasenia(passwordEncoder.encode(rawPassword));
+        usuarioRepository.save(usuario);
+        return true;
+    }
+
+    private boolean isBcryptHash(String hash) {
+        return hash != null && hash.startsWith("$2");
+    }
+
+    /**
+     * Hash MD5 legado, mantenido únicamente para verificar credenciales sembradas
+     * antes de la migración a BCrypt (issue #554); no se usa para generar hashes nuevos.
+     */
+    private String legacyMd5Hash(String stringAEncriptar) {
+        char[] hexChars = {
                 '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
         };
         try {
@@ -271,8 +295,8 @@ public class UsuarioController {
             for (int i = 0; i < bytes.length; i++) {
                 int bajo = (int) (bytes[i] & 0x0f);
                 int alto = (int) ((bytes[i] & 0xf0) >> 4);
-                strbCadenaMD5.append(CONSTS_HEX[alto]);
-                strbCadenaMD5.append(CONSTS_HEX[bajo]);
+                strbCadenaMD5.append(hexChars[alto]);
+                strbCadenaMD5.append(hexChars[bajo]);
             }
             return strbCadenaMD5.toString();
         } catch (NoSuchAlgorithmException e) {

--- a/backend-api/src/main/java/com/licensis/notaire/config/DataInitializer.java
+++ b/backend-api/src/main/java/com/licensis/notaire/config/DataInitializer.java
@@ -10,21 +10,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 
 /**
  * Siembra el usuario por defecto {@code admin}/{@code admin} una única vez, si no
  * existe ninguno.
  *
- * <p>La contraseña se almacena como hash MD5, coincidiendo con la verificación que
- * realiza {@code UsuarioController#login}. Es un seed de una sola vez: si el usuario
- * ya existe (sembrado por Flyway V2, o porque un operador ya rotó su contraseña) no
- * se toca — de lo contrario cualquier cambio de credenciales quedaría deshecho en
- * cada reinicio del backend (issue #553).</p>
+ * <p>La contraseña se almacena como hash BCrypt (issue #554), coincidiendo con la
+ * verificación que realiza {@code UsuarioController#login}. Es un seed de una sola
+ * vez: si el usuario ya existe (sembrado por Flyway V2, o porque un operador ya
+ * rotó su contraseña) no se toca — de lo contrario cualquier cambio de credenciales
+ * quedaría deshecho en cada reinicio del backend (issue #553).</p>
  */
 @Component
 public class DataInitializer implements ApplicationRunner {
@@ -36,13 +34,16 @@ public class DataInitializer implements ApplicationRunner {
     private final UsuarioRepository usuarioRepository;
     private final PersonaRepository personaRepository;
     private final TipoIdentificacionRepository tipoIdentificacionRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public DataInitializer(UsuarioRepository usuarioRepository,
                            PersonaRepository personaRepository,
-                           TipoIdentificacionRepository tipoIdentificacionRepository) {
+                           TipoIdentificacionRepository tipoIdentificacionRepository,
+                           PasswordEncoder passwordEncoder) {
         this.usuarioRepository = usuarioRepository;
         this.personaRepository = personaRepository;
         this.tipoIdentificacionRepository = tipoIdentificacionRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @Override
@@ -67,7 +68,7 @@ public class DataInitializer implements ApplicationRunner {
 
         Usuario admin = new Usuario();
         admin.setNombre(ADMIN_USER);
-        admin.setContrasenia(md5(ADMIN_PASS_PLAIN));
+        admin.setContrasenia(passwordEncoder.encode(ADMIN_PASS_PLAIN));
         admin.setEstado(true);
         admin.setTipo("Escribano");
         admin.setFkIdPersona(adminPersona);
@@ -95,17 +96,4 @@ public class DataInitializer implements ApplicationRunner {
         return tipoIdentificacionRepository.save(tipo);
     }
 
-    private static String md5(String input) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("MD5");
-            byte[] bytes = md.digest(input.getBytes());
-            StringBuilder sb = new StringBuilder(2 * bytes.length);
-            for (byte b : bytes) {
-                sb.append(String.format("%02x", b & 0xff));
-            }
-            return sb.toString();
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("MD5 no disponible en la JVM", e);
-        }
-    }
 }

--- a/backend-api/src/main/java/com/licensis/notaire/negocio/ControllerNegocio.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/ControllerNegocio.java
@@ -68,8 +68,6 @@ import com.licensis.notaire.jpa.exceptions.NonexistentJpaException;
 import com.licensis.notaire.jpa.exceptions.PreexistingEntityException;
 import com.licensis.notaire.service.AdministradorJpa;
 import com.licensis.notaire.service.AdministradorSesion;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -3736,83 +3734,6 @@ public class ControllerNegocio
 // <editor-fold defaultstate="collapsed" desc="Administracion">
     // <editor-fold defaultstate="collapsed" desc="Usuarios">
     /**
-     * Metodo que permite dar de alta un usuario
-     *
-     * @param dtoUsuario
-     * @return El dtoUsuario para confirmar el alta
-     */
-    public DtoUsuario darAltaUsuario(DtoUsuario dtoUsuario)
-    {
-        Usuario usuario = new Usuario();
-        List<Usuario> listaUsuarios = new ArrayList<>();
-        Boolean flag = false;
-        usuario.setAtributos(dtoUsuario);
-
-        //Encrypto la clave del usuario
-        String clave = usuario.getContrasenia();
-        usuario.setContrasenia(this.encriptaEnMD5(clave));
-
-        //Controlo que el nombre del usuario no se repita            
-        listaUsuarios = (ArrayList<Usuario>) miJpaUsuario.buscarUsuarios();
-
-        for (int i = 0; i < listaUsuarios.size(); i++)
-        {
-            if (listaUsuarios.get(i).getNombre().equals(dtoUsuario.getNombre()))
-            {
-                flag = true;
-            }
-        }
-
-        if (!flag)
-        {
-            try
-            {
-                miJpaUsuario.create(usuario);
-
-                this.registrarAuditoria(usuario, ConstantesGui.DAR_ALTA_USUARIO);
-            }
-            catch (Exception ex)
-            {
-                //  No se pudo crear el usuario.
-                Logger.getLogger(ControllerNegocio.class.getName()).log(Level.SEVERE, null, ex);
-            }
-        } else
-        {
-            dtoUsuario = null;
-        }
-
-        return dtoUsuario;
-    }
-
-    public String encriptaEnMD5(String stringAEncriptar)
-    {
-        {
-            char[] CONSTS_HEX =
-            {
-                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
-            };
-            try
-            {
-                MessageDigest msgd = MessageDigest.getInstance("MD5");
-                byte[] bytes = msgd.digest(stringAEncriptar.getBytes());
-                StringBuilder strbCadenaMD5 = new StringBuilder(2 * bytes.length);
-                for (int i = 0; i < bytes.length; i++)
-                {
-                    int bajo = (int) (bytes[i] & 0x0f);
-                    int alto = (int) ((bytes[i] & 0xf0) >> 4);
-                    strbCadenaMD5.append(CONSTS_HEX[alto]);
-                    strbCadenaMD5.append(CONSTS_HEX[bajo]);
-                }
-                return strbCadenaMD5.toString();
-            }
-            catch (NoSuchAlgorithmException e)
-            {
-                return null;
-            }
-        }
-    }
-
-    /**
      * Metodo que permite buscar un usuario
      *
      * @param dtoUsuario
@@ -3901,68 +3822,6 @@ public class ControllerNegocio
         }
 
         return listaDtoUsuarios;
-    }
-
-    /**
-     * Metodo que permite modificar un usuario del sistema
-     *
-     * @param miDtoUsuario
-     * @return El dtoUsuario para confirmar la modificacion.
-     */
-    public DtoUsuario modificarUsuario(DtoUsuario miDtoUsuario) throws ClassModifiedException, ClassEliminatedException
-    {
-
-        Usuario miUsuario = new Usuario();
-
-        ArrayList<Usuario> listaUsuarios = null;
-        Boolean flag = false;//Variable para controlar el resultado de la modificacion
-        int count = 0;
-
-        miUsuario.setContrasenia(miDtoUsuario.getContrasenia());
-        miUsuario.setEstado(miDtoUsuario.isEstado());
-        miUsuario.setNombre(miDtoUsuario.getNombre());
-        miUsuario.setTipo(miDtoUsuario.getTipo());
-        miUsuario.setIdUsuario(miDtoUsuario.getIdUsuario());
-        miUsuario.setVersion(miDtoUsuario.getVersion());
-
-        //Encrypto la clave del usuario
-        String clave = miUsuario.getContrasenia();
-        miUsuario.setContrasenia(this.encriptaEnMD5(clave));
-
-        //Controlo que el nombre del usuario no se repita
-        listaUsuarios = (ArrayList<Usuario>) miJpaUsuario.buscarUsuarios();
-
-        if (listaUsuarios != null)
-        {
-            for (int i = 0; i < listaUsuarios.size(); i++)
-            {
-                if (listaUsuarios.get(i).getNombre().equals(miDtoUsuario.getNombre()))
-                {
-                    count++; //El usuario puede repetirse una vez, que es el nombre actual.
-                }
-            }
-            if (count <= 1)
-            {
-
-                flag = miJpaUsuario.modificarUsuario(miUsuario);
-
-                if (flag)
-                {
-
-                    this.registrarAuditoria(miUsuario, ConstantesGui.MODIFICAR_USUARIO);
-                } else
-                {
-                    //  error al modificar usuario.
-                }
-            } else if (!flag)
-            {
-            } else if (!flag)
-            {
-                miDtoUsuario = null;
-            }
-        }
-        return miDtoUsuario;
-
     }
 
     /**

--- a/backend-api/src/main/java/com/licensis/notaire/service/AdministradorSesion.java
+++ b/backend-api/src/main/java/com/licensis/notaire/service/AdministradorSesion.java
@@ -1,20 +1,12 @@
 package com.licensis.notaire.service;
 
 import com.licensis.notaire.dto.DtoUsuario;
-import java.util.ArrayList;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import com.licensis.notaire.jpa.UsuarioJpaController;
-import com.licensis.notaire.jpa.exceptions.NonexistentJpaException;
-import com.licensis.notaire.jpa.interfaz.IPersistenciaJpa;
-import com.licensis.notaire.negocio.ControllerNegocio;
 import com.licensis.notaire.negocio.Usuario;
 
 public class AdministradorSesion
 {
 
     private static AdministradorSesion instancia = null;
-    private DtoUsuario usuarioLogueado = null;
     private DtoUsuario sesionUsuario;
 
     private AdministradorSesion()
@@ -28,62 +20,6 @@ public class AdministradorSesion
             instancia = new AdministradorSesion();
         }
         return instancia;
-    }
-
-    public void sesionIniciada(DtoUsuario miDtoUsuario)
-    {
-        this.setSesionUsuario(miDtoUsuario);
-    }
-
-    public DtoUsuario validarUsuario(DtoUsuario miDtoUsuario)
-    {
-
-        ArrayList<Usuario> listaUsuarios = new ArrayList<>();
-        Boolean flag = false;
-        String passWordUsuario;
-        String passWordIngresado;
-
-        miDtoUsuario.setValido(false);
-
-        try
-        {
-            IPersistenciaJpa miJpaUsuario = AdministradorJpa.getInstancia().obtenerJpa(UsuarioJpaController.class.getName());
-
-            listaUsuarios = (ArrayList<Usuario>) ((UsuarioJpaController) miJpaUsuario).buscarUsuarios();
-
-            if (!listaUsuarios.isEmpty() && (listaUsuarios != null))
-            {
-                for (int i = 0; i < listaUsuarios.size(); i++)
-                {
-                    if (listaUsuarios.get(i).getNombre().equals(miDtoUsuario.getNombre()))
-                    {
-
-                        passWordUsuario = listaUsuarios.get(i).getContrasenia();
-                        passWordIngresado = ControllerNegocio.getInstancia().encriptaEnMD5(miDtoUsuario.getContrasenia());
-
-                        if (passWordUsuario.equals(passWordIngresado) && listaUsuarios.get(i).getEstado())
-                        {
-                            flag = true;
-                            miDtoUsuario = listaUsuarios.get(i).getDto();
-                            miDtoUsuario.setValido(true);
-                            i = listaUsuarios.size();
-                            break;
-                        }
-
-                    }
-                }
-            } else
-            {
-                throw new NullPointerException("La lista de usuarios es nula");
-            }
-
-        }
-        catch (NonexistentJpaException ex)
-        {
-            Logger.getLogger(ControllerNegocio.class.getName()).log(Level.SEVERE, null, ex);
-        }
-        return miDtoUsuario;
-
     }
 
     public Usuario getSesionUsuario()

--- a/backend-api/src/test/java/com/licensis/notaire/unit/AdditionalControllersTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/AdditionalControllersTest.java
@@ -197,7 +197,8 @@ class AdditionalControllersTest {
             var jwtSvc = mock(com.licensis.notaire.config.JwtTokenService.class);
             when(jwtSvc.generateToken(any())).thenReturn("mock-jwt-token");
             var metrics = mock(com.licensis.notaire.observability.MetricsUtil.class);
-            var mvc = standaloneSetup(new UsuarioController(repo, jwtSvc, metrics)).build();
+            var passwordEncoder = mock(org.springframework.security.crypto.password.PasswordEncoder.class);
+            var mvc = standaloneSetup(new UsuarioController(repo, jwtSvc, metrics, passwordEncoder)).build();
             Usuario u = new Usuario(1, "admin", "abc", true, "Escribano");
 
             when(repo.findAll()).thenReturn(List.of(u));

--- a/backend-api/src/test/java/com/licensis/notaire/unit/DataInitializerTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/DataInitializerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.List;
 import java.util.Optional;
@@ -28,8 +29,7 @@ import static org.mockito.Mockito.when;
 @DisplayName("DataInitializer — usuario admin por defecto")
 class DataInitializerTest {
 
-    /** MD5("admin") — debe coincidir con la verificación de UsuarioController#login. */
-    private static final String MD5_ADMIN = "21232f297a57a5a743894a0e4a801fc3";
+    private static final String BCRYPT_ADMIN = "$2a$12$stub.bcrypt.hash.for.admin.password";
 
     @Mock
     private UsuarioRepository usuarioRepository;
@@ -37,12 +37,15 @@ class DataInitializerTest {
     private PersonaRepository personaRepository;
     @Mock
     private TipoIdentificacionRepository tipoIdentificacionRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     private DataInitializer dataInitializer;
 
     @BeforeEach
     void setUp() {
-        dataInitializer = new DataInitializer(usuarioRepository, personaRepository, tipoIdentificacionRepository);
+        dataInitializer = new DataInitializer(
+                usuarioRepository, personaRepository, tipoIdentificacionRepository, passwordEncoder);
     }
 
     @Test
@@ -63,12 +66,13 @@ class DataInitializerTest {
     }
 
     @Test
-    @DisplayName("Should create admin user with MD5 password when none exists")
+    @DisplayName("Should create admin user with BCrypt password when none exists")
     void shouldCreateAdminUserWhenNoneExists() {
         when(usuarioRepository.findByNombre("admin")).thenReturn(Optional.empty());
         TipoIdentificacion tipo = new TipoIdentificacion();
         tipo.setNombre("DNI");
         when(tipoIdentificacionRepository.findAll()).thenReturn(List.of(tipo));
+        when(passwordEncoder.encode("admin")).thenReturn(BCRYPT_ADMIN);
 
         dataInitializer.run(null);
 
@@ -77,7 +81,7 @@ class DataInitializerTest {
         verify(usuarioRepository).save(captor.capture());
         Usuario created = captor.getValue();
         assertThat(created.getNombre()).isEqualTo("admin");
-        assertThat(created.getContrasenia()).isEqualTo(MD5_ADMIN);
+        assertThat(created.getContrasenia()).isEqualTo(BCRYPT_ADMIN);
         assertThat(created.getEstado()).isTrue();
         assertThat(created.getFkIdPersona()).isNotNull();
     }

--- a/backend-api/src/test/java/com/licensis/notaire/unit/UsuarioControllerHashTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/UsuarioControllerHashTest.java
@@ -2,29 +2,158 @@ package com.licensis.notaire.unit;
 
 import com.licensis.notaire.api.UsuarioController;
 import com.licensis.notaire.config.JwtTokenService;
+import com.licensis.notaire.dto.DtoUsuario;
+import com.licensis.notaire.negocio.Usuario;
+import com.licensis.notaire.observability.MetricsUtil;
 import com.licensis.notaire.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
 
-import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UsuarioController — hashing de contraseñas (issue #554)")
 class UsuarioControllerHashTest {
 
+    private static final String LEGACY_MD5_ADMIN = "21232f297a57a5a743894a0e4a801fc3";
+    private static final String BCRYPT_HASH = "$2a$12$stub.bcrypt.hash.value.................";
+
+    @Mock
+    private UsuarioRepository usuarioRepository;
+    @Mock
+    private JwtTokenService jwtTokenService;
+    @Mock
+    private MetricsUtil metricsUtil;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private UsuarioController controller;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        controller = new UsuarioController(usuarioRepository, jwtTokenService, metricsUtil, passwordEncoder);
+        mockMvc = standaloneSetup(controller).build();
+    }
+
     @Test
-    void shouldGenerateMd5HashForPassword() throws Exception {
-        UsuarioController controller = new UsuarioController(
-                Mockito.mock(UsuarioRepository.class),
-                Mockito.mock(JwtTokenService.class),
-                Mockito.mock(com.licensis.notaire.observability.MetricsUtil.class));
-        Method method = UsuarioController.class.getDeclaredMethod("encriptaEnMD5", String.class);
-        method.setAccessible(true);
+    @DisplayName("createUsuario should store a BCrypt-encoded hash, not plaintext or MD5")
+    void createUsuarioShouldStoreBcryptHash() throws Exception {
+        when(passwordEncoder.encode("secret")).thenReturn(BCRYPT_HASH);
+        when(usuarioRepository.save(any(Usuario.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        String hashed = (String) method.invoke(controller, "admin");
+        mockMvc.perform(post("/api/v1/usuarios").contentType("application/json")
+                .content("{\"nombre\":\"juan\",\"contrasenia\":\"secret\",\"tipo\":\"Escribano\",\"activo\":true}"));
 
-        assertNotNull(hashed);
-        assertEquals("21232f297a57a5a743894a0e4a801fc3", hashed);
+        ArgumentCaptor<Usuario> captor = ArgumentCaptor.forClass(Usuario.class);
+        verify(usuarioRepository).save(captor.capture());
+        assertThat(captor.getValue().getContrasenia()).isEqualTo(BCRYPT_HASH);
+    }
+
+    @Test
+    @DisplayName("updateUsuario should store a BCrypt-encoded hash when password changes")
+    void updateUsuarioShouldStoreBcryptHash() throws Exception {
+        Usuario existing = new Usuario(1);
+        existing.setNombre("juan");
+        existing.setContrasenia(LEGACY_MD5_ADMIN);
+        when(usuarioRepository.findById(1)).thenReturn(Optional.of(existing));
+        when(passwordEncoder.encode("newpass")).thenReturn(BCRYPT_HASH);
+
+        mockMvc.perform(put("/api/v1/usuarios/1").contentType("application/json")
+                .content("{\"nombre\":\"juan\",\"contrasenia\":\"newpass\",\"tipo\":\"Escribano\",\"activo\":true}"));
+
+        assertThat(existing.getContrasenia()).isEqualTo(BCRYPT_HASH);
+        verify(usuarioRepository).save(existing);
+    }
+
+    @Test
+    @DisplayName("login should succeed for a user with a BCrypt-hashed password")
+    void loginShouldSucceedForBcryptHash() {
+        Usuario usuario = new Usuario(1);
+        usuario.setNombre("juan");
+        usuario.setContrasenia(BCRYPT_HASH);
+        usuario.setEstado(true);
+        usuario.setTipo("Escribano");
+        when(usuarioRepository.findAll()).thenReturn(List.of(usuario));
+        when(passwordEncoder.matches("secret", BCRYPT_HASH)).thenReturn(true);
+        when(jwtTokenService.generateToken("juan")).thenReturn("jwt-token");
+
+        DtoUsuario loginRequest = new DtoUsuario();
+        loginRequest.setNombre("juan");
+        loginRequest.setContrasenia("secret");
+
+        ResponseEntity<?> response = controller.login(loginRequest);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertThat(body).containsEntry("valido", true);
+        verify(usuarioRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("login should succeed for a legacy MD5 hash and transparently upgrade it to BCrypt")
+    void loginShouldUpgradeLegacyMd5HashOnSuccess() {
+        Usuario usuario = new Usuario(1);
+        usuario.setNombre("admin");
+        usuario.setContrasenia(LEGACY_MD5_ADMIN);
+        usuario.setEstado(true);
+        usuario.setTipo("Escribano");
+        when(usuarioRepository.findAll()).thenReturn(List.of(usuario));
+        when(passwordEncoder.encode("admin")).thenReturn(BCRYPT_HASH);
+        when(jwtTokenService.generateToken("admin")).thenReturn("jwt-token");
+
+        DtoUsuario loginRequest = new DtoUsuario();
+        loginRequest.setNombre("admin");
+        loginRequest.setContrasenia("admin");
+
+        ResponseEntity<?> response = controller.login(loginRequest);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertThat(body).containsEntry("valido", true);
+        assertThat(usuario.getContrasenia()).isEqualTo(BCRYPT_HASH);
+        verify(usuarioRepository).save(usuario);
+    }
+
+    @Test
+    @DisplayName("login should reject a wrong password regardless of stored hash format")
+    void loginShouldRejectWrongPassword() {
+        Usuario usuario = new Usuario(1);
+        usuario.setNombre("juan");
+        usuario.setContrasenia(BCRYPT_HASH);
+        usuario.setEstado(true);
+        when(usuarioRepository.findAll()).thenReturn(List.of(usuario));
+        when(passwordEncoder.matches(eq("wrong"), eq(BCRYPT_HASH))).thenReturn(false);
+
+        DtoUsuario loginRequest = new DtoUsuario();
+        loginRequest.setNombre("juan");
+        loginRequest.setContrasenia("wrong");
+
+        ResponseEntity<?> response = controller.login(loginRequest);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertThat(body).containsEntry("valido", false);
+        verify(usuarioRepository, never()).save(any());
     }
 }


### PR DESCRIPTION
## Summary
- Replaces unsalted MD5 password hashing with the existing `BCryptPasswordEncoder` bean across both live credential paths (`DataInitializer` admin seed, `UsuarioController` create/update/login).
- `login()` now verifies against either hash format and transparently upgrades a matching legacy MD5 hash to BCrypt on successful login, migrating existing credentials without forcing a reset.
- Deletes the third MD5 location cited in the issue (`ControllerNegocio.encriptaEnMD5`, `AdministradorSesion.validarUsuario`/`sesionIniciada`, `ControllerNegocio.darAltaUsuario`/`modificarUsuario`) — confirmed dead via exhaustive grep across `backend-api/src/main/java`, unreachable legacy-Swing-monolith code superseded by `UsuarioController`/`UsuarioJpaController`.

## Root cause
Passwords were hashed with unsalted MD5 in three duplicated locations, making stored credentials trivially crackable with database read access. A BCrypt bean already existed in `SecurityAndCorsConfig` but was unused for application passwords.

## Testing
- TDD: `DataInitializerTest` and `UsuarioControllerHashTest` updated/rewritten first, then production code changed to match.
- `UsuarioControllerHashTest` covers: create/update store BCrypt hashes, login succeeds for BCrypt hashes, login succeeds for legacy MD5 hashes **and** upgrades them to BCrypt + persists, wrong password rejected regardless of format.
- Full suite: 597 tests, 0 failures/errors (was 593 after #628; net +4 from the rewritten hash test class).
- `mvn checkstyle:check` clean.

## Issue Reference
Closes #554