### PR TITLE
[#631] fix(security): protect Usuario.contrasenia from Jackson serialization

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/negocio/Usuario.java
+++ b/backend-api/src/main/java/com/licensis/notaire/negocio/Usuario.java
@@ -10,6 +10,7 @@ import java.io.Serializable;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.Basic;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -109,6 +110,7 @@ public class Usuario implements Serializable {
         this.nombre = nombre;
     }
 
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     public String getContrasenia() {
         return contrasenia;
     }

--- a/backend-api/src/test/java/com/licensis/notaire/unit/UsuarioSerializationTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/UsuarioSerializationTest.java
@@ -1,0 +1,34 @@
+package com.licensis.notaire.unit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.licensis.notaire.negocio.Usuario;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@DisplayName("Usuario entity JSON serialization")
+class UsuarioSerializationTest {
+
+    @Test
+    @DisplayName("Should never include the password hash in serialized JSON (issue #631)")
+    void shouldNotSerializeContrasenia() throws Exception {
+        Usuario usuario = new Usuario(1, "admin", "5f4dcc3b5aa765d61d8327deb882cf99", true, "ADMIN");
+
+        String json = new ObjectMapper().writeValueAsString(usuario);
+
+        assertFalse(json.contains("contrasenia"), "Serialized Usuario must not contain the password field");
+        assertFalse(json.contains("5f4dcc3b5aa765d61d8327deb882cf99"),
+                "Serialized Usuario must not leak the password hash");
+    }
+
+    @Test
+    @DisplayName("Should still expose contrasenia to plain Java callers, e.g. login (getter not removed, only hidden from Jackson)")
+    void shouldStillExposeContraseniaViaGetter() {
+        Usuario usuario = new Usuario();
+        usuario.setContrasenia("5f4dcc3b5aa765d61d8327deb882cf99");
+
+        assertEquals("5f4dcc3b5aa765d61d8327deb882cf99", usuario.getContrasenia());
+    }
+}


### PR DESCRIPTION
## Summary
- Follow-up from #564. `Usuario.getContrasenia()` (the JPA entity, not `DtoUsuario`) had no `@JsonProperty`/`@JsonIgnore` protection — a latent trap for any future controller change that returns the entity directly.
- Added `@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)` to `Usuario.getContrasenia()`, mirroring the `DtoUsuario` fix from #564.

## Changes
### Modified
- `Usuario.java`: `getContrasenia()` annotated `@JsonProperty(access = WRITE_ONLY)` — still deserializes/settable, never serializes out.

### Added
- `UsuarioSerializationTest.java`: mirrors `DtoUsuarioSerializationTest` — asserts the entity never serializes `contrasenia`, and that the getter still works for plain Java callers (e.g. `UsuarioController.login()`, which reads `getContrasenia()` internally).

## Testing
- [x] Unit tests added (TDD: written first, confirmed RED via missing annotation, then GREEN)
- [x] Full backend suite: 1392 tests, 0 failures, 0 errors, 1 skipped
- [x] Confirmed via full-suite run that login flow (`UsuarioController` tests) is unaffected — the getter is still readable from Java, only Jackson serialization is blocked
- [x] checkstyle/spotbugs: no new violations in `Usuario.java`

## Verified exposure before the fix
- `UsuarioController` (`getAllUsuarios`, `getUsuarioByPersona`, `getUsuarioById`) maps to a nested `UsuarioResponse` record with no `contrasenia` field — was already safe.
- `RolController` returns `Map.of(...)` or `ResponseEntity<Void>`, never the raw entity — was already safe.
- So this was not currently exploitable, but is now hardened against future regressions (defense-in-depth, same reasoning as #564).

## Documentation
- No API contract change; no docs update needed.

## Checklist
- [x] Code follows project conventions
- [x] No hardcoded credentials
- [x] No dead code
- [x] No TODO comments left
- [x] KIS and SRP applied

## Issue Reference
Fixes #631