### PR TITLE
[#608] a11y(frontend): add aria-label to search inputs on 9 pages

### DIFF
--- a/frontend/src/app/dashboard/administracion/conceptos/page.tsx
+++ b/frontend/src/app/dashboard/administracion/conceptos/page.tsx
@@ -121,6 +121,7 @@ export default function ConceptosPage() {
       <div className="px-4 pb-4">
         <Input
           placeholder={t("searchPlaceholder")}
+          aria-label={t("searchPlaceholder")}
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="w-64"

--- a/frontend/src/app/dashboard/administracion/documentos/page.tsx
+++ b/frontend/src/app/dashboard/administracion/documentos/page.tsx
@@ -134,6 +134,7 @@ export default function DocumentosPage() {
       <div className="mb-4">
         <Input
           placeholder={t("searchPlaceholder")}
+          aria-label={t("searchPlaceholder")}
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="max-w-sm"

--- a/frontend/src/app/dashboard/administracion/estados-gestion/page.tsx
+++ b/frontend/src/app/dashboard/administracion/estados-gestion/page.tsx
@@ -157,6 +157,7 @@ export default function EstadosGestionPage() {
       <div className="mb-4">
         <Input
           placeholder={t("searchPlaceholder")}
+          aria-label={t("searchPlaceholder")}
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="max-w-sm"

--- a/frontend/src/app/dashboard/administracion/tramites/page.tsx
+++ b/frontend/src/app/dashboard/administracion/tramites/page.tsx
@@ -135,6 +135,7 @@ export default function TramitesPage() {
       <div className="mb-4">
         <Input
           placeholder={t("searchPlaceholder")}
+          aria-label={t("searchPlaceholder")}
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="max-w-sm"

--- a/frontend/src/app/dashboard/administracion/workflows/page.tsx
+++ b/frontend/src/app/dashboard/administracion/workflows/page.tsx
@@ -136,6 +136,7 @@ export default function WorkflowsPage() {
       <div className="mb-4">
         <Input
           placeholder="Buscar por nombre..."
+          aria-label="Buscar por nombre..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="max-w-sm"

--- a/frontend/src/app/dashboard/auditoria/page.tsx
+++ b/frontend/src/app/dashboard/auditoria/page.tsx
@@ -88,6 +88,7 @@ export default function AuditoriaPage() {
           <Input
             className="pl-10"
             placeholder={t("searchPlaceholder")}
+            aria-label={t("searchPlaceholder")}
             value={search}
             onChange={(e) => setSearch(e.target.value)}
           />

--- a/frontend/src/app/dashboard/escrituras/page.tsx
+++ b/frontend/src/app/dashboard/escrituras/page.tsx
@@ -97,6 +97,7 @@ export default function EscriturasPage() {
       <div className="px-4 pb-4">
         <Input
           placeholder={t("searchPlaceholder")}
+          aria-label={t("searchPlaceholder")}
           value={searchNumero}
           onChange={(e) => setSearchNumero(e.target.value)}
           className="w-48"

--- a/frontend/src/app/dashboard/personas/page.tsx
+++ b/frontend/src/app/dashboard/personas/page.tsx
@@ -177,6 +177,7 @@ export default function PersonasPage() {
       <div data-testid="search-bar" className="flex flex-wrap gap-3 px-4 pb-4">
         <Input
           placeholder={t("searchPlaceholders.nombre")}
+          aria-label={t("searchPlaceholders.nombre")}
           value={searchNombre}
           onChange={(e) => setSearchNombre(e.target.value)}
           data-testid="input-search-nombre"
@@ -184,6 +185,7 @@ export default function PersonasPage() {
         />
         <Input
           placeholder={t("searchPlaceholders.apellido")}
+          aria-label={t("searchPlaceholders.apellido")}
           value={searchApellido}
           onChange={(e) => setSearchApellido(e.target.value)}
           data-testid="input-search-apellido"
@@ -191,6 +193,7 @@ export default function PersonasPage() {
         />
         <Input
           placeholder={t("searchPlaceholders.dni")}
+          aria-label={t("searchPlaceholders.dni")}
           value={searchDni}
           onChange={(e) => setSearchDni(e.target.value)}
           data-testid="input-search-dni"

--- a/frontend/src/app/dashboard/presupuestos/page.tsx
+++ b/frontend/src/app/dashboard/presupuestos/page.tsx
@@ -162,6 +162,7 @@ export default function PresupuestosPage() {
       <div className="flex flex-wrap gap-3 px-4 pb-4">
         <Input
           placeholder={t("searchPlaceholder")}
+          aria-label={t("searchPlaceholder")}
           value={searchPresupuesto}
           onChange={(e) => setSearchPresupuesto(e.target.value)}
           data-testid="input-search-presupuesto"

--- a/frontend/tests/e2e/a11y-search-inputs.spec.ts
+++ b/frontend/tests/e2e/a11y-search-inputs.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Playwright E2E tests — search inputs must be reachable by accessible label.
+ * Issue #608: 9 pages rendered search <Input>s with placeholder as the only
+ * label, failing WCAG label-association for screen-reader users.
+ */
+import { test, expect } from "@playwright/test";
+
+const adminAuthSetup = async (page: import("@playwright/test").Page) => {
+  await page.context().addCookies([
+    {
+      name: "notaire-auth-status",
+      value: "authenticated",
+      domain: "localhost",
+      path: "/",
+    },
+  ]);
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "notaire-auth",
+      JSON.stringify({
+        state: {
+          user: { nombre: "admin", tipo: "ADMIN", valido: true },
+          isAuthenticated: true,
+        },
+        version: 0,
+      })
+    );
+  });
+};
+
+test.describe("Search inputs expose an accessible label (#608)", () => {
+  test.beforeEach(async ({ page }) => {
+    await adminAuthSetup(page);
+  });
+
+  test("personas page search inputs are labeled", async ({ page }) => {
+    await page.goto("/dashboard/personas");
+    await expect(page.getByLabel("Buscar por nombre...", { exact: true })).toBeVisible();
+    await expect(page.getByLabel("Buscar por apellido...", { exact: true })).toBeVisible();
+    await expect(page.getByLabel("Buscar por DNI...", { exact: true })).toBeVisible();
+  });
+
+  test("escrituras page search input is labeled", async ({ page }) => {
+    await page.goto("/dashboard/escrituras");
+    await expect(page.getByLabel("Buscar por número...", { exact: true })).toBeVisible();
+  });
+
+  test("presupuestos page search input is labeled", async ({ page }) => {
+    await page.goto("/dashboard/presupuestos");
+    await expect(page.getByLabel("Buscar por ID o cliente...", { exact: true })).toBeVisible();
+  });
+
+  test("auditoria page search input is labeled", async ({ page }) => {
+    await page.goto("/dashboard/auditoria");
+    await expect(page.getByLabel("Buscar por usuario u operación...", { exact: true })).toBeVisible();
+  });
+
+  test("administracion/workflows page search input is labeled", async ({ page }) => {
+    await page.goto("/dashboard/administracion/workflows");
+    await expect(page.getByLabel("Buscar por nombre...", { exact: true })).toBeVisible();
+  });
+
+  test("administracion/tramites page search input is labeled", async ({ page }) => {
+    await page.goto("/dashboard/administracion/tramites");
+    await expect(page.getByLabel("Buscar por nombre...", { exact: true })).toBeVisible();
+  });
+
+  test("administracion/conceptos page search input is labeled", async ({ page }) => {
+    await page.goto("/dashboard/administracion/conceptos");
+    await expect(page.getByLabel("Buscar por nombre...", { exact: true })).toBeVisible();
+  });
+
+  test("administracion/documentos page search input is labeled", async ({ page }) => {
+    await page.goto("/dashboard/administracion/documentos");
+    await expect(page.getByLabel("Buscar por nombre...", { exact: true })).toBeVisible();
+  });
+
+  test("administracion/estados-gestion page search input is labeled", async ({ page }) => {
+    await page.goto("/dashboard/administracion/estados-gestion");
+    await expect(page.getByLabel("Buscar por nombre...", { exact: true })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- 9 pages (personas, escrituras, presupuestos, administracion/workflows, auditoria, administracion/tramites, administracion/conceptos, administracion/documentos, administracion/estados-gestion) rendered search `<Input>`s with placeholder text as their only label, failing WCAG label-association for screen readers and violating the project's own "never use placeholder as label" rule in `.claude/rules/ui-ux-design.md`.
- Added `aria-label` mirroring each input's existing placeholder text (reusing translation keys already in use — no new i18n keys needed).
- New Playwright spec `tests/e2e/a11y-search-inputs.spec.ts` asserts every search input is reachable via `page.getByLabel()`, which only matches `<label>`/`aria-label` (not placeholder) — giving a genuine RED before the fix and GREEN after.

## Testing
- [x] New E2E test added (9 cases, one per page) — RED confirmed before fix, GREEN after
- [x] Frontend unit suite: 211/211 pass
- [x] `tsc --noEmit`: no new errors (4 pre-existing errors unrelated to this change)

## Issue Reference
Closes #608