### PR TITLE
[#613] fix(a11y): WorkflowViewer node colors from theme + state icons

### DIFF
--- a/frontend/src/components/shared/WorkflowViewer.tsx
+++ b/frontend/src/components/shared/WorkflowViewer.tsx
@@ -9,25 +9,42 @@ import {
   type Edge,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import { theme } from "@/theme/tokens";
 import type { WorkflowNode, WorkflowTransition } from "@/types";
 
-const NODE_COLORS: Record<string, { background: string; border: string; color: string }> = {
-  INITIAL: { background: "#dcfce7", border: "#16a34a", color: "#15803d" },
-  INTERMEDIATE: { background: "#dbeafe", border: "#2563eb", color: "#1d4ed8" },
-  FINAL: { background: "#fee2e2", border: "#dc2626", color: "#b91c1c" },
+const NODE_META: Record<string, { background: string; border: string; color: string; icon: string }> = {
+  INITIAL: {
+    background: theme.colors.success[50],
+    border: theme.colors.success[500],
+    color: theme.colors.success[600],
+    icon: "▶",
+  },
+  INTERMEDIATE: {
+    background: theme.colors.primary[50],
+    border: theme.colors.primary[500],
+    color: theme.colors.primary[700],
+    icon: "●",
+  },
+  FINAL: {
+    background: theme.colors.error[50],
+    border: theme.colors.error[500],
+    color: theme.colors.error[600],
+    icon: "■",
+  },
 };
 
-function toFlowNodes(nodes: WorkflowNode[]): Node[] {
+export function toFlowNodes(nodes: WorkflowNode[]): Node[] {
   return nodes.map((n) => {
-    const colors = NODE_COLORS[n.tipo ?? "INTERMEDIATE"];
+    const meta = NODE_META[n.tipo ?? "INTERMEDIATE"];
+    const label = `${meta.icon} ${n.estadoGestionNombre ?? `Nodo ${n.id}`}`;
     return {
       id: String(n.id),
       position: { x: n.posicionX ?? 0, y: n.posicionY ?? 0 },
-      data: { label: n.estadoGestionNombre ?? `Nodo ${n.id}` },
+      data: { label },
       style: {
-        background: colors.background,
-        border: `2px solid ${colors.border}`,
-        color: colors.color,
+        background: meta.background,
+        border: `2px solid ${meta.border}`,
+        color: meta.color,
         borderRadius: "8px",
         padding: "8px 16px",
         fontWeight: 600,
@@ -39,14 +56,14 @@ function toFlowNodes(nodes: WorkflowNode[]): Node[] {
   });
 }
 
-function toFlowEdges(transitions: WorkflowTransition[]): Edge[] {
+export function toFlowEdges(transitions: WorkflowTransition[]): Edge[] {
   return transitions.map((t) => ({
     id: String(t.id),
     source: String(t.nodoOrigenId),
     target: String(t.nodoDestinoId),
     label: t.descripcion ?? undefined,
     animated: false,
-    style: { stroke: "#94a3b8" },
+    style: { stroke: theme.colors.neutral[500] },
   }));
 }
 
@@ -72,7 +89,11 @@ export function WorkflowViewer({ nodes, transitions, "data-testid": testId }: Wo
   }
 
   return (
-    <div style={{ height: 440 }} className="rounded-xl border border-neutral-200 overflow-hidden" data-testid={testId}>
+    <div
+      style={{ height: theme.sizes.workflowViewer.height }}
+      className="rounded-xl border border-neutral-200 overflow-hidden"
+      data-testid={testId}
+    >
       <ReactFlow
         nodes={flowNodes}
         edges={flowEdges}
@@ -85,7 +106,7 @@ export function WorkflowViewer({ nodes, transitions, "data-testid": testId }: Wo
         <Controls showInteractive={false} />
         <MiniMap nodeColor={(n) => {
           const tipo = nodes.find((wn) => String(wn.id) === n.id)?.tipo ?? "INTERMEDIATE";
-          return NODE_COLORS[tipo]?.border ?? "#94a3b8";
+          return NODE_META[tipo]?.border ?? theme.colors.neutral[500];
         }} />
       </ReactFlow>
     </div>

--- a/frontend/src/tests/unit/workflow-viewer.test.tsx
+++ b/frontend/src/tests/unit/workflow-viewer.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { theme } from "@/theme/tokens";
+import { WorkflowViewer, toFlowNodes, toFlowEdges } from "@/components/shared/WorkflowViewer";
+import type { WorkflowNode, WorkflowTransition } from "@/types";
+
+const node = (id: number, tipo: string): WorkflowNode => ({
+  id,
+  estadoGestionNombre: `Estado ${id}`,
+  tipo,
+  posicionX: 0,
+  posicionY: 0,
+} as WorkflowNode);
+
+describe("WorkflowViewer node styling (#613)", () => {
+  it("sources node colors from theme tokens, not hardcoded hex values", () => {
+    const [initial, intermediate, final] = toFlowNodes([
+      node(1, "INITIAL"),
+      node(2, "INTERMEDIATE"),
+      node(3, "FINAL"),
+    ]);
+
+    expect(initial.style?.background).toBe(theme.colors.success[50]);
+    expect(initial.style?.border).toContain(theme.colors.success[500]);
+
+    expect(intermediate.style?.background).toBe(theme.colors.primary[50]);
+    expect(intermediate.style?.border).toContain(theme.colors.primary[500]);
+
+    expect(final.style?.background).toBe(theme.colors.error[50]);
+    expect(final.style?.border).toContain(theme.colors.error[500]);
+  });
+
+  it("differentiates node state with a text/icon badge, not color alone", () => {
+    const [initial, intermediate, final] = toFlowNodes([
+      node(1, "INITIAL"),
+      node(2, "INTERMEDIATE"),
+      node(3, "FINAL"),
+    ]);
+
+    const initialLabel = String((initial.data as { label: string }).label);
+    const intermediateLabel = String((intermediate.data as { label: string }).label);
+    const finalLabel = String((final.data as { label: string }).label);
+
+    expect(initialLabel).not.toBe("Estado 1");
+    expect(finalLabel).not.toBe("Estado 3");
+    expect(initialLabel).not.toBe(intermediateLabel.replace("Estado 2", "Estado 1"));
+    expect(initialLabel.charAt(0)).not.toBe(finalLabel.charAt(0));
+    expect(initialLabel.charAt(0)).not.toBe(intermediateLabel.charAt(0));
+  });
+
+  it("sources the edge stroke color from theme tokens", () => {
+    const transition: WorkflowTransition = {
+      id: 1,
+      nodoOrigenId: 1,
+      nodoDestinoId: 2,
+      descripcion: "next",
+    } as WorkflowTransition;
+
+    const [edge] = toFlowEdges([transition]);
+    expect(edge.style?.stroke).toBe(theme.colors.neutral[500]);
+  });
+
+  it("renders the empty state without any nodes", () => {
+    render(<WorkflowViewer nodes={[]} transitions={[]} data-testid="wf-viewer" />);
+    expect(screen.getByTestId("wf-viewer")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/theme/tokens.ts
+++ b/frontend/src/theme/tokens.ts
@@ -227,6 +227,9 @@ export const sizes = {
     padding: spacing[8],
     gap: spacing[4],
   },
+  workflowViewer: {
+    height: "27.5rem", // 440px
+  },
 } as const;
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- `WorkflowViewer.tsx`'s `NODE_COLORS` hardcoded 9 raw hex values and used color alone to differentiate INITIAL/INTERMEDIATE/FINAL workflow node states, violating the "never use color alone" WCAG rule in `.claude/rules/ui-ux-design.md`.
- The viewer's container height (`440`) was a magic number instead of a theme token.

## Changes
### Added
- `theme.sizes.workflowViewer.height` token (440px / 27.5rem).
- `▶`/`●`/`■` icon prefix per node type in `toFlowNodes`, so state is distinguishable without relying on color.
- `frontend/src/tests/unit/workflow-viewer.test.tsx` — unit tests for the (now exported) `toFlowNodes`/`toFlowEdges` pure functions plus the empty-state render.

### Modified
- `NODE_COLORS` → `NODE_META`, sourced from `theme.colors.success/primary/error` instead of raw hex.
- Edge stroke and MiniMap node color now use `theme.colors.neutral[500]`.

## Testing
- [x] Unit tests added (4 new, TDD RED confirmed before implementation)
- [x] Full frontend unit suite: 215/215 green
- [x] `tsc --noEmit`: only 4 pre-existing, unrelated errors in `pages.test.tsx` (tracked separately)

## Follow-up
Filed #646 — the workflow *editor* page (`administracion/workflows/[id]/page.tsx`) has the identical hardcoded-color pattern in a separate component; left out of scope here to keep this PR to a single file/component.

Closes #613