### PR TITLE
[#646] fix(a11y): extract shared workflow node meta, remove duplicate color-only pattern

### DIFF
--- a/frontend/src/app/dashboard/administracion/workflows/[id]/page.tsx
+++ b/frontend/src/app/dashboard/administracion/workflows/[id]/page.tsx
@@ -35,21 +35,17 @@ import {
 import { apiPost } from "@/lib/api-client";
 import type { WorkflowNodeType } from "@/types";
 import { useEstadosGestion } from "@/hooks/useEstadosGestion";
-
-const NODE_COLORS: Record<string, { bg: string; border: string; text: string }> = {
-  INITIAL: { bg: "#dcfce7", border: "#16a34a", text: "#15803d" },
-  INTERMEDIATE: { bg: "#dbeafe", border: "#2563eb", text: "#1d4ed8" },
-  FINAL: { bg: "#fee2e2", border: "#dc2626", text: "#b91c1c" },
-};
+import { theme } from "@/theme/tokens";
+import { getNodeMeta, withNodeIcon } from "@/lib/workflow-node-meta";
 
 function WorkflowNodeComponent({ data }: { data: { label: string; tipo: string } }) {
-  const colors = NODE_COLORS[data.tipo] ?? NODE_COLORS.INTERMEDIATE;
+  const meta = getNodeMeta(data.tipo);
   return (
     <div
       style={{
-        background: colors.bg,
-        border: `2px solid ${colors.border}`,
-        color: colors.text,
+        background: meta.background,
+        border: `2px solid ${meta.border}`,
+        color: meta.color,
         borderRadius: "8px",
         padding: "8px 16px",
         fontWeight: 600,
@@ -94,7 +90,10 @@ export default function WorkflowEditorPage() {
     id: String(n.id),
     type: "workflowNode",
     position: { x: n.posicionX ?? 0, y: n.posicionY ?? 0 },
-    data: { label: n.estadoGestionNombre ?? `Nodo ${n.id}`, tipo: n.tipo ?? "INTERMEDIATE" },
+    data: {
+      label: withNodeIcon(n.estadoGestionNombre ?? `Nodo ${n.id}`, n.tipo ?? "INTERMEDIATE"),
+      tipo: n.tipo ?? "INTERMEDIATE",
+    },
   }));
 
   const flowEdges: Edge[] = rawTransitions.map((t) => ({
@@ -103,7 +102,7 @@ export default function WorkflowEditorPage() {
     target: String(t.nodoDestinoId),
     label: t.descripcion ?? undefined,
     animated: false,
-    style: { stroke: "#94a3b8" },
+    style: { stroke: theme.colors.neutral[500] },
   }));
 
   const [nodes, , onNodesChange] = useNodesState(flowNodes);
@@ -248,7 +247,11 @@ export default function WorkflowEditorPage() {
         <span className="flex items-center gap-1"><span className="w-3 h-3 rounded-full bg-red-200 border border-red-600 inline-block" />Final</span>
       </div>
 
-      <div style={{ height: 520 }} className="rounded-xl border border-neutral-200 overflow-hidden" data-testid="workflow-editor">
+      <div
+        style={{ height: theme.sizes.workflowEditor.height }}
+        className="rounded-xl border border-neutral-200 overflow-hidden"
+        data-testid="workflow-editor"
+      >
         <ReactFlow
           nodes={nodes}
           edges={edges}

--- a/frontend/src/components/shared/WorkflowViewer.tsx
+++ b/frontend/src/components/shared/WorkflowViewer.tsx
@@ -10,33 +10,13 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { theme } from "@/theme/tokens";
+import { NODE_META, getNodeMeta, withNodeIcon } from "@/lib/workflow-node-meta";
 import type { WorkflowNode, WorkflowTransition } from "@/types";
-
-const NODE_META: Record<string, { background: string; border: string; color: string; icon: string }> = {
-  INITIAL: {
-    background: theme.colors.success[50],
-    border: theme.colors.success[500],
-    color: theme.colors.success[600],
-    icon: "▶",
-  },
-  INTERMEDIATE: {
-    background: theme.colors.primary[50],
-    border: theme.colors.primary[500],
-    color: theme.colors.primary[700],
-    icon: "●",
-  },
-  FINAL: {
-    background: theme.colors.error[50],
-    border: theme.colors.error[500],
-    color: theme.colors.error[600],
-    icon: "■",
-  },
-};
 
 export function toFlowNodes(nodes: WorkflowNode[]): Node[] {
   return nodes.map((n) => {
-    const meta = NODE_META[n.tipo ?? "INTERMEDIATE"];
-    const label = `${meta.icon} ${n.estadoGestionNombre ?? `Nodo ${n.id}`}`;
+    const meta = getNodeMeta(n.tipo);
+    const label = withNodeIcon(n.estadoGestionNombre ?? `Nodo ${n.id}`, n.tipo);
     return {
       id: String(n.id),
       position: { x: n.posicionX ?? 0, y: n.posicionY ?? 0 },

--- a/frontend/src/lib/workflow-node-meta.ts
+++ b/frontend/src/lib/workflow-node-meta.ts
@@ -1,0 +1,37 @@
+import { theme } from "@/theme/tokens";
+
+export interface WorkflowNodeMeta {
+  background: string;
+  border: string;
+  color: string;
+  icon: string;
+}
+
+export const NODE_META: Record<string, WorkflowNodeMeta> = {
+  INITIAL: {
+    background: theme.colors.success[50],
+    border: theme.colors.success[500],
+    color: theme.colors.success[600],
+    icon: "▶",
+  },
+  INTERMEDIATE: {
+    background: theme.colors.primary[50],
+    border: theme.colors.primary[500],
+    color: theme.colors.primary[700],
+    icon: "●",
+  },
+  FINAL: {
+    background: theme.colors.error[50],
+    border: theme.colors.error[500],
+    color: theme.colors.error[600],
+    icon: "■",
+  },
+};
+
+export function getNodeMeta(tipo?: string): WorkflowNodeMeta {
+  return NODE_META[tipo ?? "INTERMEDIATE"] ?? NODE_META.INTERMEDIATE;
+}
+
+export function withNodeIcon(label: string, tipo?: string): string {
+  return `${getNodeMeta(tipo).icon} ${label}`;
+}

--- a/frontend/src/tests/unit/workflow-node-meta.test.ts
+++ b/frontend/src/tests/unit/workflow-node-meta.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { theme } from "@/theme/tokens";
+import { NODE_META, getNodeMeta, withNodeIcon } from "@/lib/workflow-node-meta";
+
+describe("workflow node meta (#646)", () => {
+  it("sources every node type's colors from theme tokens, not hardcoded hex", () => {
+    expect(NODE_META.INITIAL.background).toBe(theme.colors.success[50]);
+    expect(NODE_META.INITIAL.border).toBe(theme.colors.success[500]);
+
+    expect(NODE_META.INTERMEDIATE.background).toBe(theme.colors.primary[50]);
+    expect(NODE_META.INTERMEDIATE.border).toBe(theme.colors.primary[500]);
+
+    expect(NODE_META.FINAL.background).toBe(theme.colors.error[50]);
+    expect(NODE_META.FINAL.border).toBe(theme.colors.error[500]);
+  });
+
+  it("falls back to INTERMEDIATE meta for an unknown or missing tipo", () => {
+    expect(getNodeMeta(undefined)).toBe(NODE_META.INTERMEDIATE);
+    expect(getNodeMeta("SOMETHING_ELSE")).toBe(NODE_META.INTERMEDIATE);
+  });
+
+  it("differentiates each node type with a distinct icon, not color alone", () => {
+    const icons = new Set([NODE_META.INITIAL.icon, NODE_META.INTERMEDIATE.icon, NODE_META.FINAL.icon]);
+    expect(icons.size).toBe(3);
+  });
+
+  it("prefixes a label with the type's icon", () => {
+    expect(withNodeIcon("Borrador", "INITIAL")).toBe(`${NODE_META.INITIAL.icon} Borrador`);
+    expect(withNodeIcon("Firmado", "FINAL")).toBe(`${NODE_META.FINAL.icon} Firmado`);
+  });
+});

--- a/frontend/src/theme/tokens.ts
+++ b/frontend/src/theme/tokens.ts
@@ -230,6 +230,9 @@ export const sizes = {
   workflowViewer: {
     height: "27.5rem", // 440px
   },
+  workflowEditor: {
+    height: "32.5rem", // 520px
+  },
 } as const;
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- WorkflowNodeComponent in the workflow editor page duplicated the same color-only/hardcoded-hex pattern already fixed in `WorkflowViewer.tsx` for #613.
- Extracted `NODE_META` / `getNodeMeta` / `withNodeIcon` into a shared `frontend/src/lib/workflow-node-meta.ts` module, now consumed by both `WorkflowViewer.tsx` and the workflow editor page — so the two can no longer drift out of sync.
- Node labels in the editor now get the same ▶/●/■ icon prefix so state is never conveyed by color alone.
- Replaced the editor's remaining hardcoded edge-stroke hex and 520px magic-number height with theme tokens (new `theme.sizes.workflowEditor.height`).

## Testing
- [x] Unit tests added: `frontend/src/tests/unit/workflow-node-meta.test.ts` (4 tests, TDD RED confirmed before extracting the module, GREEN after)
- [x] Full frontend unit suite: 219/219 passing
- [x] `tsc --noEmit`: no new errors (4 pre-existing, unrelated `pages.test.tsx` errors confirmed present on main before this change too)
- [x] `next lint` on touched files: clean

## Documentation
- No architecture/ADR-level change — internal refactor consolidating a duplicated UI pattern into a shared module, consistent with #613's fix.

## Checklist
- [x] Code follows project conventions (theme tokens, no hardcoded colors)
- [x] No hardcoded credentials
- [x] No dead code (old `NODE_COLORS` map removed entirely)
- [x] No TODO comments left
- [x] KIS and SRP applied — DRY fix removes the duplication at its root instead of re-patching it twice

## Issue Reference
Fixes #646