### PR TITLE
[#593] test(quality): re-enable undocumented @Disabled integration test

### DIFF
--- a/backend-api/src/test/java/com/licensis/notaire/integration/ApiH2IntegrationTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/ApiH2IntegrationTest.java
@@ -1,6 +1,5 @@
 package com.licensis.notaire.integration;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -44,7 +43,6 @@ class ApiH2IntegrationTest {
     }
 
     @Test
-    @Disabled("Pending fix for lazy loading in JSON serialization")
     void shouldExposeCoreCatalogEndpoints() throws Exception {
         mockMvc.perform(get("/api/v1/conceptos"))
                 .andExpect(status().isOk());


### PR DESCRIPTION
## Summary
- `ApiH2IntegrationTest.shouldExposeCoreCatalogEndpoints` was `@Disabled("Pending fix for lazy loading in JSON serialization")` with no linked issue, violating the project's disabled-test policy.
- Confirmed the underlying lazy-loading/JSON-serialization bug no longer reproduces (already fixed by prior JPA/serialization work — see recent MD5→BCrypt/actuator/audit security PRs). Removed the `@Disabled` annotation and unused import; the test now passes cleanly.
- Repo-wide grep confirms this was the only undocumented `@Disabled` test — no other instances found in `backend-api` or `frontend`.

## Testing
- [x] `mvn test -pl backend-api -Dtest=ApiH2IntegrationTest`: 2/2 passing (previously 1 run + 1 skipped)
- [x] Full backend suite: `mvn test -pl backend-api` — 1392/1392 passing, 0 skipped
- [x] No new tests needed — this re-enables an existing test rather than adding new coverage

## Documentation
- No architecture/ADR-level change.

## Checklist
- [x] Code follows project conventions
- [x] No hardcoded credentials
- [x] No dead code
- [x] No TODO comments left
- [x] KIS and SRP applied

## Issue Reference
Fixes #593