### PR TITLE
fix(config): fail fast on default admin credentials in production

### DIFF
--- a/backend-api/src/main/java/com/licensis/notaire/config/ProductionCredentialsGuard.java
+++ b/backend-api/src/main/java/com/licensis/notaire/config/ProductionCredentialsGuard.java
@@ -1,0 +1,55 @@
+package com.licensis.notaire.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class ProductionCredentialsGuard {
+
+    private static final String PRODUCTION_ENVIRONMENT = "production";
+    private static final String INSECURE_DEFAULT_VALUE = "admin";
+
+    @Value("${app.environment:development}")
+    private String environment;
+
+    @Value("${spring.datasource.username}")
+    private String datasourceUsername;
+
+    @Value("${spring.datasource.password}")
+    private String datasourcePassword;
+
+    @Value("${actuator.security.username}")
+    private String actuatorUsername;
+
+    @Value("${actuator.security.password}")
+    private String actuatorPassword;
+
+    @PostConstruct
+    public void validateCredentials() {
+        if (!PRODUCTION_ENVIRONMENT.equalsIgnoreCase(environment)) {
+            return;
+        }
+
+        List<String> insecureProperties = new ArrayList<>();
+        addIfDefault(insecureProperties, "spring.datasource.username", datasourceUsername);
+        addIfDefault(insecureProperties, "spring.datasource.password", datasourcePassword);
+        addIfDefault(insecureProperties, "actuator.security.username", actuatorUsername);
+        addIfDefault(insecureProperties, "actuator.security.password", actuatorPassword);
+
+        if (!insecureProperties.isEmpty()) {
+            throw new IllegalStateException(
+                    "Credenciales inseguras detectadas en producción: " + String.join(", ", insecureProperties)
+                    + ". Configurá valores propios antes de iniciar la aplicación en este entorno.");
+        }
+    }
+
+    private void addIfDefault(List<String> insecureProperties, String propertyName, String value) {
+        if (INSECURE_DEFAULT_VALUE.equals(value)) {
+            insecureProperties.add(propertyName);
+        }
+    }
+}

--- a/backend-api/src/test/java/com/licensis/notaire/unit/ProductionCredentialsGuardTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/ProductionCredentialsGuardTest.java
@@ -1,0 +1,73 @@
+package com.licensis.notaire.unit;
+
+import com.licensis.notaire.config.ProductionCredentialsGuard;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("ProductionCredentialsGuard (issue #565)")
+class ProductionCredentialsGuardTest {
+
+    private ProductionCredentialsGuard guardWith(String environment, String datasourceUsername,
+            String datasourcePassword, String actuatorUsername, String actuatorPassword) {
+        ProductionCredentialsGuard guard = new ProductionCredentialsGuard();
+        ReflectionTestUtils.setField(guard, "environment", environment);
+        ReflectionTestUtils.setField(guard, "datasourceUsername", datasourceUsername);
+        ReflectionTestUtils.setField(guard, "datasourcePassword", datasourcePassword);
+        ReflectionTestUtils.setField(guard, "actuatorUsername", actuatorUsername);
+        ReflectionTestUtils.setField(guard, "actuatorPassword", actuatorPassword);
+        return guard;
+    }
+
+    @Test
+    @DisplayName("Should reject default datasource password in production")
+    void shouldRejectDefaultDatasourcePasswordInProduction() {
+        ProductionCredentialsGuard guard = guardWith("production", "notaire_app", "admin",
+                "custom-actuator", "s3cur3-pass");
+
+        assertThatThrownBy(guard::validateCredentials)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("spring.datasource.password");
+    }
+
+    @Test
+    @DisplayName("Should reject default actuator credentials in production")
+    void shouldRejectDefaultActuatorCredentialsInProduction() {
+        ProductionCredentialsGuard guard = guardWith("production", "notaire_app", "s3cur3-pass",
+                "admin", "admin");
+
+        assertThatThrownBy(guard::validateCredentials)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("actuator.security.username")
+                .hasMessageContaining("actuator.security.password");
+    }
+
+    @Test
+    @DisplayName("Should accept non-default credentials in production")
+    void shouldAcceptNonDefaultCredentialsInProduction() {
+        ProductionCredentialsGuard guard = guardWith("production", "notaire_app", "s3cur3-pass",
+                "custom-actuator", "s3cur3-pass2");
+
+        assertThatCode(guard::validateCredentials).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Should not validate credentials outside production")
+    void shouldSkipValidationOutsideProduction() {
+        ProductionCredentialsGuard guard = guardWith("development", "admin", "admin", "admin", "admin");
+
+        assertThatCode(guard::validateCredentials).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Should treat environment check as case-insensitive")
+    void shouldTreatEnvironmentAsCaseInsensitive() {
+        ProductionCredentialsGuard guard = guardWith("PRODUCTION", "notaire_app", "admin",
+                "custom-actuator", "s3cur3-pass");
+
+        assertThatThrownBy(guard::validateCredentials).isInstanceOf(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ProductionCredentialsGuard`, a `@PostConstruct` bean that refuses to start when `app.environment` resolves to `production` and `spring.datasource.username`/`password` or `actuator.security.username`/`password` still equal the documented `admin` default.
- Mirrors the existing `JwtTokenService.validateSecret()` fail-fast pattern already used for `jwt.secret`.
- No-ops outside production, so dev/test profiles (which intentionally default to `admin`/`admin`) are unaffected.

## Scope note
`.env.example` also documents `POSTGRES_PASSWORD`, `PGADMIN_DEFAULT_PASSWORD`, and `APP_ADMIN_PASSWORD` as `admin`. These are out of scope for this Spring bean:
- `POSTGRES_PASSWORD`/`PGADMIN_DEFAULT_PASSWORD` belong to separate Docker services the backend has no visibility into.
- `APP_ADMIN_PASSWORD` is not currently wired to any Spring property at all — `DataInitializer` hardcodes `admin`/`admin` regardless of env vars. That's a distinct, larger issue (the seeded admin user's credentials aren't configurable at all yet) and will be filed as its own follow-up rather than folded into this fix.

## Testing
- [x] Unit tests added (`ProductionCredentialsGuardTest`, 5 cases: default datasource password, default actuator creds, accepts non-default creds, skips validation outside production, case-insensitive environment check) — TDD RED confirmed before implementation.
- [x] Full backend suite: 1397/1397 tests passing (was 1392; +5 new).
- [x] Checkstyle: no new violations introduced.

## Documentation
- N/A — internal startup-safety guard, no API/UI surface change.

## Issue Reference
Closes #565