### PR TITLE
[#560] fix(auth): add login rate limiting and account lockout

### DIFF
--- a/.claude/loop-state.md
+++ b/.claude/loop-state.md
@@ -1,0 +1,64 @@
+# Loop State
+
+This file is the memory for the autonomous issue-loop agent (`.claude/agents/issue-loop.md`).
+It did not exist before the 2026-07-22 01:00 Europe/Madrid scheduled run — created now.
+
+## Current
+
+- current_issue: 560
+- status: pr_open
+- branch: fix/560_login-rate-limiting
+- pr_url: https://github.com/matiaspakua/notaire/pull/653
+- blocked_reason: null
+
+Note: PR #653's first CI run failed "Validate PR" because the title used the type
+`security(auth):`, which isn't in the workflow's allowed Conventional Commits type list
+(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert). Renamed to `fix(auth): ...`
+in both the PR title and the commit subject (amended + force-pushed the feature branch,
+not main) and CI re-ran green except the known-flaky "Publish to Wiki" job.
+
+## Completed (this and prior runs, from git history)
+
+- 648, 649, 650, 652 (merged before this loop-state.md file existed; see `git log --oneline main`)
+
+## This run's queue (2026-07-22 01:00 Europe/Madrid)
+
+Selected top candidates from the 2026-07-02 repository audit issues (labels `priority:*`),
+after excluding RF-XX/RNF-XX/CU-* tracking issues, TAREA-labeled issues, and pure
+`docs(...)`-only "create a guide" issues (not bug/test/refactor/a11y/security in nature):
+
+1. #560 — security(auth): login endpoint has no rate limiting or account lockout (priority:high)
+2. #561 — security(validation): zero Jakarta Bean Validation usage (priority:high) — scoped to
+   the issue's own suggested starting point (UsuarioController + ReporteController), full rollout
+   across all 31 controllers tracked as a follow-up issue.
+3. #587 — test(e2e): E2E coverage reports are a static hardcoded template (priority:high)
+4. #610 — test(e2e): no mobile/responsive viewport coverage in Playwright config (priority:high)
+
+### Deferred this run (judgment call — not skipped permanently, see Policy)
+
+- #566 (ci: no quality/security gate can ever fail the build, priority:critical) — investigated
+  first since it's critical priority. Found the codebase currently has **3069 Checkstyle
+  warnings** and **234 SpotBugs findings**. Flipping `failOnViolation`/`failOnError` to true as
+  the issue suggests would immediately red-CI every future PR (including the other 3 issues in
+  this run) until those pre-existing findings are fixed — that is a large, multi-week cleanup
+  project, not a well-scoped single-issue fix. Needs a dedicated effort (fix violations first,
+  then flip the gate, ratchet-style like the existing JaCoCo floor) rather than being rushed in
+  an autonomous cycle. Left open for a deliberate follow-up.
+- #559 (security(authz): no RBAC enforcement anywhere in the backend, priority:high) — requires
+  per-endpoint judgment calls about which of 31 controllers/endpoints need which role, which is
+  a domain-knowledge-heavy design task, not mechanical. Deferred for a focused pass rather than
+  guessed at speed.
+- #567 (security(deps): outdated JasperReports 3.5.3, priority:high) — a major version bump of
+  the report-generation engine risks breaking compiled `.jasper` templates; needs careful
+  regression testing of report generation, deferred rather than rushed.
+
+## Policy (skip rules, carried forward for future runs)
+
+- Skip RF-XX / RNF-XX requirement-tracking issues and CU-* use-case tracking issues (they are
+  documentation/traceability placeholders, not actionable work items).
+- Skip TAREA-labeled issues and large architectural `arch(...)` issues.
+- Skip pure `docs(...)`-only "create a new guide" issues — not bug/test/refactor/a11y/security.
+- Treat issues that would require touching 25+ files / a systemic multi-week cleanup as
+  "large architectural" in spirit even if not literally labeled that way — defer them with a
+  written reason (see "Deferred this run" above) rather than doing a misleading partial fix that
+  closes the issue without resolving the underlying problem.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Login rate limiting / account lockout** (issue #560): `POST /api/v1/usuarios/login`
+  now locks a username out for a configurable duration (`security.login.lockout-duration-ms`,
+  default 15 minutes) after a configurable number of consecutive failed attempts
+  (`security.login.max-attempts`, default 5), returning `429 Too Many Requests`. A
+  successful login resets the counter. Implemented in the new
+  `com.licensis.notaire.security.LoginAttemptService`.
+
 ### Fixed
+
+- **Login attempt double-counting** (found while implementing #560): `UsuarioController.login()`
+  fell through to its "usuario no encontrado" branch even when a username **was** matched but
+  the password was wrong or the account was inactive, executing that branch's logic in addition
+  to the matched-user branch. Fixed by returning immediately once a matching user has been
+  handled.
 
 - **Flyway single source of truth**: Removed dual schema source (init-db + Flyway)
   - Removed `init-db:/docker-entrypoint-initdb.d` volume mount from docker-compose.yml

--- a/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
@@ -6,6 +6,7 @@ import com.licensis.notaire.dto.DtoUsuario;
 import com.licensis.notaire.negocio.Usuario;
 import com.licensis.notaire.observability.MetricsUtil;
 import com.licensis.notaire.repository.UsuarioRepository;
+import com.licensis.notaire.security.LoginAttemptService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -44,13 +45,16 @@ public class UsuarioController {
     private final JwtTokenService jwtTokenService;
     private final MetricsUtil metricsUtil;
     private final PasswordEncoder passwordEncoder;
+    private final LoginAttemptService loginAttemptService;
 
     public UsuarioController(UsuarioRepository usuarioRepository, JwtTokenService jwtTokenService,
-                             MetricsUtil metricsUtil, PasswordEncoder passwordEncoder) {
+                             MetricsUtil metricsUtil, PasswordEncoder passwordEncoder,
+                             LoginAttemptService loginAttemptService) {
         this.usuarioRepository = usuarioRepository;
         this.jwtTokenService = jwtTokenService;
         this.metricsUtil = metricsUtil;
         this.passwordEncoder = passwordEncoder;
+        this.loginAttemptService = loginAttemptService;
     }
 
     record PersonaInfo(Integer idPersona, String nombre, String apellido) {}
@@ -176,10 +180,23 @@ public class UsuarioController {
         }
     }
 
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "OK (ver campo 'valido' para el resultado)"),
+    @ApiResponse(responseCode = "429", description = "Cuenta bloqueada temporalmente por intentos fallidos")
+})
     @PostMapping("/login")
     @Operation(summary = "Autenticar usuario")
     public ResponseEntity<?> login(@RequestBody DtoUsuario loginRequest) {
         try {
+            if (loginAttemptService.isLocked(loginRequest.getNombre())) {
+                log.warn("Login bloqueado para '{}': demasiados intentos fallidos.", loginRequest.getNombre());
+                metricsUtil.incrementCounter("login", "locked");
+                Map<String, Object> lockedResponse = new HashMap<>();
+                lockedResponse.put("valido", false);
+                lockedResponse.put("message", "Cuenta bloqueada temporalmente por demasiados intentos fallidos.");
+                return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(lockedResponse);
+            }
+
             List<Usuario> usuarios = usuarioRepository.findAll();
 
             if (usuarios == null || usuarios.isEmpty()) {
@@ -197,6 +214,7 @@ public class UsuarioController {
                         if (usuario.getEstado()) {
                             log.info("Login exitoso para usuario: '{}'", usuario.getNombre());
                             metricsUtil.incrementCounter("login", "success");
+                            loginAttemptService.onLoginSucceeded(usuario.getNombre());
                             DtoUsuario dtoUsuario = new DtoUsuario();
                             dtoUsuario.setIdUsuario(usuario.getIdUsuario());
                             dtoUsuario.setNombre(usuario.getNombre());
@@ -233,10 +251,14 @@ public class UsuarioController {
                         } else {
                             log.warn("Login fallido para '{}': usuario inactivo", usuario.getNombre());
                             metricsUtil.incrementCounter("login", "inactive");
+                            loginAttemptService.onLoginFailed(usuario.getNombre());
+                            return ResponseEntity.ok(invalidLoginResponse());
                         }
                     } else {
                         log.warn("Login fallido para '{}': contraseña incorrecta", usuario.getNombre());
                         metricsUtil.incrementCounter("login", "bad_credentials");
+                        loginAttemptService.onLoginFailed(usuario.getNombre());
+                        return ResponseEntity.ok(invalidLoginResponse());
                     }
                 }
             }
@@ -244,17 +266,20 @@ public class UsuarioController {
             log.warn("Login fallido: usuario '{}' no encontrado en {} usuarios cargados.", loginRequest.getNombre(),
                     usuarios.size());
             metricsUtil.incrementCounter("login", "not_found");
-            Map<String, Object> errorResponse = new HashMap<>();
-            errorResponse.put("valido", false);
-            return ResponseEntity.ok(errorResponse);
+            loginAttemptService.onLoginFailed(loginRequest.getNombre());
+            return ResponseEntity.ok(invalidLoginResponse());
 
         } catch (Exception e) {
             log.error("Failed to process login for {}", loginRequest.getNombre(), e);
             metricsUtil.incrementCounter("login", "error");
-            Map<String, Object> errorResponse = new HashMap<>();
-            errorResponse.put("valido", false);
-            return ResponseEntity.ok(errorResponse);
+            return ResponseEntity.ok(invalidLoginResponse());
         }
+    }
+
+    private Map<String, Object> invalidLoginResponse() {
+        Map<String, Object> response = new HashMap<>();
+        response.put("valido", false);
+        return response;
     }
 
     /**

--- a/backend-api/src/main/java/com/licensis/notaire/security/LoginAttemptService.java
+++ b/backend-api/src/main/java/com/licensis/notaire/security/LoginAttemptService.java
@@ -1,0 +1,72 @@
+package com.licensis.notaire.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * Tracks failed login attempts per username and locks an account out for a
+ * configurable duration once a configurable threshold is reached (issue #560).
+ * State is kept in-memory; this is a single-instance mitigation, not a
+ * distributed rate limiter.
+ */
+@Component
+public class LoginAttemptService {
+
+    private final int maxAttempts;
+    private final long lockoutDurationMillis;
+    private final Supplier<Instant> clock;
+    private final ConcurrentHashMap<String, Attempt> attemptsByUsername = new ConcurrentHashMap<>();
+
+    @Autowired
+    public LoginAttemptService(
+            @Value("${security.login.max-attempts:5}") int maxAttempts,
+            @Value("${security.login.lockout-duration-ms:900000}") long lockoutDurationMillis) {
+        this(maxAttempts, lockoutDurationMillis, Instant::now);
+    }
+
+    LoginAttemptService(int maxAttempts, long lockoutDurationMillis, Supplier<Instant> clock) {
+        this.maxAttempts = maxAttempts;
+        this.lockoutDurationMillis = lockoutDurationMillis;
+        this.clock = clock;
+    }
+
+    public boolean isLocked(String username) {
+        String key = normalize(username);
+        Attempt attempt = attemptsByUsername.get(key);
+        if (attempt == null || attempt.lockedUntil == null) {
+            return false;
+        }
+        if (clock.get().isBefore(attempt.lockedUntil)) {
+            return true;
+        }
+        attemptsByUsername.remove(key);
+        return false;
+    }
+
+    public void onLoginFailed(String username) {
+        String key = normalize(username);
+        Attempt attempt = attemptsByUsername.computeIfAbsent(key, k -> new Attempt());
+        attempt.failedCount++;
+        if (attempt.failedCount >= maxAttempts) {
+            attempt.lockedUntil = clock.get().plusMillis(lockoutDurationMillis);
+        }
+    }
+
+    public void onLoginSucceeded(String username) {
+        attemptsByUsername.remove(normalize(username));
+    }
+
+    private String normalize(String username) {
+        return username == null ? "" : username.trim().toLowerCase();
+    }
+
+    private static final class Attempt {
+        private int failedCount;
+        private Instant lockedUntil;
+    }
+}

--- a/backend-api/src/main/resources/application.properties
+++ b/backend-api/src/main/resources/application.properties
@@ -113,6 +113,11 @@ logging.file.max-history=30
 security.password.algorithm=bcrypt
 security.password.bcrypt-strength=12
 
+# Login rate limiting / account lockout (issue #560)
+# Locks a username out for lockout-duration-ms after max-attempts consecutive failed logins.
+security.login.max-attempts=${SECURITY_LOGIN_MAX_ATTEMPTS:5}
+security.login.lockout-duration-ms=${SECURITY_LOGIN_LOCKOUT_DURATION_MS:900000}
+
 # CORS Configuration
 cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:8080,http://localhost:3001,http://localhost:9090}
 cors.allowed-methods=GET,POST,PUT,DELETE,PATCH,OPTIONS

--- a/backend-api/src/test/java/com/licensis/notaire/integration/LoginRateLimitIntegrationTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/LoginRateLimitIntegrationTest.java
@@ -1,0 +1,111 @@
+package com.licensis.notaire.integration;
+
+import com.licensis.notaire.security.LoginAttemptService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test-h2")
+@TestPropertySource(properties = {
+        "security.login.max-attempts=3",
+        "security.login.lockout-duration-ms=60000",
+        "spring.datasource.url=jdbc:h2:mem:notaire_test_rate_limit;MODE=PostgreSQL;"
+                + "DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH"
+})
+@DisplayName("Login rate limiting / account lockout (issue #560)")
+class LoginRateLimitIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private LoginAttemptService loginAttemptService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        loginAttemptService.onLoginSucceeded("admin");
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(SecurityMockMvcConfigurers.springSecurity())
+                .build();
+    }
+
+    private void attemptLoginWithWrongPassword() throws Exception {
+        mockMvc.perform(post("/api/v1/usuarios/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"nombre": "admin", "contrasenia": "wrongpassword"}
+                        """));
+    }
+
+    @Test
+    @DisplayName("Locks the account out after reaching the max failed attempts")
+    void shouldLockAccountAfterMaxFailedAttempts() throws Exception {
+        attemptLoginWithWrongPassword();
+        attemptLoginWithWrongPassword();
+        attemptLoginWithWrongPassword();
+
+        mockMvc.perform(post("/api/v1/usuarios/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"nombre": "admin", "contrasenia": "admin"}
+                                """))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(jsonPath("$.valido").value(false));
+    }
+
+    @Test
+    @DisplayName("Does not lock the account before reaching the max failed attempts")
+    void shouldNotLockAccountBeforeMaxFailedAttempts() throws Exception {
+        attemptLoginWithWrongPassword();
+
+        mockMvc.perform(post("/api/v1/usuarios/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"nombre": "admin", "contrasenia": "admin"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valido").value(true));
+    }
+
+    @Test
+    @DisplayName("A successful login resets the failed attempt counter")
+    void shouldResetCounterAfterSuccessfulLogin() throws Exception {
+        attemptLoginWithWrongPassword();
+        attemptLoginWithWrongPassword();
+
+        mockMvc.perform(post("/api/v1/usuarios/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"nombre": "admin", "contrasenia": "admin"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valido").value(true));
+
+        attemptLoginWithWrongPassword();
+        attemptLoginWithWrongPassword();
+
+        mockMvc.perform(post("/api/v1/usuarios/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"nombre": "admin", "contrasenia": "admin"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valido").value(true));
+    }
+}

--- a/backend-api/src/test/java/com/licensis/notaire/security/LoginAttemptServiceTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/security/LoginAttemptServiceTest.java
@@ -1,0 +1,89 @@
+package com.licensis.notaire.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("LoginAttemptService")
+class LoginAttemptServiceTest {
+
+    private static final int MAX_ATTEMPTS = 3;
+    private static final long LOCKOUT_DURATION_MS = 1000L;
+
+    private Instant now;
+    private LoginAttemptService service;
+
+    @BeforeEach
+    void setUp() {
+        now = Instant.parse("2026-01-01T00:00:00Z");
+        service = new LoginAttemptService(MAX_ATTEMPTS, LOCKOUT_DURATION_MS, () -> now);
+    }
+
+    @Test
+    @DisplayName("Should not lock a user before reaching the max failed attempts")
+    void shouldNotLockBeforeMaxFailedAttempts() {
+        service.onLoginFailed("admin");
+        service.onLoginFailed("admin");
+
+        assertThat(service.isLocked("admin")).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should lock a user after reaching the max failed attempts")
+    void shouldLockAfterMaxFailedAttempts() {
+        service.onLoginFailed("admin");
+        service.onLoginFailed("admin");
+        service.onLoginFailed("admin");
+
+        assertThat(service.isLocked("admin")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should treat usernames case-insensitively")
+    void shouldTreatUsernamesCaseInsensitively() {
+        service.onLoginFailed("Admin");
+        service.onLoginFailed("ADMIN");
+        service.onLoginFailed("admin");
+
+        assertThat(service.isLocked("aDmIn")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should not lock unrelated usernames")
+    void shouldNotLockUnrelatedUsernames() {
+        service.onLoginFailed("admin");
+        service.onLoginFailed("admin");
+        service.onLoginFailed("admin");
+
+        assertThat(service.isLocked("otheruser")).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should unlock automatically once the lockout duration has elapsed")
+    void shouldUnlockAfterLockoutDurationElapses() {
+        service.onLoginFailed("admin");
+        service.onLoginFailed("admin");
+        service.onLoginFailed("admin");
+        assertThat(service.isLocked("admin")).isTrue();
+
+        now = now.plusMillis(LOCKOUT_DURATION_MS + 1);
+
+        assertThat(service.isLocked("admin")).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should reset the failed attempt counter after a successful login")
+    void shouldResetFailedCountOnSuccessfulLogin() {
+        service.onLoginFailed("admin");
+        service.onLoginFailed("admin");
+        service.onLoginSucceeded("admin");
+        service.onLoginFailed("admin");
+        service.onLoginFailed("admin");
+
+        assertThat(service.isLocked("admin")).isFalse();
+    }
+}

--- a/backend-api/src/test/java/com/licensis/notaire/unit/AdditionalControllersTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/AdditionalControllersTest.java
@@ -198,7 +198,8 @@ class AdditionalControllersTest {
             when(jwtSvc.generateToken(any())).thenReturn("mock-jwt-token");
             var metrics = mock(com.licensis.notaire.observability.MetricsUtil.class);
             var passwordEncoder = mock(org.springframework.security.crypto.password.PasswordEncoder.class);
-            var mvc = standaloneSetup(new UsuarioController(repo, jwtSvc, metrics, passwordEncoder)).build();
+            var mvc = standaloneSetup(new UsuarioController(repo, jwtSvc, metrics, passwordEncoder,
+                    new com.licensis.notaire.security.LoginAttemptService(5, 900000))).build();
             Usuario u = new Usuario(1, "admin", "abc", true, "Escribano");
 
             when(repo.findAll()).thenReturn(List.of(u));

--- a/backend-api/src/test/java/com/licensis/notaire/unit/UsuarioControllerHashTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/UsuarioControllerHashTest.java
@@ -6,6 +6,7 @@ import com.licensis.notaire.dto.DtoUsuario;
 import com.licensis.notaire.negocio.Usuario;
 import com.licensis.notaire.observability.MetricsUtil;
 import com.licensis.notaire.repository.UsuarioRepository;
+import com.licensis.notaire.security.LoginAttemptService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -52,7 +53,8 @@ class UsuarioControllerHashTest {
 
     @BeforeEach
     void setUp() {
-        controller = new UsuarioController(usuarioRepository, jwtTokenService, metricsUtil, passwordEncoder);
+        controller = new UsuarioController(usuarioRepository, jwtTokenService, metricsUtil, passwordEncoder,
+                new LoginAttemptService(5, 900000));
         mockMvc = standaloneSetup(controller).build();
     }
 


### PR DESCRIPTION
## Summary

- Adds a `LoginAttemptService` that locks a username out for a configurable duration after a configurable number of consecutive failed logins, returning `429 Too Many Requests`.
- Fixes a pre-existing control-flow bug in `UsuarioController.login()` found while wiring this up (see below).

## Use Case Reference

Security hardening for the authentication/login flow used by every Use Case that requires an authenticated session. Found via the 2026-07-02 repository security audit (no single numbered CU covers login itself).

**Issue:** #560

## Changes

### Added
- `com.licensis.notaire.security.LoginAttemptService`: in-memory per-username failed-attempt counter with configurable `security.login.max-attempts` (default 5) and `security.login.lockout-duration-ms` (default 15 min).
- `UsuarioController.login()` now checks `LoginAttemptService.isLocked(...)` before processing and returns `429` with `{"valido": false, "message": "..."}` while locked.
- A successful login resets the counter (`onLoginSucceeded`).

### Fixed
- `UsuarioController.login()` fell through to its "usuario no encontrado" branch **even when a username was matched** but had the wrong password or was inactive, because there was no early return for those branches. This was harmless before (both paths returned the same `valido:false` shape), but would have double-counted failed attempts against the new lockout counter. Fixed by returning immediately once a matching user has been handled, and de-duplicated the repeated `{"valido": false}` map construction into a small `invalidLoginResponse()` helper.

## Testing

- [x] Unit tests added: `LoginAttemptServiceTest` (6 cases — threshold, case-insensitivity, unrelated usernames, expiry, reset)
- [x] Integration tests added: `LoginRateLimitIntegrationTest` (lock after max attempts, no lock before threshold, reset after success)
- [x] Existing `JwtAuthIntegrationTest`, `UsuarioControllerHashTest`, `AdditionalControllersTest` updated for the new constructor param and pass unchanged otherwise
- [x] `mvn test -pl backend-api` — full suite: same pre-existing 1 failure / 4 errors as on `main` (`WorkflowTraceApiH2IntegrationTest`, `WorkflowTransitionIntegrationTest` — confirmed present on a clean `main` checkout too, unrelated to this change, not introduced by it)
- [ ] E2E Playwright — not applicable, no frontend change

## Documentation

- [x] CHANGELOG.md updated
- [x] OpenAPI: added `429` response doc to `POST /api/v1/usuarios/login`
- [x] `security.login.*` properties documented in `application.properties`

## Code Quality

- [x] Follows project conventions
- [x] No hardcoded credentials
- [x] No commented-out code / debug logging left

## Dependencies

- No new dependencies (in-memory `ConcurrentHashMap`, no Bucket4j needed for this scope)

## Breaking Changes

- None. New properties have defaults; existing login behavior for correct/incorrect single attempts is unchanged.

## Reviewer Notes

The "double fallthrough" bug (see Fixed above) is pre-existing on `main` — it was previously harmless (same JSON response either way) but became a real bug once attempt-counting had a side effect. Worth double-checking the early-return placement in `login()` matches intent.


---
_Generated by [Claude Code](https://claude.ai/code/session_016CHE67J9jDYFCNWhZcTtyS)_