### PR TITLE
[#561] fix(validation): add Jakarta Bean Validation to UsuarioController and ReporteController

### DIFF
--- a/.claude/loop-state.md
+++ b/.claude/loop-state.md
@@ -6,9 +6,9 @@ It did not exist before the 2026-07-22 01:00 Europe/Madrid scheduled run — cre
 ## Current
 
 - current_issue: 561
-- status: in_progress
+- status: pr_open
 - branch: fix/561_bean-validation
-- pr_url: null
+- pr_url: https://github.com/matiaspakua/notaire/pull/654
 - blocked_reason: null
 
 ## Completed (this and prior runs, from git history)

--- a/.claude/loop-state.md
+++ b/.claude/loop-state.md
@@ -5,21 +5,19 @@ It did not exist before the 2026-07-22 01:00 Europe/Madrid scheduled run — cre
 
 ## Current
 
-- current_issue: 560
-- status: pr_open
-- branch: fix/560_login-rate-limiting
-- pr_url: https://github.com/matiaspakua/notaire/pull/653
+- current_issue: 561
+- status: in_progress
+- branch: fix/561_bean-validation
+- pr_url: null
 - blocked_reason: null
-
-Note: PR #653's first CI run failed "Validate PR" because the title used the type
-`security(auth):`, which isn't in the workflow's allowed Conventional Commits type list
-(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert). Renamed to `fix(auth): ...`
-in both the PR title and the commit subject (amended + force-pushed the feature branch,
-not main) and CI re-ran green except the known-flaky "Publish to Wiki" job.
 
 ## Completed (this and prior runs, from git history)
 
 - 648, 649, 650, 652 (merged before this loop-state.md file existed; see `git log --oneline main`)
+- 560 — security(auth): login rate limiting and account lockout. PR #653, squash-merged at
+  2026-07-22T18:46:59Z. Found and fixed a real pre-existing bug along the way (see PR body):
+  UsuarioController.login() fell through to its "not found" branch even after a match, which
+  would have double-counted failed attempts against the new lockout counter.
 
 ## This run's queue (2026-07-22 01:00 Europe/Madrid)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   successful login resets the counter. Implemented in the new
   `com.licensis.notaire.security.LoginAttemptService`.
 
+- **Jakarta Bean Validation on request boundaries** (issue #561): `UsuarioController`'s
+  `createUsuario`/`updateUsuario` now validate the request body (`@NotBlank nombre`, `tipo`),
+  and `ReporteController`'s path/query parameters are validated (`@Positive` on ID-like
+  parameters, `@NotBlank` on `nombreTipoTramite`, `@Min(1)/@Max(12)` on `mes`), returning a
+  clean `400` instead of a generic `500` or silently accepting malformed input.
+  `GlobalExceptionHandler` now handles `MethodArgumentNotValidException` (body validation) and
+  `ConstraintViolationException` (`@RequestParam`/`@PathVariable` validation) consistently.
+  Full rollout across the remaining controllers is tracked as a follow-up.
+
 ### Fixed
 
 - **Login attempt double-counting** (found while implementing #560): `UsuarioController.login()`

--- a/backend-api/src/main/java/com/licensis/notaire/api/ReporteController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/ReporteController.java
@@ -6,11 +6,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/api/v1/reportes")
+@Validated
 @Tag(name = "Reportes", description = "API para generación de reportes PDF")
 public class ReporteController {
 
@@ -57,7 +63,7 @@ public class ReporteController {
                description = "Genera un PDF con el presupuesto especificado")
     public ResponseEntity<byte[]> generarReportePresupuesto(
             @Parameter(description = "ID del presupuesto")
-            @PathVariable Integer idPresupuesto) {
+            @PathVariable @Positive Integer idPresupuesto) {
         return buildPdfResponse("presupuesto_" + idPresupuesto + ".pdf",
                 () -> reporteService.generarReportePresupuesto(idPresupuesto));
     }
@@ -67,7 +73,7 @@ public class ReporteController {
                description = "Genera un PDF con el presupuesto e información de inmuebles")
     public ResponseEntity<byte[]> generarReportePresupuestoInmuebles(
             @Parameter(description = "ID del presupuesto")
-            @PathVariable Integer idPresupuesto) {
+            @PathVariable @Positive Integer idPresupuesto) {
         return buildPdfResponse("presupuesto_inmuebles_" + idPresupuesto + ".pdf",
                 () -> reporteService.generarReportePresupuestoInmuebles(idPresupuesto));
     }
@@ -77,7 +83,7 @@ public class ReporteController {
                description = "Genera un PDF con la lista de documentos requeridos para un tipo de trámite")
     public ResponseEntity<byte[]> generarReporteListaDocumentosTramite(
             @Parameter(description = "Nombre del tipo de trámite")
-            @RequestParam String nombreTipoTramite) {
+            @RequestParam @NotBlank String nombreTipoTramite) {
         return buildPdfResponse("lista_documentos.pdf",
                 () -> reporteService.generarReporteListaDocumentosTramite(nombreTipoTramite));
     }
@@ -87,7 +93,7 @@ public class ReporteController {
                description = "Genera un PDF con el historial de una gestión específica")
     public ResponseEntity<byte[]> generarReporteHistorialGestion(
             @Parameter(description = "ID de la gestión")
-            @PathVariable Integer idGestion) {
+            @PathVariable @Positive Integer idGestion) {
         return buildPdfResponse("historial_gestion_" + idGestion + ".pdf",
                 () -> reporteService.generarReporteHistorialGestion(idGestion));
     }
@@ -97,7 +103,7 @@ public class ReporteController {
                description = "Genera un PDF con información de documentos próximos a vencer")
     public ResponseEntity<byte[]> generarReporteDocumentosPorVencer(
             @Parameter(description = "ID del documento presentado")
-            @PathVariable Integer idDocumentoPresentado) {
+            @PathVariable @Positive Integer idDocumentoPresentado) {
         return buildPdfResponse("documentos_vencer.pdf",
                 () -> reporteService.generarReporteDocumentosPorVencer(idDocumentoPresentado));
     }
@@ -107,7 +113,7 @@ public class ReporteController {
                description = "Genera un PDF con la consulta de deuda de documentos para una gestión")
     public ResponseEntity<byte[]> generarReporteConsultarDeudaDocumentos(
             @Parameter(description = "Número de gestión")
-            @RequestParam Integer numeroGestion) {
+            @RequestParam @Positive Integer numeroGestion) {
         return buildPdfResponse("deuda_documentos_" + numeroGestion + ".pdf",
                 () -> reporteService.generarReporteConsultarDeudaDocumentos(numeroGestion));
     }
@@ -117,7 +123,7 @@ public class ReporteController {
                description = "Endpoint base para CU24. Requiere plantilla Jasper de libro de indice")
     public ResponseEntity<byte[]> generarLibroIndice(
             @Parameter(description = "Año del libro de indice")
-            @RequestParam Integer anio) {
+            @RequestParam @Positive Integer anio) {
         return buildPdfResponse("libro_indice_" + anio + ".pdf",
                 () -> reporteService.generarReporteLibroIndice(anio));
     }
@@ -127,9 +133,9 @@ public class ReporteController {
                description = "Endpoint base para CU25. Requiere plantilla Jasper de DDJJ mensual")
     public ResponseEntity<byte[]> generarDeclaracionJuradaMensual(
             @Parameter(description = "Año del periodo")
-            @RequestParam Integer anio,
+            @RequestParam @Positive Integer anio,
             @Parameter(description = "Mes del periodo")
-            @RequestParam Integer mes) {
+            @RequestParam @Min(1) @Max(12) Integer mes) {
         if (mes < 1 || mes > 12) {
             return ResponseEntity.badRequest().build();
         }
@@ -142,9 +148,9 @@ public class ReporteController {
                description = "Endpoint base para CU50. Requiere plantilla Jasper de DDJJ rentas")
     public ResponseEntity<byte[]> generarDeclaracionJuradaRentas(
             @Parameter(description = "Año del periodo")
-            @RequestParam Integer anio,
+            @RequestParam @Positive Integer anio,
             @Parameter(description = "Mes del periodo")
-            @RequestParam Integer mes) {
+            @RequestParam @Min(1) @Max(12) Integer mes) {
         if (mes < 1 || mes > 12) {
             return ResponseEntity.badRequest().build();
         }

--- a/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
+++ b/backend-api/src/main/java/com/licensis/notaire/api/UsuarioController.java
@@ -11,6 +11,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -64,7 +66,11 @@ public class UsuarioController {
     record UsuarioResponse(Integer idUsuario, String nombre, String tipo, boolean activo,
                             PersonaInfo persona, RolInfo rol) {}
 
-    record UsuarioRequest(String nombre, String contrasenia, String tipo, boolean activo) {}
+    record UsuarioRequest(
+            @NotBlank String nombre,
+            String contrasenia,
+            @NotBlank String tipo,
+            boolean activo) {}
 
     private UsuarioResponse toResponse(Usuario u) {
         PersonaInfo persona = null;
@@ -117,7 +123,7 @@ public class UsuarioController {
 })
     @PostMapping
     @Operation(summary = "Crear nuevo usuario")
-    public ResponseEntity<Object> createUsuario(@RequestBody UsuarioRequest request) {
+    public ResponseEntity<Object> createUsuario(@Valid @RequestBody UsuarioRequest request) {
         try {
             Usuario usuario = new Usuario();
             usuario.setNombre(request.nombre());
@@ -139,7 +145,7 @@ public class UsuarioController {
 })
     @PutMapping("/{id}")
     @Operation(summary = "Actualizar usuario")
-    public ResponseEntity<Void> updateUsuario(@PathVariable Integer id, @RequestBody UsuarioRequest request) {
+    public ResponseEntity<Void> updateUsuario(@PathVariable Integer id, @Valid @RequestBody UsuarioRequest request) {
         Optional<Usuario> existing = usuarioRepository.findById(id);
         if (existing.isEmpty()) {
             return ResponseEntity.notFound().build();

--- a/backend-api/src/main/java/com/licensis/notaire/config/GlobalExceptionHandler.java
+++ b/backend-api/src/main/java/com/licensis/notaire/config/GlobalExceptionHandler.java
@@ -6,15 +6,21 @@ import com.licensis.notaire.exception.NotaireException;
 import com.licensis.notaire.exception.ResourceNotFoundException;
 import com.licensis.notaire.observability.StructuredLogger;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Global exception handler for all REST controllers.
@@ -105,6 +111,74 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             Map.of(
                 "path", request.getRequestURI(),
                 "message", ex.getMessage()
+            )
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * Handle bean validation failures on {@code @RequestBody} arguments (issue #561).
+     * Overrides the superclass's default {@code ProblemDetail} handling to keep the
+     * project's own {@link ErrorResponse} shape consistent across all error responses.
+     *
+     * @param ex      the exception
+     * @param headers the HTTP headers
+     * @param status  the HTTP status
+     * @param request the web request
+     * @return 400 error response entity
+     */
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
+                .collect(Collectors.joining("; "));
+        String path = request.getDescription(false).replace("uri=", "");
+        ErrorResponse errorResponse = new ErrorResponse(
+            400,
+            HttpStatus.BAD_REQUEST.getReasonPhrase(),
+            message,
+            path
+        );
+        STRUCTURED_LOG.logWarn(
+            "Request body validation failed",
+            Map.of(
+                "path", path,
+                "message", message
+            )
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * Handle bean validation failures on {@code @RequestParam}/{@code @PathVariable}
+     * arguments, raised when the controller class is annotated {@code @Validated} (issue #561).
+     *
+     * @param ex      the exception
+     * @param request the HTTP request
+     * @return 400 error response entity
+     */
+    @ExceptionHandler({ConstraintViolationException.class})
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(
+            ConstraintViolationException ex,
+            HttpServletRequest request) {
+        String message = ex.getConstraintViolations().stream()
+                .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+                .collect(Collectors.joining("; "));
+        ErrorResponse errorResponse = new ErrorResponse(
+            400,
+            HttpStatus.BAD_REQUEST.getReasonPhrase(),
+            message,
+            request.getRequestURI()
+        );
+        STRUCTURED_LOG.logWarn(
+            "Request parameter validation failed",
+            Map.of(
+                "path", request.getRequestURI(),
+                "message", message
             )
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);

--- a/backend-api/src/test/java/com/licensis/notaire/integration/ReporteControllerValidationIntegrationTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/ReporteControllerValidationIntegrationTest.java
@@ -1,0 +1,70 @@
+package com.licensis.notaire.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test-h2")
+@DisplayName("Reporte controller request validation (issue #561)")
+class ReporteControllerValidationIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    @Test
+    @DisplayName("GET presupuesto report with non-positive idPresupuesto returns 400")
+    void shouldRejectPresupuestoReportWithNonPositiveId() throws Exception {
+        mockMvc.perform(get("/api/v1/reportes/presupuesto/0"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET presupuesto report with negative idPresupuesto returns 400")
+    void shouldRejectPresupuestoReportWithNegativeId() throws Exception {
+        mockMvc.perform(get("/api/v1/reportes/presupuesto/-1"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET lista-documentos-tramite with blank nombreTipoTramite returns 400")
+    void shouldRejectListaDocumentosWithBlankNombreTipoTramite() throws Exception {
+        mockMvc.perform(get("/api/v1/reportes/lista-documentos-tramite")
+                        .param("nombreTipoTramite", "   "))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET declaracion-jurada-mensual with mes=13 returns 400")
+    void shouldRejectDeclaracionJuradaMensualWithMesOutOfRange() throws Exception {
+        mockMvc.perform(get("/api/v1/reportes/declaracion-jurada-mensual")
+                        .param("anio", "2026")
+                        .param("mes", "13"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET declaracion-jurada-mensual with non-positive anio returns 400")
+    void shouldRejectDeclaracionJuradaMensualWithNonPositiveAnio() throws Exception {
+        mockMvc.perform(get("/api/v1/reportes/declaracion-jurada-mensual")
+                        .param("anio", "0")
+                        .param("mes", "6"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend-api/src/test/java/com/licensis/notaire/integration/UsuarioRequestValidationIntegrationTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/integration/UsuarioRequestValidationIntegrationTest.java
@@ -1,0 +1,88 @@
+package com.licensis.notaire.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test-h2")
+@DisplayName("Usuario request validation (issue #561)")
+class UsuarioRequestValidationIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    @Test
+    @DisplayName("POST /usuarios with blank nombre returns 400")
+    void shouldRejectCreateWithBlankNombre() throws Exception {
+        mockMvc.perform(post("/api/v1/usuarios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"nombre": "", "contrasenia": "pass", "tipo": "EMPLEADO", "activo": true}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /usuarios with missing nombre returns 400")
+    void shouldRejectCreateWithMissingNombre() throws Exception {
+        mockMvc.perform(post("/api/v1/usuarios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"contrasenia": "pass", "tipo": "EMPLEADO", "activo": true}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /usuarios with blank tipo returns 400")
+    void shouldRejectCreateWithBlankTipo() throws Exception {
+        mockMvc.perform(post("/api/v1/usuarios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"nombre": "someuser", "contrasenia": "pass", "tipo": "", "activo": true}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /usuarios with valid payload still succeeds")
+    void shouldAcceptCreateWithValidPayload() throws Exception {
+        mockMvc.perform(post("/api/v1/usuarios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"nombre": "valid_user_561", "contrasenia": "pass", "tipo": "EMPLEADO", \
+                                "activo": true}
+                                """))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("PUT /usuarios/{id} with blank nombre returns 400")
+    void shouldRejectUpdateWithBlankNombre() throws Exception {
+        mockMvc.perform(put("/api/v1/usuarios/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"nombre": "", "contrasenia": "", "tipo": "EMPLEADO", "activo": true}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Summary

- `spring-boot-starter-validation` was already a declared dependency with zero usage anywhere in the codebase. Adds bean validation to the two endpoints the issue itself calls out as a starting point: `UsuarioController` and `ReporteController`.
- Full rollout across the remaining ~29 controllers is real, judgment-heavy follow-up work (each needs the right constraints for its own domain) — not attempted here, and not claimed as done.

## Use Case Reference

Security/input-hardening for the REST API boundary generally (not a single numbered CU). Found via the 2026-07-02 repository audit.

**Issue:** #561

## Changes

### Added
- `UsuarioController.UsuarioRequest`: `@NotBlank` on `nombre` and `tipo`. `@Valid` on the `@RequestBody` in `createUsuario`/`updateUsuario`. (`contrasenia` intentionally stays unvalidated — blank means "keep existing password" on update, by existing design.)
- `ReporteController`: `@Validated` on the class; `@Positive` on ID-like path/query params (`idPresupuesto`, `idGestion`, `idDocumentoPresentado`, `numeroGestion`, `anio`); `@NotBlank` on `nombreTipoTramite`; `@Min(1)/@Max(12)` on `mes` (kept alongside the existing manual guard clause — some existing unit tests instantiate the controller directly via `standaloneSetup()` without a full Spring context, so Spring's `@Validated` AOP proxy never fires there; the manual check is what keeps those tests correct).
- `GlobalExceptionHandler`: overrides `handleMethodArgumentNotValid` (body validation, `@Valid @RequestBody`) and adds a handler for `ConstraintViolationException` (`@RequestParam`/`@PathVariable` validation), both mapped to a clean `400` using the project's own `ErrorResponse` shape instead of a generic `500`.

## Testing

- [x] Unit/integration tests added: `UsuarioRequestValidationIntegrationTest` (5 cases), `ReporteControllerValidationIntegrationTest` (5 cases)
- [x] Existing `AdditionalControllersTest`, `ReportesUseCaseIntegrationTest`, `EdgeCaseBoundaryConditionsTest`, `UsuarioControllerTest`, `UsuarioDeleteControllerTest`, `UsuarioControllerHashTest` pass unchanged
- [x] `mvn test -pl backend-api` — full suite: same pre-existing 1 failure / 4 errors as on `main` (`WorkflowTraceApiH2IntegrationTest`, `WorkflowTransitionIntegrationTest` — confirmed present on a clean `main` checkout too, unrelated to this change)
- [ ] E2E Playwright — not applicable, no frontend change

## Documentation

- [x] CHANGELOG.md updated
- [x] Javadoc added on the two new exception handlers

## Code Quality

- [x] Follows project conventions
- [x] No hardcoded credentials
- [x] No commented-out code / debug logging left

## Dependencies

- No new dependencies (`spring-boot-starter-validation` was already declared, just unused)

## Breaking Changes

- None for well-formed requests. Malformed requests that previously silently succeeded or 500'd now correctly return 400 (e.g. creating a user with a blank `nombre`, or requesting a report with `mes=13`).

## Reviewer Notes

The `@Min(1)/@Max(12)` on `mes` alongside a manual `if` guard is intentionally redundant — see the "Changes" note above for why the manual check couldn't just be deleted.


---
_Generated by [Claude Code](https://claude.ai/code/session_016CHE67J9jDYFCNWhZcTtyS)_