### PR TITLE
[#610] fix(frontend): add mobile/tablet viewport coverage to Playwright E2E

### DIFF
--- a/.claude/loop-state.md
+++ b/.claude/loop-state.md
@@ -5,10 +5,10 @@ It did not exist before the 2026-07-22 01:00 Europe/Madrid scheduled run — cre
 
 ## Current
 
-- current_issue: 587
-- status: pr_open
-- branch: fix/587_e2e-coverage-report
-- pr_url: https://github.com/matiaspakua/notaire/pull/656
+- current_issue: 610
+- status: in_progress
+- branch: fix/610_mobile-viewport-e2e
+- pr_url: null
 - blocked_reason: null
 
 ## Completed (this and prior runs, from git history)
@@ -22,6 +22,12 @@ It did not exist before the 2026-07-22 01:00 Europe/Madrid scheduled run — cre
   (the issue's own suggested starting point). PR #654, squash-merged at 2026-07-22T19:18:51Z.
   Filed #655 to track the full rollout across the remaining ~29 controllers as deliberate
   follow-up rather than claiming it done here.
+- 587 — test(e2e): E2E coverage reports were a static hardcoded template. PR #656, squash-merged
+  at 2026-07-22T19:33:03Z. Note: this PR's own CI couldn't exercise the changed
+  `coverage-report` job (path-filtered to frontend/**/backend-api/**) — first real validation
+  happens on the next push to main touching those paths, or the weekday cron. Worth a spot
+  check by a future run or human that the first post-merge e2e-coverage-*.md report looks sane
+  (real numbers, not a crash).
 
 ## This run's queue (2026-07-22 01:00 Europe/Madrid)
 

--- a/.claude/loop-state.md
+++ b/.claude/loop-state.md
@@ -6,9 +6,9 @@ It did not exist before the 2026-07-22 01:00 Europe/Madrid scheduled run — cre
 ## Current
 
 - current_issue: 610
-- status: in_progress
+- status: pr_open
 - branch: fix/610_mobile-viewport-e2e
-- pr_url: null
+- pr_url: https://github.com/matiaspakua/notaire/pull/657
 - blocked_reason: null
 
 ## Completed (this and prior runs, from git history)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ConstraintViolationException` (`@RequestParam`/`@PathVariable` validation) consistently.
   Full rollout across the remaining controllers is tracked as a follow-up.
 
+- **Mobile/tablet viewport coverage in Playwright E2E** (issue #610): `frontend/playwright.config.ts`
+  previously only ran against `devices["Desktop Chrome"]`, with zero specs asserting layout at
+  the 320px/768px/1024px breakpoints mandated by `.claude/rules/ui-ux-design.md`. Added a
+  `mobile` project (`devices["iPhone SE"]`) and `tests/e2e/mobile-viewport.spec.ts`, which
+  asserts no horizontal overflow on the login page at 320px and 768px and on the dashboard at
+  320px after login.
+
 ### Fixed
 
 - **Login attempt double-counting** (found while implementing #560): `UsuarioController.login()`

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -46,6 +46,11 @@ export default defineConfig({
       // Use the real Google Chrome browser (channel) instead of bundled Chromium.
       use: { ...devices["Desktop Chrome"], channel: "chrome" },
     },
+    {
+      name: "mobile",
+      testMatch: "**/mobile-viewport.spec.ts",
+      use: { ...devices["iPhone SE"] },
+    },
   ],
   // Skip webServer since we're using Docker
   // Tests expect backend on :8080 and frontend on :3000

--- a/frontend/tests/e2e/mobile-viewport.spec.ts
+++ b/frontend/tests/e2e/mobile-viewport.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * E2E tests — Mobile/responsive viewport coverage (issue #610)
+ *
+ * .claude/rules/ui-ux-design.md mandates testing at the 320px/768px/1024px
+ * breakpoints, but no spec previously asserted layout at those widths.
+ * Runs under both the default "chromium" project (Desktop Chrome) and the
+ * "mobile" project (devices["iPhone SE"]) added to playwright.config.ts.
+ */
+import { type Page, test, expect } from "@playwright/test";
+
+async function hasNoHorizontalOverflow(page: Page): Promise<boolean> {
+  return page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth);
+}
+
+async function loginAsAdmin(page: Page) {
+  await page.goto("/login");
+  await page.getByTestId("input-usuario").fill("admin");
+  await page.getByTestId("input-contrasenia").fill("admin");
+  await page.getByTestId("btn-ingresar").click();
+  await page.waitForURL(/\/dashboard/, { timeout: 15000 });
+  await page.waitForLoadState("domcontentloaded");
+}
+
+test.describe("Mobile/responsive viewport @mobile", () => {
+  test("login page has no horizontal overflow at 320px", async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.goto("/login");
+
+    await expect(page.getByTestId("input-usuario")).toBeVisible();
+    await expect(page.getByTestId("input-contrasenia")).toBeVisible();
+    await expect(page.getByTestId("btn-ingresar")).toBeVisible();
+    expect(await hasNoHorizontalOverflow(page)).toBe(true);
+  });
+
+  test("login page has no horizontal overflow at 768px (tablet)", async ({ page }) => {
+    await page.setViewportSize({ width: 768, height: 1024 });
+    await page.goto("/login");
+
+    expect(await hasNoHorizontalOverflow(page)).toBe(true);
+  });
+
+  test("dashboard has no horizontal overflow at 320px after login", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await loginAsAdmin(page);
+
+    await page.setViewportSize({ width: 320, height: 568 });
+    expect(await hasNoHorizontalOverflow(page)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- `frontend/playwright.config.ts` only defined projects using `devices["Desktop Chrome"]` — no mobile/tablet viewport project existed, and zero specs asserted layout at the 320px/768px/1024px breakpoints `.claude/rules/ui-ux-design.md` mandates.
- Adds a `mobile` project (`devices["iPhone SE"]`) and a new spec asserting no horizontal overflow at 320px/768px.

## Use Case Reference

UI/UX quality gate for the frontend generally — not tied to a single numbered CU. Found via the 2026-07-02 repository audit (UI/UX dimension).

**Issue:** #610

## Changes

### Added
- `mobile` project in `frontend/playwright.config.ts` (`devices["iPhone SE"]`), matched only against the new spec so it doesn't re-run the entire existing suite under a second viewport.
- `frontend/tests/e2e/mobile-viewport.spec.ts`: asserts `document.documentElement.scrollWidth <= window.innerWidth` (no horizontal overflow) on the login page at 320px and 768px, and on the dashboard at 320px after logging in, plus that the login form's key elements stay visible at 320px.

## Testing

- [x] `npx tsc --noEmit` — no new errors (pre-existing unrelated errors in `src/tests/unit/pages.test.tsx`)
- [x] `npx playwright test --list` — the 3 new specs are correctly picked up under both the `chromium` and new `mobile` projects (411 total tests listed, up from 408)
- [x] `npx vitest run` — 219/219 unit tests still pass
- [x] `npm run build` — production build succeeds
- [x] Verified the actual assertion against the real rendered login page: built and ran `next start` locally, then drove a standalone Playwright script (bypassing this project's `global-setup`, which needs the full Docker stack with a live backend) at 320px and 768px — confirmed `NO_OVERFLOW` and all three key fields (`input-usuario`, `input-contrasenia`, `btn-ingresar`) visible at both widths, against today's actual login page
- [ ] Could not run the new spec through the full `npx playwright test` pipeline end-to-end in this sandbox — `global-setup` authenticates against a live backend on `:8080`, and Docker isn't available here (no `dockerd`). This **will** run for real in CI, since this PR touches `frontend/**` and `playwright-e2e.yml` triggers on that path (unlike #587's workflow-only change, which couldn't self-validate).

## Documentation

- [x] CHANGELOG.md updated

## Code Quality

- [x] Follows project conventions (same `testMatch`-scoped-project pattern already used for `smoke`/`health`)
- [x] No hardcoded credentials
- [x] No commented-out code / debug logging left

## Dependencies

- None new

## Breaking Changes

- None. Existing `chromium`/`smoke`/`health` projects and specs are untouched; the new `mobile` project only matches the one new spec file.

## Reviewer Notes

Worth watching this PR's own CI run (which will genuinely execute the new `mobile` project against a live Docker stack) rather than just trusting my local standalone verification, since that verification necessarily bypassed the project's real auth/session setup.


---
_Generated by [Claude Code](https://claude.ai/code/session_016CHE67J9jDYFCNWhZcTtyS)_