### PR TITLE
[#658] fix(devops): fix generate_e2e_coverage_report.py crash on real Bruno CLI output

### DIFF
--- a/.claude/loop-state.md
+++ b/.claude/loop-state.md
@@ -5,11 +5,21 @@ It did not exist before the 2026-07-22 01:00 Europe/Madrid scheduled run — cre
 
 ## Current
 
-- current_issue: 610
-- status: pr_open
-- branch: fix/610_mobile-viewport-e2e
-- pr_url: https://github.com/matiaspakua/notaire/pull/657
+- current_issue: 658
+- status: in_progress
+- branch: fix/658_bruno-json-parsing
+- pr_url: null
 - blocked_reason: null
+
+Note: 658 is a hotfix filed mid-run — PR #657 (issue #610)'s own CI run was the first real
+trigger of #587's coverage-report job (since #657 touched frontend/**), and it exposed a real
+crash: generate_e2e_coverage_report.py's _bruno_section() assumed bruno-results.json is a dict
+with a top-level "summary" key; the real @usebruno/cli output is a list of per-iteration
+objects, each with its own "results" and "summary". Downloaded the actual failing job's
+bruno-results artifact via the GitHub API to confirm the real shape before fixing (not
+guessing a second time). This is issue #4 in terms of PRs opened this run, but was not part of
+the original planned queue of 4 — it's an unplanned same-run regression fix, done immediately
+per the "fix forward" instruction rather than left for a future run.
 
 ## Completed (this and prior runs, from git history)
 
@@ -23,11 +33,13 @@ It did not exist before the 2026-07-22 01:00 Europe/Madrid scheduled run — cre
   Filed #655 to track the full rollout across the remaining ~29 controllers as deliberate
   follow-up rather than claiming it done here.
 - 587 — test(e2e): E2E coverage reports were a static hardcoded template. PR #656, squash-merged
-  at 2026-07-22T19:33:03Z. Note: this PR's own CI couldn't exercise the changed
-  `coverage-report` job (path-filtered to frontend/**/backend-api/**) — first real validation
-  happens on the next push to main touching those paths, or the weekday cron. Worth a spot
-  check by a future run or human that the first post-merge e2e-coverage-*.md report looks sane
-  (real numbers, not a crash).
+  at 2026-07-22T19:33:03Z. Its own CI couldn't exercise the changed `coverage-report` job
+  (path-filtered to frontend/**/backend-api/**) — see #658 below for what that first real run
+  found.
+- 610 — test(e2e): mobile/tablet viewport coverage in Playwright. PR #657, squash-merged at
+  2026-07-22T19:57:07Z. Its CI run (the first to touch frontend/** since #587 merged) exposed
+  a real crash in #587's script — filed and fixed as #658 (see Current, above), not folded into
+  this PR since the bug belongs to #587's file, not #610's.
 
 ## This run's queue (2026-07-22 01:00 Europe/Madrid)
 

--- a/.claude/loop-state.md
+++ b/.claude/loop-state.md
@@ -6,9 +6,9 @@ It did not exist before the 2026-07-22 01:00 Europe/Madrid scheduled run — cre
 ## Current
 
 - current_issue: 658
-- status: in_progress
+- status: pr_open
 - branch: fix/658_bruno-json-parsing
-- pr_url: null
+- pr_url: https://github.com/matiaspakua/notaire/pull/659
 - blocked_reason: null
 
 Note: 658 is a hotfix filed mid-run — PR #657 (issue #610)'s own CI run was the first real

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -212,13 +212,18 @@ jobs:
           retention-days: 14
 
       # ── Run Playwright E2E tests ──
+      # Deliberately NOT passing --reporter here (issue #658): the CLI --reporter flag
+      # fully overrides playwright.config.ts's own `reporter` array, silently dropping
+      # its outputFile paths (test-results/results.json, results.xml) that
+      # scripts/generate_e2e_coverage_report.py depends on, and the custom
+      # tests/e2e/reporters/coverage-report.ts business-coverage reporter entirely.
       - name: Run Playwright E2E tests
         continue-on-error: true
         run: |
           if [ -n "${{ inputs.test_filter }}" ]; then
-            npx playwright test --grep "${{ inputs.test_filter }}" --reporter=html,json,junit
+            npx playwright test --grep "${{ inputs.test_filter }}"
           else
-            npx playwright test --reporter=html,json,junit
+            npx playwright test
           fi
         working-directory: frontend
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   report actual pass/fail/skip counts and the actual failing test titles, with no fabricated
   numbers when a results file is missing.
 
+- **`generate_e2e_coverage_report.py` crashed on the real Bruno CLI output** (issue #658,
+  found on #587's own first real CI run): `_bruno_section()` assumed `bruno-results.json` is a
+  JSON object with a top-level `"summary"` key; the real `@usebruno/cli` output is a JSON array
+  of per-iteration objects, each with its own `"summary"`. Verified the fix against the actual
+  artifact from the failing job rather than guessing the schema a second time, and added a
+  regression test using that real (trimmed) sample. Also found and fixed the reason Playwright
+  results always showed "not found": `playwright-e2e.yml`'s "Run Playwright E2E tests" step
+  passed `--reporter=html,json,junit` on the CLI, which fully overrides
+  `playwright.config.ts`'s own `reporter` array — silently dropping the `outputFile` paths this
+  script depends on, and the custom `tests/e2e/reporters/coverage-report.ts` business-coverage
+  reporter entirely. Removed the CLI override so the config's reporters (which already have the
+  correct paths) take effect. Bruno failures are now also surfaced in the report's Action Items
+  section, not just Playwright ones — the discovery run had 137 failing Bruno tests silently
+  reported as "no action items" before this fix.
+
 - **Flyway single source of truth**: Removed dual schema source (init-db + Flyway)
   - Removed `init-db:/docker-entrypoint-initdb.d` volume mount from docker-compose.yml
   - PostgreSQL now starts empty; Flyway applies all V1→V11 migrations on startup

--- a/scripts/fixtures/bruno-results-sample.json
+++ b/scripts/fixtures/bruno-results-sample.json
@@ -1,0 +1,174 @@
+[
+  {
+    "iterationIndex": 0,
+    "results": [
+      {
+        "test": {
+          "filename": "auditoria/get-registros-auditoria.yml"
+        },
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:8080/api/v1/registro-auditoria",
+          "headers": {
+            "content-type": null
+          }
+        },
+        "response": {
+          "status": 401,
+          "statusText": "",
+          "headers": {
+            "vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+            "x-content-type-options": "nosniff",
+            "x-xss-protection": "0",
+            "cache-control": "no-cache, no-store, max-age=0, must-revalidate",
+            "pragma": "no-cache",
+            "expires": "0",
+            "x-frame-options": "DENY",
+            "content-type": "application/json",
+            "transfer-encoding": "chunked",
+            "date": "Wed, 22 Jul 2026 19:43:54 GMT",
+            "keep-alive": "timeout=60",
+            "connection": "keep-alive"
+          },
+          "data": {
+            "timestamp": "2026-07-22T19:43:54.462Z",
+            "status": 401,
+            "error": "Unauthorized",
+            "path": "/api/v1/registro-auditoria"
+          },
+          "url": "http://localhost/api/v1/registro-auditoria",
+          "responseTime": 38,
+          "duration": 38,
+          "size": 112
+        },
+        "error": null,
+        "status": "pass",
+        "assertionResults": [],
+        "testResults": [
+          {
+            "description": "Status 200",
+            "status": "fail",
+            "error": "expected 401 to equal 200",
+            "uid": "SfAIP91OhfS7pa7YXsNPn"
+          },
+          {
+            "description": "Response is array",
+            "status": "fail",
+            "error": "expected { \u2026(4) } to be an array",
+            "uid": "0j3mhKZEnSZVAx4kxZyaB"
+          }
+        ],
+        "preRequestTestResults": [],
+        "postResponseTestResults": [],
+        "shouldStopRunnerExecution": false,
+        "runDuration": 0.25541129,
+        "name": "Get All Registros de Auditoria",
+        "suitename": "/home/runner/work/notaire/notaire/backend-api/api-test/auditoria/get-registros-auditoria",
+        "path": "auditoria/get-registros-auditoria.yml",
+        "iterationIndex": 0
+      },
+      {
+        "test": {
+          "filename": "auth/login.yml"
+        },
+        "request": {
+          "method": "POST",
+          "url": "http://localhost:8080/api/v1/usuarios/login",
+          "headers": {
+            "content-type": "application/json"
+          },
+          "data": "{ \"nombre\": \"admin\", \"contrasenia\": \"admin\" }"
+        },
+        "response": {
+          "status": 200,
+          "statusText": "",
+          "headers": {
+            "vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+            "x-content-type-options": "nosniff",
+            "x-xss-protection": "0",
+            "cache-control": "no-cache, no-store, max-age=0, must-revalidate",
+            "pragma": "no-cache",
+            "expires": "0",
+            "x-frame-options": "DENY",
+            "content-type": "application/json",
+            "transfer-encoding": "chunked",
+            "date": "Wed, 22 Jul 2026 19:43:55 GMT",
+            "keep-alive": "timeout=60",
+            "connection": "keep-alive"
+          },
+          "data": {
+            "estado": true,
+            "tipo": "Escribano",
+            "valido": true,
+            "idUsuario": 1,
+            "nombre": "admin",
+            "version": 0,
+            "personas": {
+              "apellido": "Garcia",
+              "nombre": "Juan Carlos",
+              "idPersona": 1
+            },
+            "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsImlhdCI6MTc4NDc0OTQzNSwiZXhwIjoxNzg0ODM1ODM1fQ.JwRwvak0BHlPB-Wm-Ywk4hZiV0m38_IIcqr8cyYXYAA"
+          },
+          "url": "http://localhost/api/v1/usuarios/login",
+          "responseTime": 515,
+          "duration": 515,
+          "size": 303
+        },
+        "error": null,
+        "status": "pass",
+        "assertionResults": [],
+        "testResults": [
+          {
+            "description": "Status 200",
+            "status": "pass",
+            "uid": "ICPszBlYczrl-d6T8ERoL"
+          },
+          {
+            "description": "Response has valido field",
+            "status": "pass",
+            "uid": "bHoiEoj4CtEqgHETDE9zA"
+          },
+          {
+            "description": "admin login is valido",
+            "status": "pass",
+            "uid": "pcKlBWVZufA5V_YhIYKSp"
+          },
+          {
+            "description": "Stores user_id on success",
+            "status": "pass",
+            "uid": "8ogjlzo9Ir9177YYomAx-"
+          }
+        ],
+        "preRequestTestResults": [],
+        "postResponseTestResults": [],
+        "shouldStopRunnerExecution": false,
+        "runDuration": 0.627611294,
+        "name": "Login",
+        "suitename": "/home/runner/work/notaire/notaire/backend-api/api-test/auth/login",
+        "path": "auth/login.yml",
+        "iterationIndex": 0
+      }
+    ],
+    "summary": {
+      "totalRequests": 86,
+      "passedRequests": 3,
+      "failedRequests": 83,
+      "errorRequests": 0,
+      "skippedRequests": 0,
+      "skippedByBail": 0,
+      "totalAssertions": 0,
+      "passedAssertions": 0,
+      "failedAssertions": 0,
+      "totalTests": 147,
+      "passedTests": 10,
+      "failedTests": 137,
+      "totalPreRequestTests": 0,
+      "passedPreRequestTests": 0,
+      "failedPreRequestTests": 0,
+      "totalPostResponseTests": 0,
+      "passedPostResponseTests": 0,
+      "failedPostResponseTests": 0
+    }
+  }
+]

--- a/scripts/generate_e2e_coverage_report.py
+++ b/scripts/generate_e2e_coverage_report.py
@@ -60,32 +60,56 @@ def _playwright_section(pw_data):
     return "\n".join(lines), failing
 
 
+def _bruno_summaries(bruno_data):
+    """`@usebruno/cli run --reporter-json` writes a LIST of per-iteration
+    objects (one per `--iteration-count` run, typically just one), each with
+    its own "summary" — not a single top-level object with a "summary" key
+    (issue #658, verified against a real CI artifact rather than guessed)."""
+    if isinstance(bruno_data, list):
+        return [item["summary"] for item in bruno_data if isinstance(item, dict) and item.get("summary")]
+    if isinstance(bruno_data, dict) and bruno_data.get("summary"):
+        return [bruno_data["summary"]]
+    return []
+
+
 def _bruno_section(bruno_data):
+    """Returns (markdown_summary, failed_test_count)."""
     if bruno_data is None:
-        return "No Bruno API test results found — the Bruno run may not have completed."
+        return "No Bruno API test results found — the Bruno run may not have completed.", 0
 
-    summary = bruno_data.get("summary")
-    if not summary:
-        return "Bruno results file present but its summary format was not recognized."
+    summaries = _bruno_summaries(bruno_data)
+    if not summaries:
+        return "Bruno results file present but its summary format was not recognized.", 0
 
-    total = summary.get("totalRequests", "?")
-    passed = summary.get("passedRequests", "?")
-    failed = summary.get("failedRequests", "?")
-    return (
-        f"- **Total requests:** {total}\n"
-        f"- **Passed:** {passed}\n"
-        f"- **Failed:** {failed}"
+    total_requests = sum(s.get("totalRequests", 0) for s in summaries)
+    passed_requests = sum(s.get("passedRequests", 0) for s in summaries)
+    failed_requests = sum(s.get("failedRequests", 0) for s in summaries)
+    total_tests = sum(s.get("totalTests", 0) for s in summaries)
+    passed_tests = sum(s.get("passedTests", 0) for s in summaries)
+    failed_tests = sum(s.get("failedTests", 0) for s in summaries)
+
+    summary_md = (
+        f"- **Total requests:** {total_requests}\n"
+        f"- **Passed requests:** {passed_requests}\n"
+        f"- **Failed requests:** {failed_requests}\n"
+        f"- **Total tests/assertions:** {total_tests}\n"
+        f"- **Passed tests:** {passed_tests}\n"
+        f"- **Failed tests:** {failed_tests}"
     )
+    return summary_md, failed_tests
 
 
 def build_report(pw_data, bruno_data, report_date, trigger):
     pw_summary, failing_specs = _playwright_section(pw_data)
-    bruno_summary = _bruno_section(bruno_data)
+    bruno_summary, bruno_failed_tests = _bruno_section(bruno_data)
 
-    if failing_specs:
-        action_items = "\n".join(f"- `{file}` — {title}" for title, file in failing_specs)
-    else:
-        action_items = "No action items — all executed tests passed."
+    items = [f"- `{file}` — {title}" for title, file in failing_specs]
+    if bruno_failed_tests:
+        items.append(
+            f"- Bruno API tests: {bruno_failed_tests} failing assertion(s) — see the "
+            f"`bruno-results` artifact for per-request detail."
+        )
+    action_items = "\n".join(items) if items else "No action items — all executed tests passed."
 
     return f"""---
 title: E2E Coverage Report - {report_date}

--- a/scripts/test_generate_e2e_coverage_report.py
+++ b/scripts/test_generate_e2e_coverage_report.py
@@ -1,16 +1,20 @@
 #!/usr/bin/env python3
 """
-Tests for generate_e2e_coverage_report.build_report (issue #587).
+Tests for generate_e2e_coverage_report.build_report (issue #587, #658).
 
 Plain stdlib unittest — no extra dependency, consistent with this project's
 other one-off CI scripts (generate-coverage-snapshot.py) which also have no
 test framework wired in. Run with: python3 scripts/test_generate_e2e_coverage_report.py
 """
+import json
+import os
 import unittest
 
 from generate_e2e_coverage_report import build_report
 
 OLD_HARDCODED_ACTION_ITEM = "Fix backend 500 errors on testimonio endpoints (CU07, CU08)"
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 
 
 def playwright_result(expected=10, unexpected=0, skipped=0, flaky=0, failing_specs=None):
@@ -23,8 +27,28 @@ def playwright_result(expected=10, unexpected=0, skipped=0, flaky=0, failing_spe
     }
 
 
-def bruno_result(total=20, passed=20, failed=0):
-    return {"summary": {"totalRequests": total, "passedRequests": passed, "failedRequests": failed}}
+def bruno_result(total=20, passed=20, failed=0, total_tests=0, passed_tests=0, failed_tests=0):
+    """Shape actually produced by `@usebruno/cli run --reporter-json` (issue #658):
+    a LIST of per-iteration objects, each carrying its own "summary" — not a
+    single top-level object with a "summary" key.
+    """
+    return [{
+        "iterationIndex": 0,
+        "results": [],
+        "summary": {
+            "totalRequests": total,
+            "passedRequests": passed,
+            "failedRequests": failed,
+            "totalTests": total_tests,
+            "passedTests": passed_tests,
+            "failedTests": failed_tests,
+        },
+    }]
+
+
+def load_real_bruno_fixture():
+    with open(os.path.join(FIXTURES_DIR, "bruno-results-sample.json"), encoding="utf-8") as f:
+        return json.load(f)
 
 
 class BuildReportTest(unittest.TestCase):
@@ -89,6 +113,52 @@ class BuildReportTest(unittest.TestCase):
         )
         self.assertIn("2026-07-22", report)
         self.assertIn("pull_request", report)
+
+    def test_reports_real_bruno_request_and_test_counts(self):
+        report = build_report(
+            pw_data=playwright_result(),
+            bruno_data=bruno_result(total=86, passed=3, failed=83, total_tests=147,
+                                      passed_tests=10, failed_tests=137),
+            report_date="2026-07-22",
+            trigger="pull_request",
+        )
+        self.assertIn("86", report)
+        self.assertIn("83", report)
+        self.assertIn("137", report)
+
+    def test_handles_unrecognized_bruno_shape_honestly_without_crashing(self):
+        report = build_report(
+            pw_data=playwright_result(),
+            bruno_data=["totally", "unexpected", "shape"],
+            report_date="2026-07-22",
+            trigger="pull_request",
+        )
+        self.assertIn("not recognized", report)
+
+    def test_surfaces_bruno_failures_as_action_items_even_when_playwright_is_green(self):
+        report = build_report(
+            pw_data=playwright_result(expected=10, unexpected=0),
+            bruno_data=bruno_result(total=86, passed=3, failed=83, total_tests=147,
+                                     passed_tests=10, failed_tests=137),
+            report_date="2026-07-22",
+            trigger="pull_request",
+        )
+        self.assertNotIn("No action items", report)
+        self.assertIn("137", report)
+        self.assertIn("Bruno", report)
+
+    def test_handles_real_bruno_cli_array_shape_without_crashing(self):
+        """Regression test (issue #658): the actual array-of-iterations shape
+        produced by a real `@usebruno/cli run --reporter-json` invocation,
+        captured from a live CI run's failing job artifact — not guessed."""
+        report = build_report(
+            pw_data=playwright_result(),
+            bruno_data=load_real_bruno_fixture(),
+            report_date="2026-07-22",
+            trigger="pull_request",
+        )
+        self.assertNotIn("not recognized", report)
+        self.assertIn("Total requests", report)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Fixes a regression in #587's `scripts/generate_e2e_coverage_report.py`, caught by its own first real CI run: `_bruno_section()` crashed with `AttributeError: 'list' object has no attribute 'get'` because it assumed `bruno-results.json` is a dict with a top-level `"summary"` key, when the real `@usebruno/cli` output is an array of per-iteration objects.
- Also fixes the reason "Playwright E2E Results" always showed "not found": the workflow's Playwright invocation passed `--reporter=html,json,junit` on the CLI, which overrides `playwright.config.ts`'s reporter array entirely.
- Bruno failures are now surfaced in the report's Action Items section too.

## Use Case Reference

Same as #587/#610 — CI/DevOps observability infrastructure, not tied to a numbered CU.

**Issue:** #658

## How this was found and verified

PR #657 (issue #610) touched `frontend/**`, so it was the first PR since #587 merged to actually trigger `playwright-e2e.yml`'s `coverage-report` job for real. It failed with the `AttributeError` above (job log: https://github.com/matiaspakua/notaire/actions/runs/29951941384/job/89035072980). Rather than guess the correct Bruno JSON schema a second time, I downloaded the actual `bruno-results` artifact from that failing job via the GitHub API (`actions_get` → `download_workflow_run_artifact`) and inspected it directly. Real shape:

```json
[
  {
    "iterationIndex": 0,
    "results": [ /* one entry per API request, each with its own testResults */ ],
    "summary": { "totalRequests": 86, "passedRequests": 3, "failedRequests": 83, "totalTests": 147, "passedTests": 10, "failedTests": 137, ... }
  }
]
```

A trimmed copy is committed as `scripts/fixtures/bruno-results-sample.json` and used in a genuine regression test. I also downloaded that same run's `playwright-report` artifact (118MB, extracted just the file listing) and confirmed `test-results/results.json`/`results.xml` are **not present at all** in the real upload — which is what led to finding the `--reporter` CLI-override bug.

## Changes

### Fixed
- `scripts/generate_e2e_coverage_report.py`: `_bruno_section()` now handles the real array-of-iterations shape (summing across iterations if there happen to be more than one), falls back to a dict-with-summary shape defensively, and reports an honest "not recognized" message for anything else — never crashes.
- `.github/workflows/playwright-e2e.yml`: removed `--reporter=html,json,junit` from the "Run Playwright E2E tests" step so `playwright.config.ts`'s own `reporter` array (already correctly configured, and includes the custom `coverage-report.ts` business-coverage reporter that was also being silently dropped) takes effect.
- `build_report()`: Bruno's `failedTests` count is now included in the Action Items section alongside Playwright's failing spec titles, instead of only ever reflecting Playwright.

### Added
- `scripts/fixtures/bruno-results-sample.json`: real (trimmed to 2 of 86 requests) sample captured from the failing job's artifact.
- 4 new tests in `scripts/test_generate_e2e_coverage_report.py` (10 total now): real-shape regression test, unrecognized-shape honesty test, real request/test count verification, and Bruno-failures-surfaced-as-action-items.

## Testing

- [x] `python3 scripts/test_generate_e2e_coverage_report.py` — 10/10 pass (was 6, all passing against the *wrong* assumed schema before this fix — the new tests specifically target the real schema)
- [x] Ran the actual script end-to-end against the real downloaded `bruno-results.json` from the failing job — produces correct output (86 total / 3 passed / 83 failed requests, 147/10/137 tests) instead of crashing
- [x] Workflow YAML re-parses successfully after edits
- [ ] Like #587/#610 before it, this PR only touches `.github/workflows/`, `scripts/`, and `.claude/` — none of which match `playwright-e2e.yml`'s `frontend/**`/`backend-api/**` path trigger, so this PR's own CI can't re-exercise the `coverage-report` job. High confidence in this fix specifically *because* it was built directly against real captured artifacts rather than another guess, but the next real trigger (push to main touching those paths, or the weekday cron) is worth a spot check.

## Documentation

- [x] CHANGELOG.md updated

## Code Quality

- [x] No hardcoded credentials
- [x] No commented-out code / debug logging left
- [x] Temporary local diagnostic files (downloaded artifacts) not committed — only the trimmed fixture

## Dependencies

- None new

## Breaking Changes

- None. Report output format is additive (more detail in the Bruno section, Bruno failures now counted in Action Items).

## Reviewer Notes

This is an unplanned mid-run hotfix for a regression this same session introduced in #587 — filed as its own issue (#658) and branch per the "one issue = one branch = one PR" rule, rather than folded into #610's PR (which didn't touch this file) or #587's (already merged).


---
_Generated by [Claude Code](https://claude.ai/code/session_016CHE67J9jDYFCNWhZcTtyS)_