### PR TITLE
[#588] fix(coverage): reconcile contradicting JaCoCo coverage-floor numbers

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -23,9 +23,9 @@ Coverage is split into an **aspirational target** and an **enforced ratchet floo
 
 - **Long-term target**: 80% line / 80% branch.
 - **Enforced gate** (`jacoco:check`, bound to `mvn verify`, BUNDLE scope, legacy
-  `jpa`/`servicios.Administrador*` packages excluded): a ratchet floor set just below
-  the current real coverage — **28% line / 14% branch** as of 2026-05-29 (actual:
-  ~29% line / ~15% branch). The build fails if coverage drops below the floor.
+  `jpa`/`service.Administrador*` packages excluded): a ratchet floor of
+  **70% line / 25% branch** as of 2026-06-16, Phase 8 (actual: ~84% line / ~74% branch
+  as of 2026-07-23). The build fails if coverage drops below the floor.
 - **Policy**: raise the floor as coverage improves; never lower it. The historical
   per-class 80% rule was bound to `<phase>none</phase>` and never ran, so the prior
   "80% enforced" claim was inaccurate.

--- a/backend-api/pom.xml
+++ b/backend-api/pom.xml
@@ -259,11 +259,11 @@
                                 <exclude>sun/**/*</exclude>
                                 <exclude>com/licensis/notaire/jpa/**/*</exclude>
                                 <exclude>com/licensis/notaire/negocio/ControllerNegocio*</exclude>
-                                <exclude>com/licensis/notaire/servicios/AdministradorJpa*</exclude>
-                                <exclude>com/licensis/notaire/servicios/AdministradorReportes*</exclude>
-                                <exclude>com/licensis/notaire/servicios/AdministradorSesion*</exclude>
-                                <exclude>com/licensis/notaire/servicios/AdministradorValidaciones*</exclude>
-                                <exclude>com/licensis/notaire/servicios/Conexion*</exclude>
+                                <exclude>com/licensis/notaire/service/AdministradorJpa*</exclude>
+                                <exclude>com/licensis/notaire/service/AdministradorReportes*</exclude>
+                                <exclude>com/licensis/notaire/service/AdministradorSesion*</exclude>
+                                <exclude>com/licensis/notaire/service/AdministradorValidaciones*</exclude>
+                                <exclude>com/licensis/notaire/service/Conexion*</exclude>
                                 <exclude>com/licensis/notaire/NotaireBackendApplication*</exclude>
                             </excludes>
                         </configuration>
@@ -279,11 +279,11 @@
                                 <exclude>com/licensis/notaire/jpa/**/*</exclude>
                                 <exclude>com/licensis/notaire/jpa/exceptions/**/*</exclude>
                                 <exclude>com/licensis/notaire/negocio/ControllerNegocio*</exclude>
-                                <exclude>com/licensis/notaire/servicios/AdministradorJpa*</exclude>
-                                <exclude>com/licensis/notaire/servicios/AdministradorReportes*</exclude>
-                                <exclude>com/licensis/notaire/servicios/AdministradorSesion*</exclude>
-                                <exclude>com/licensis/notaire/servicios/AdministradorValidaciones*</exclude>
-                                <exclude>com/licensis/notaire/servicios/Conexion*</exclude>
+                                <exclude>com/licensis/notaire/service/AdministradorJpa*</exclude>
+                                <exclude>com/licensis/notaire/service/AdministradorReportes*</exclude>
+                                <exclude>com/licensis/notaire/service/AdministradorSesion*</exclude>
+                                <exclude>com/licensis/notaire/service/AdministradorValidaciones*</exclude>
+                                <exclude>com/licensis/notaire/service/Conexion*</exclude>
                                 <exclude>com/licensis/notaire/NotaireBackendApplication*</exclude>
                             </excludes>
                         </configuration>
@@ -293,7 +293,8 @@
                         <!--
                             Enforced ratchet floor (runs on `mvn verify`). Legacy jpa package
                             is excluded from instrumentation so numbers reflect modern code only.
-                            Current: ~78% line / ~62% branch (2026-06-16, Phase 8).
+                            Floor: 70% line / 25% branch, set 2026-06-16 (Phase 8).
+                            Actual: ~84% line / ~74% branch as of 2026-07-23.
                             Long-term target: 80% line / 80% branch.
                             Raise these minimums as coverage improves; never lower.
                         -->
@@ -305,11 +306,11 @@
                             <excludes>
                                 <exclude>com/licensis/notaire/jpa/**/*</exclude>
                                 <exclude>com/licensis/notaire/negocio/ControllerNegocio*</exclude>
-                                <exclude>com/licensis/notaire/servicios/AdministradorJpa*</exclude>
-                                <exclude>com/licensis/notaire/servicios/AdministradorReportes*</exclude>
-                                <exclude>com/licensis/notaire/servicios/AdministradorSesion*</exclude>
-                                <exclude>com/licensis/notaire/servicios/AdministradorValidaciones*</exclude>
-                                <exclude>com/licensis/notaire/servicios/Conexion*</exclude>
+                                <exclude>com/licensis/notaire/service/AdministradorJpa*</exclude>
+                                <exclude>com/licensis/notaire/service/AdministradorReportes*</exclude>
+                                <exclude>com/licensis/notaire/service/AdministradorSesion*</exclude>
+                                <exclude>com/licensis/notaire/service/AdministradorValidaciones*</exclude>
+                                <exclude>com/licensis/notaire/service/Conexion*</exclude>
                                 <exclude>com/licensis/notaire/NotaireBackendApplication*</exclude>
                             </excludes>
                             <rules>

--- a/backend-api/src/test/java/com/licensis/notaire/unit/JacocoCoverageConfigConsistencyTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/unit/JacocoCoverageConfigConsistencyTest.java
@@ -1,0 +1,73 @@
+package com.licensis.notaire.unit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards against the JaCoCo coverage-floor numbers drifting out of sync again across
+ * pom.xml, CLAUDE.md and .claude/rules/code-quality.md (see issue #588).
+ */
+class JacocoCoverageConfigConsistencyTest {
+
+    private static final String POM_PATH = "pom.xml";
+    private static final String CLAUDE_MD_PATH = "../CLAUDE.md";
+    private static final String CODE_QUALITY_MD_PATH = "../.claude/rules/code-quality.md";
+    private static final Pattern LINE_MINIMUM_PATTERN = Pattern.compile(
+            "<counter>LINE</counter>\\s*<value>COVEREDRATIO</value>\\s*<minimum>([\\d.]+)</minimum>");
+    private static final Pattern BRANCH_MINIMUM_PATTERN = Pattern.compile(
+            "<counter>BRANCH</counter>\\s*<value>COVEREDRATIO</value>\\s*<minimum>([\\d.]+)</minimum>");
+
+    @Test
+    @DisplayName("Should not reference the nonexistent servicios package in JaCoCo exclusions")
+    void shouldNotReferenceNonexistentServiciosPackageInPomExclusions() throws IOException {
+        String pomContent = Files.readString(Paths.get(POM_PATH));
+
+        assertThat(pomContent)
+                .as("pom.xml JaCoCo exclusions must reference the real 'service' package, not 'servicios'")
+                .doesNotContain("com/licensis/notaire/servicios/");
+    }
+
+    @Test
+    @DisplayName("Should have the enforced coverage floor documented consistently in code-quality.md")
+    void shouldHaveConsistentCoverageFloorAcrossDocsAndPom() throws IOException {
+        String pomContent = Files.readString(Paths.get(POM_PATH));
+        String codeQualityMd = Files.readString(Paths.get(CODE_QUALITY_MD_PATH));
+
+        int linePercent = extractPercent(pomContent, LINE_MINIMUM_PATTERN);
+        int branchPercent = extractPercent(pomContent, BRANCH_MINIMUM_PATTERN);
+
+        String expectedFragment = linePercent + "% line / " + branchPercent + "% branch";
+
+        assertThat(codeQualityMd)
+                .as("code-quality.md is the single source of truth for the enforced floor and must match "
+                        + "pom.xml's <minimum> values")
+                .contains(expectedFragment);
+    }
+
+    @Test
+    @DisplayName("Should not restate a stale enforced coverage floor in CLAUDE.md")
+    void shouldNotRestateStaleCoverageFloorInClaudeMd() throws IOException {
+        String claudeMd = Files.readString(Paths.get(CLAUDE_MD_PATH));
+
+        assertThat(claudeMd)
+                .as("CLAUDE.md must not duplicate a specific enforced-floor percentage (single source of truth "
+                        + "is code-quality.md) — the historical '28% line / 14% branch' figure went stale once "
+                        + "pom.xml's floor was raised in Phase 8")
+                .doesNotContain("28% line / 14% branch");
+    }
+
+    private int extractPercent(String pomContent, Pattern pattern) {
+        Matcher matcher = pattern.matcher(pomContent);
+        assertThat(matcher.find()).as("pom.xml must declare a %s COVEREDRATIO minimum", pattern).isTrue();
+        return Math.round(Float.parseFloat(matcher.group(1)) * 100);
+    }
+}


### PR DESCRIPTION
## Summary

- `CLAUDE.md`/`code-quality.md` said the enforced floor was 28%/14%, `pom.xml`'s own comment said ~78%/~62%, and the actually-enforced `<minimum>` values were 70%/25% — three different numbers describing the same gate.
- Fixed a dead JaCoCo exclusion path referencing the nonexistent `com/licensis/notaire/servicios/*` package (the real package is `service`), which meant `AdministradorJpa`/`AdministradorReportes`/`AdministradorSesion`/`AdministradorValidaciones`/`Conexion` were silently being counted in the coverage gate instead of excluded as intended.
- Re-measured real coverage after the fix: **~84% line / ~74% branch**. `code-quality.md` (kept as the single source of truth for the floor number) and the `pom.xml` comment now agree with the actual, unchanged 70%/25% enforced minimum; removed the stale duplicate figure from `CLAUDE.md` instead of just updating it, so there's only one place left to drift.

**Issue:** #588
**Use Case(s):** N/A — repository-audit config/documentation consistency fix, not tied to a functional Use Case.

## Changes

### Added
- `JacocoCoverageConfigConsistencyTest` — guards against the exclusion-path typo and the floor-number drift recurring.

### Modified
- `backend-api/pom.xml` — fixed `servicios` → `service` in all three JaCoCo exclusion blocks; updated the stale inline comment.
- `.claude/rules/code-quality.md` — corrected floor to 70%/25% (matching the real enforced `pom.xml` value) and updated the actual-coverage figure.
- `CLAUDE.md` — removed the stale duplicate "28%/14%" figure (single source of truth is now `code-quality.md` alone).

## Testing

- [x] Unit tests added/updated (`JacocoCoverageConfigConsistencyTest`, written failing first per TDD, then made green)
- [x] Integration tests passing (unaffected by this change)
- [ ] E2E tests passing (N/A — no frontend/UI change)
- [x] Test coverage: ~84% line / ~74% branch (target: ≥80% line)
- [x] Manual testing completed (`mvn test -pl backend-api -am -Dtest="**/unit/*"` green; `mvn checkstyle:check` clean)

## Documentation

- [x] Updated architecture documentation (`.claude/rules/code-quality.md`, `CLAUDE.md`)

## Code Quality

- [x] Code follows project conventions
- [x] No hardcoded credentials or secrets
- [x] No large files (>5MB)
- [x] No commented-out code
- [x] No debug logging left

## Dependencies

- No new dependencies

## Breaking Changes

- None — the enforced `<minimum>` values in `pom.xml` are unchanged (still 0.70/0.25); only the exclusion path and documentation were corrected.

## Deployment Notes

None.

## Reviewer Notes

While establishing a clean coverage baseline for this fix, I found the full `mvn test -pl backend-api -am` run currently fails 5 tests on `main` (`WorkflowTraceApiH2IntegrationTest` + `WorkflowTransitionIntegrationTest`) due to order-dependent shared H2 state pollution — confirmed by running those classes in isolation, where they pass cleanly. This is unrelated to this PR's scope; filed as #661 rather than folded in here.

---

Closes #588


---
_Generated by [Claude Code](https://claude.ai/code/session_01L3VfSRHLVCDFsHVkfdQaqi)_