### PR TITLE
[#594] feat(perf): add minimal k6 load-test suite for top-traffic endpoints

### DIFF
--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -1,0 +1,84 @@
+name: Performance - k6 Load Test
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'  # Weekly, Mondays 4am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  load-test:
+    name: k6 Load Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: notaire
+          POSTGRES_USER: notaire
+          POSTGRES_PASSWORD: notaire
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Build backend
+        run: mvn clean package -pl backend-api -am -DskipTests -q
+
+      - name: Start backend API
+        run: |
+          java -jar backend-api/target/*.jar \
+            --server.port=8080 \
+            --spring.datasource.url=jdbc:postgresql://localhost:5432/notaire \
+            --spring.datasource.username=notaire \
+            --spring.datasource.password=notaire \
+            --spring.jpa.hibernate.ddl-auto=update \
+            --jwt.secret="${JWT_SECRET}" \
+            --actuator.security.username="${ACTUATOR_USER}" \
+            --actuator.security.password="${ACTUATOR_PASSWORD}" \
+            --app.admin.username="${ADMIN_USER}" \
+            --app.admin.password="${ADMIN_PASSWORD}" &
+          echo "Waiting for backend..."
+          sleep 15
+          timeout 60 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8080/actuator/health)" != "200" ]]; do sleep 2; done'
+          echo "Backend is ready"
+        env:
+          JWT_SECRET: ci-perf-test-only-jwt-secret-do-not-use-in-prod-!!
+          ACTUATOR_USER: ci-perf-test-actuator-user
+          ACTUATOR_PASSWORD: ci-perf-test-actuator-pass
+          ADMIN_USER: ci-perf-test-admin
+          ADMIN_PASSWORD: ci-perf-test-admin-pass
+
+      - name: Run k6 load test
+        uses: grafana/k6-action@v0.3.1
+        with:
+          filename: performance-test/k6/load-test.js
+        env:
+          BASE_URL: http://localhost:8080
+          ADMIN_USER: ci-perf-test-admin
+          ADMIN_PASSWORD: ci-perf-test-admin-pass
+
+      - name: Upload k6 results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k6-load-test-results
+          path: |
+            summary.json
+          retention-days: 30
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -556,6 +556,13 @@ cd frontend && npm run test:e2e
 # Tests HTTP con Bruno (requiere API corriendo)
 bash integration-test/scripts/test.sh
 
+# ────── PERFORMANCE ──────
+
+# Load test con k6 (requiere API corriendo, ver performance-test/k6/load-test.js)
+k6 run -e BASE_URL=http://localhost:8080 -e ADMIN_USER=admin -e ADMIN_PASSWORD=admin \
+  performance-test/k6/load-test.js
+# Ejecutado automáticamente semanal (no bloquea PRs) por .github/workflows/performance-test.yml
+
 # ────── TODO ──────
 
 # Verificación completa

--- a/performance-test/k6/load-test.js
+++ b/performance-test/k6/load-test.js
@@ -1,0 +1,60 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+// Minimal load test for the highest-traffic read endpoints (issue #594).
+// Run manually with:
+//   k6 run -e BASE_URL=http://localhost:8080 \
+//           -e ADMIN_USER=admin -e ADMIN_PASSWORD=admin \
+//           performance-test/k6/load-test.js
+// Wired into .github/workflows/performance-test.yml as a scheduled (not per-PR) CI job.
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = __ENV.ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = __ENV.ADMIN_PASSWORD || 'admin';
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 10 },  // Ramp up to 10 users
+    { duration: '1m', target: 10 },   // Stay at 10 users
+    { duration: '30s', target: 0 },   // Ramp down
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<500'],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+export function setup() {
+  const loginRes = http.post(
+      `${BASE_URL}/api/v1/usuarios/login`,
+      JSON.stringify({ nombre: ADMIN_USER, contrasenia: ADMIN_PASSWORD }),
+      { headers: { 'Content-Type': 'application/json' } },
+  );
+
+  check(loginRes, {
+    'login succeeded': (r) => r.status === 200 && r.json('token') !== undefined,
+  });
+
+  return { token: loginRes.json('token') };
+}
+
+export default function (data) {
+  const params = {
+    headers: { Authorization: `Bearer ${data.token}` },
+  };
+
+  const endpoints = [
+    { name: 'gestiones', url: `${BASE_URL}/api/v1/gestiones` },
+    { name: 'presupuestos', url: `${BASE_URL}/api/v1/presupuestos` },
+    { name: 'tramites', url: `${BASE_URL}/api/v1/tramites` },
+  ];
+
+  for (const endpoint of endpoints) {
+    const res = http.get(endpoint.url, params);
+    check(res, {
+      [`${endpoint.name}: status is 200`]: (r) => r.status === 200,
+    });
+  }
+
+  sleep(1);
+}

--- a/scripts/test_performance_test_assets.py
+++ b/scripts/test_performance_test_assets.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Validates the k6 load-test suite and its CI wiring (issue #594).
+
+Plain stdlib unittest, consistent with this project's other one-off CI/config
+validation scripts (see scripts/test_generate_e2e_coverage_report.py).
+Run with: python3 scripts/test_performance_test_assets.py
+"""
+import os
+import unittest
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+K6_SCRIPT_PATH = os.path.join(REPO_ROOT, "performance-test", "k6", "load-test.js")
+WORKFLOW_PATH = os.path.join(REPO_ROOT, ".github", "workflows", "performance-test.yml")
+
+
+class K6LoadTestScriptTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        with open(K6_SCRIPT_PATH, encoding="utf-8") as f:
+            cls.script = f.read()
+
+    def test_imports_k6_http_module(self):
+        self.assertIn("from 'k6/http'", self.script)
+
+    def test_declares_stages_and_thresholds(self):
+        self.assertIn("stages:", self.script)
+        self.assertIn("thresholds:", self.script)
+        self.assertIn("http_req_duration", self.script)
+        self.assertIn("http_req_failed", self.script)
+
+    def test_authenticates_in_setup_and_reuses_token(self):
+        self.assertIn("export function setup()", self.script)
+        self.assertIn("/api/v1/usuarios/login", self.script)
+        self.assertIn("Authorization", self.script)
+        self.assertIn("Bearer", self.script)
+
+    def test_covers_the_highest_traffic_endpoints(self):
+        for path in ("/api/v1/gestiones", "/api/v1/presupuestos", "/api/v1/tramites"):
+            self.assertIn(path, self.script)
+
+
+class PerformanceTestWorkflowTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        with open(WORKFLOW_PATH, encoding="utf-8") as f:
+            cls.workflow = yaml.safe_load(f)
+
+    def test_is_scheduled_not_gated_on_pull_requests(self):
+        triggers = self.workflow.get(True, self.workflow.get("on"))
+        self.assertIn("schedule", triggers, "workflow must run on a schedule")
+        self.assertNotIn("pull_request", triggers, "load tests must not gate every PR")
+
+    def test_runs_k6_against_a_live_stack(self):
+        raw = yaml.dump(self.workflow)
+        self.assertIn("k6-action", raw)
+        self.assertIn("performance-test/k6/load-test.js", raw)
+        self.assertIn("actuator/health", raw)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- No performance/load testing existed anywhere in the repository (only doc references in ADR-006 and the testing skill, no actual test assets or CI job).
- Adds a minimal k6 suite covering the highest-traffic read endpoints (`gestiones`, `presupuestos`, `tramites`), authenticating via the existing JWT `/api/v1/usuarios/login` endpoint in `setup()`.
- Wires it into a new **scheduled** (weekly, not per-PR) CI workflow so it doesn't gate every PR the way per-commit checks do, per the issue's suggested fix.

**Issue:** #594
**Use Case(s):** N/A — repository-audit performance-testing infrastructure gap, not tied to a functional Use Case.

## Changes

### Added
- `performance-test/k6/load-test.js` — k6 script: ramps to 10 VUs, hits the three target endpoints with a Bearer token from login, thresholds `p(95)<500ms` / error rate `<1%`.
- `.github/workflows/performance-test.yml` — scheduled (`cron: weekly Monday 4am UTC`) + `workflow_dispatch` job that builds the backend, brings up Postgres + the Spring Boot jar, waits on `/actuator/health`, then runs the k6 script via `grafana/k6-action`.
- `scripts/test_performance_test_assets.py` — standalone validation test (no new dependency, same convention as `test_generate_e2e_coverage_report.py`) asserting the k6 script has the required stages/thresholds/auth/endpoints, and the workflow is schedule-triggered (not `pull_request`-gated) and actually runs k6 against a live stack. Written failing first per TDD, then made green.

### Modified
- `README.md` — documented the new `k6 run` command under the testing section.

## Testing

- [x] Unit tests added/updated (`scripts/test_performance_test_assets.py`, TDD red→green)
- [x] Integration tests passing (unaffected — no Java source touched)
- [ ] E2E tests passing (N/A — no frontend/UI change)
- [x] Test coverage: N/A (new script/config assets, not covered by JaCoCo)
- [x] Manual testing completed: `node --check` on the k6 script (syntax), `python3 scripts/test_performance_test_assets.py` green, YAML parses cleanly, `mvn test -Dtest="**/unit/*"` unaffected/green

## Documentation

- [x] Updated architecture documentation (`README.md` testing section)

## Code Quality

- [x] Code follows project conventions
- [x] No hardcoded credentials or secrets (CI-only placeholder secrets, same pattern as `playwright-e2e.yml`)
- [x] No large files (>5MB)
- [x] No commented-out code
- [x] No debug logging left

## Dependencies

- No new dependencies (uses the `grafana/k6-action` GitHub Action; k6 itself isn't a project dependency)

## Breaking Changes

- None

## Deployment Notes

None — new workflow only runs on its own schedule / manual dispatch, doesn't affect existing pipelines.

---

Closes #594


---
_Generated by [Claude Code](https://claude.ai/code/session_01L3VfSRHLVCDFsHVkfdQaqi)_