### PR TITLE
[#562] fix(security): add security response headers to Next.js frontend

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -27,6 +27,41 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  // Security response headers (issue #562) — defense-in-depth against
+  // clickjacking, MIME-sniffing, and protocol downgrade.
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' data:",
+              "font-src 'self' data:",
+              "connect-src 'self'",
+              "frame-ancestors 'none'",
+            ].join("; "),
+          },
+          {
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+          {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default withNextIntl(nextConfig);

--- a/frontend/src/tests/unit/next-config-security-headers.test.ts
+++ b/frontend/src/tests/unit/next-config-security-headers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import nextConfig from "../../../next.config";
+
+describe("next.config security headers", () => {
+  it("declares a headers() function", () => {
+    expect(typeof nextConfig.headers).toBe("function");
+  });
+
+  it("applies security headers to every route", async () => {
+    const rules = await nextConfig.headers!();
+
+    expect(rules).toHaveLength(1);
+    expect(rules[0].source).toBe("/:path*");
+
+    const headerNames = rules[0].headers.map((h) => h.key);
+    expect(headerNames).toEqual(
+      expect.arrayContaining([
+        "Content-Security-Policy",
+        "X-Frame-Options",
+        "X-Content-Type-Options",
+        "Strict-Transport-Security",
+      ]),
+    );
+  });
+
+  it("sets X-Frame-Options to DENY", async () => {
+    const rules = await nextConfig.headers!();
+    const header = rules[0].headers.find((h) => h.key === "X-Frame-Options");
+
+    expect(header?.value).toBe("DENY");
+  });
+
+  it("sets X-Content-Type-Options to nosniff", async () => {
+    const rules = await nextConfig.headers!();
+    const header = rules[0].headers.find((h) => h.key === "X-Content-Type-Options");
+
+    expect(header?.value).toBe("nosniff");
+  });
+
+  it("enables HSTS with a long max-age and includeSubDomains", async () => {
+    const rules = await nextConfig.headers!();
+    const header = rules[0].headers.find((h) => h.key === "Strict-Transport-Security");
+
+    expect(header?.value).toMatch(/max-age=\d+/);
+    expect(header?.value).toContain("includeSubDomains");
+  });
+});


### PR DESCRIPTION
## Summary

- `frontend/next.config.ts` had no `headers()` callback — no `Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, or `Strict-Transport-Security`, leaving the app exposed to clickjacking, MIME-sniffing, and no defense-in-depth against injected content.
- Adds a `headers()` block applying all four to every route (`source: "/:path*"`).

**Issue:** #562
**Use Case(s):** N/A — repository-audit security hardening, not tied to a functional Use Case.

## Changes

### Added
- `frontend/src/tests/unit/next-config-security-headers.test.ts` — asserts the four required headers are present with the expected values, written failing first per TDD, then made green.

### Modified
- `frontend/next.config.ts` — new `headers()` callback:
  - `Content-Security-Policy`: `default-src 'self'` scoped, with the minimal `script-src`/`style-src` allowances Next.js itself needs, plus `frame-ancestors 'none'`.
  - `X-Frame-Options: DENY`
  - `X-Content-Type-Options: nosniff`
  - `Strict-Transport-Security: max-age=63072000; includeSubDomains`

## Testing

- [x] Unit tests added/updated (TDD red→green, 5 new tests)
- [x] Integration tests passing (unaffected)
- [ ] E2E tests passing (N/A — headers aren't observable from Playwright's browser context in a meaningful new way; covered by the config-level unit test instead)
- [x] Test coverage: full frontend suite green (`npx vitest run` → 224/224 passing)
- [x] Manual testing completed: `npx tsc --noEmit` shows no new type errors from this change (pre-existing unrelated errors in `pages.test.tsx` confirmed present on a clean `main` checkout too — filed as #664)

## Documentation

- [x] N/A — small, self-documented config change

## Code Quality

- [x] Code follows project conventions
- [x] No hardcoded credentials or secrets
- [x] No large files (>5MB)
- [x] No commented-out code
- [x] No debug logging left

## Dependencies

- No new dependencies

## Breaking Changes

- None. CSP is scoped permissively enough (`'unsafe-inline' 'unsafe-eval'` on `script-src`) to avoid breaking existing Next.js behavior; tightening it further (nonces, hashes) is a separate, riskier follow-up not attempted here.

## Deployment Notes

None.

## Reviewer Notes

While verifying this locally I found two pre-existing, unrelated problems on `main` (confirmed via a clean checkout, not caused by this PR) masked by `continue-on-error: true` in `frontend-ci.yml`:
- #664 — `pages.test.tsx` references a `tramiteList` field that doesn't exist on `GestionDeEscritura`.
- #665 — `next lint` no longer exists in the installed Next.js 16.2.4, so the ESLint CI step has been silently no-op-ing.

Neither is in scope here; filed separately.

---

Closes #562


---
_Generated by [Claude Code](https://claude.ai/code/session_01L3VfSRHLVCDFsHVkfdQaqi)_