### PR TITLE
[#589] test(mappers): add unit tests for HistorialMapper

### DIFF
--- a/backend-api/src/test/java/com/licensis/notaire/service/mappers/HistorialMapperTest.java
+++ b/backend-api/src/test/java/com/licensis/notaire/service/mappers/HistorialMapperTest.java
@@ -1,0 +1,90 @@
+package com.licensis.notaire.service.mappers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.licensis.notaire.dto.DtoHistorialSummary;
+import com.licensis.notaire.negocio.EstadoDeGestion;
+import com.licensis.notaire.negocio.GestionDeEscritura;
+import com.licensis.notaire.negocio.Historial;
+
+class HistorialMapperTest {
+
+    @Test
+    @DisplayName("Should map all fields when gestion and estado are present")
+    void shouldMapAllFieldsWhenGestionAndEstadoArePresent() {
+        Date fecha = new Date();
+        GestionDeEscritura gestion = new GestionDeEscritura();
+        gestion.setIdGestion(7);
+        EstadoDeGestion estado = new EstadoDeGestion();
+        estado.setIdEstadoGestion(3);
+        estado.setNombre("En proceso");
+
+        Historial historial = new Historial(1, fecha);
+        historial.setObservaciones("Cambio de estado inicial");
+        historial.setFkIdGestion(gestion);
+        historial.setFkIdEstadoGestion(estado);
+
+        DtoHistorialSummary dto = HistorialMapper.toDto(historial);
+
+        assertThat(dto.idHistorial()).isEqualTo(1);
+        assertThat(dto.fecha()).isEqualTo(fecha);
+        assertThat(dto.observaciones()).isEqualTo("Cambio de estado inicial");
+        assertThat(dto.gestionId()).isEqualTo(7);
+        assertThat(dto.estadoGestionId()).isEqualTo(3);
+        assertThat(dto.estadoGestionNombre()).isEqualTo("En proceso");
+    }
+
+    @Test
+    @DisplayName("Should map a null gestion ID when fkIdGestion is null")
+    void shouldMapNullGestionIdWhenFkIdGestionIsNull() {
+        EstadoDeGestion estado = new EstadoDeGestion();
+        estado.setIdEstadoGestion(3);
+        estado.setNombre("En proceso");
+
+        Historial historial = new Historial(1, new Date());
+        historial.setFkIdGestion(null);
+        historial.setFkIdEstadoGestion(estado);
+
+        DtoHistorialSummary dto = HistorialMapper.toDto(historial);
+
+        assertThat(dto.gestionId()).isNull();
+        assertThat(dto.estadoGestionId()).isEqualTo(3);
+        assertThat(dto.estadoGestionNombre()).isEqualTo("En proceso");
+    }
+
+    @Test
+    @DisplayName("Should map null estado fields when fkIdEstadoGestion is null")
+    void shouldMapNullEstadoFieldsWhenFkIdEstadoGestionIsNull() {
+        GestionDeEscritura gestion = new GestionDeEscritura();
+        gestion.setIdGestion(7);
+
+        Historial historial = new Historial(1, new Date());
+        historial.setFkIdGestion(gestion);
+        historial.setFkIdEstadoGestion(null);
+
+        DtoHistorialSummary dto = HistorialMapper.toDto(historial);
+
+        assertThat(dto.gestionId()).isEqualTo(7);
+        assertThat(dto.estadoGestionId()).isNull();
+        assertThat(dto.estadoGestionNombre()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should map both gestion and estado as null when both FKs are absent")
+    void shouldMapBothNullWhenBothForeignKeysAreAbsent() {
+        Historial historial = new Historial(1, new Date());
+        historial.setFkIdGestion(null);
+        historial.setFkIdEstadoGestion(null);
+
+        DtoHistorialSummary dto = HistorialMapper.toDto(historial);
+
+        assertThat(dto.gestionId()).isNull();
+        assertThat(dto.estadoGestionId()).isNull();
+        assertThat(dto.estadoGestionNombre()).isNull();
+    }
+}


### PR DESCRIPTION
## Summary

- `service.mappers.HistorialMapper` is not excluded from the JaCoCo coverage gate, but had zero test coverage anywhere under `backend-api/src/test/java`.
- Adds `HistorialMapperTest` covering the audit-trail mapping logic (`Historial` → `DtoHistorialSummary`).

**Issue:** #589
**Use Case(s):** N/A — repository-audit test-coverage gap, not tied to a functional Use Case.

## Changes

### Added
- `HistorialMapperTest` — 4 tests: the full happy path, and each nullable FK (`fkIdGestion`, `fkIdEstadoGestion`, and both absent) individually, since the mapper's null-safety ternaries are exactly the branches most likely to regress silently without coverage.

## Testing

- [x] Unit tests added/updated (4 new tests, all passing)
- [x] Integration tests passing (unaffected — no production code touched)
- [ ] E2E tests passing (N/A — no frontend/UI change)
- [x] Test coverage: adds coverage to a previously-untested class
- [x] Manual testing completed: `mvn test -Dtest=HistorialMapperTest` green, `mvn checkstyle:check` clean, full `mvn test -Dtest="**/unit/*"` green

## Documentation

- [x] N/A — test-only change

## Code Quality

- [x] Code follows project conventions
- [x] No hardcoded credentials or secrets
- [x] No large files (>5MB)
- [x] No commented-out code
- [x] No debug logging left

## Dependencies

- No new dependencies

## Breaking Changes

- None — test-only change, no production code modified.

## Deployment Notes

None.

---

Closes #589


---
_Generated by [Claude Code](https://claude.ai/code/session_01L3VfSRHLVCDFsHVkfdQaqi)_