### PR TITLE
[#668] docs(loop): document Docker-unavailable deploy-check fallback

### DIFF
--- a/.claude/agents/issue-loop.md
+++ b/.claude/agents/issue-loop.md
@@ -80,6 +80,25 @@ Repeat until no open issues remain OR `status: blocked` is written.
 - If any check fails: read the failure log, fix, push again, re-poll
 - Timeout after 10 polls → write status=blocked, blocked_reason="CI timeout on #<issue>", STOP
 
+### 8.5. DEPLOY CHECK — verify the stack actually runs
+
+- Bring up the stack and confirm the backend answers `/actuator/health` (and, for
+  frontend-affecting changes, that the relevant page/route loads and any new response headers
+  are actually present). Treat a failed deploy check the same as failed CI: diagnose, fix,
+  retest — never merge past it.
+- **Docker-unavailable fallback**: some execution sandboxes have no Docker daemon
+  (`docker version` connects fine but `docker compose up` / any container run fails with
+  `failed to connect to the docker API at unix:///var/run/docker.sock`). When that happens,
+  don't skip the check — do it directly instead:
+  - Backend: `service postgresql start` (a local PostgreSQL is available even without Docker in
+    that case), create the `notaire`/`notaire` role+database with `psql` if they don't exist yet,
+    `mvn -pl backend-api -am clean package -DskipTests`, then run the jar directly with the same
+    flags `.github/workflows/playwright-e2e.yml` already uses to start the backend without
+    Docker (`--spring.datasource.url=jdbc:postgresql://localhost:5432/notaire ...`), then
+    `curl localhost:8080/actuator/health` and kill the process afterward.
+  - Frontend: `npm run build && npx next start` in `frontend/`, then `curl -D -` the affected
+    page/route and grep for the expected headers/content, then stop the server.
+
 ### 9. MERGE — close the loop
 - merge_pull_request(owner=matiaspakua, repo=notaire, pullNumber=<pr>, merge_method=squash)
 - Add issue number to completed[] in loop-state.md


### PR DESCRIPTION
## Summary

- The autonomous issue-loop's scheduled prompt requires a basic deploy check before merging each PR, but assumes Docker is available. This run's execution sandbox had no Docker daemon (confirmed real, not hypothetical: `docker version` works, `docker compose up` fails with a daemon-socket connection error).
- Documents the fallback actually used this run in `.claude/agents/issue-loop.md`, as a new step 8.5.

**Issue:** #668
**Use Case(s):** N/A — process/agent-procedure documentation, not tied to a functional Use Case.

## Changes

### Added
- `.claude/agents/issue-loop.md` — new "8.5. DEPLOY CHECK" step documenting the Docker-unavailable fallback: local PostgreSQL + `java -jar` for the backend (same flags `playwright-e2e.yml` already uses to run the backend without Docker), and `next start` for the frontend.

## Testing

- [ ] N/A — documentation-only change (agent procedure markdown), no test suite applies.

## Documentation

- [x] This PR *is* the documentation update.

## Code Quality

- [x] No hardcoded credentials or secrets
- [x] No large files (>5MB)
- [x] No commented-out code

## Dependencies

- No new dependencies

## Breaking Changes

- None

---

Closes #668


---
_Generated by [Claude Code](https://claude.ai/code/session_01L3VfSRHLVCDFsHVkfdQaqi)_